### PR TITLE
fix(eslint-plugin): avoid unsafe strict null optional chains

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-optional-chain-utils/analyzeChain.ts
+++ b/packages/eslint-plugin/src/rules/prefer-optional-chain-utils/analyzeChain.ts
@@ -722,8 +722,33 @@ export function analyzeChain(
   const maybeReportThenReset = (
     newChainSeed?: readonly [ValidOperand, ...ValidOperand[]],
   ): void => {
-    if (subChain.length + (lastChain ? 1 : 0) > 1) {
-      const subChainFlat = subChain.flat();
+    const subChainFlat = subChain.flat();
+    const lastSubChainOperand = subChainFlat.at(-1);
+    // Optional chains return `undefined` at a short-circuited boundary, so
+    // strict comparisons against `null` would invert the guarded result.
+    const hasUnsafeStrictNullComparison =
+      !lastChain &&
+      chain.at(-1)?.node === lastSubChainOperand?.node &&
+      ((operator === '||' &&
+        lastSubChainOperand?.comparisonType ===
+          NullishComparisonType.StrictEqualNull &&
+        subChainFlat.some(
+          operand =>
+            operand.comparisonType ===
+            NullishComparisonType.StrictEqualUndefined,
+        )) ||
+        (operator === '&&' &&
+          lastSubChainOperand?.comparisonType ===
+            NullishComparisonType.NotStrictEqualNull &&
+          subChainFlat.some(
+            operand =>
+              operand.comparisonType ===
+              NullishComparisonType.NotStrictEqualUndefined,
+          )));
+    if (
+      subChain.length + (lastChain ? 1 : 0) > 1 &&
+      !hasUnsafeStrictNullComparison
+    ) {
       const maybeNullishNodes = lastChain
         ? subChainFlat.map(({ node }) => node)
         : subChainFlat.slice(0, -1).map(({ node }) => node);

--- a/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain.test.ts
@@ -689,6 +689,111 @@ describe('|| {}', () => {
   });
 });
 
+describe('chain ending with a strict null comparison', () => {
+  ruleTester.run('prefer-optional-chain', rule, {
+    invalid: [
+      {
+        code: `
+          declare const foo: { bar: number | null } | undefined;
+          foo === undefined || foo.bar !== null;
+        `,
+        errors: [
+          {
+            messageId: 'preferOptionalChain',
+            suggestions: [
+              {
+                messageId: 'optionalChainSuggest',
+                output: `
+          declare const foo: { bar: number | null } | undefined;
+          foo?.bar !== null;
+        `,
+              },
+            ],
+          },
+        ],
+      },
+      {
+        code: `
+          declare const foo: { bar: number | null } | undefined;
+          foo !== undefined && foo.bar === null;
+        `,
+        errors: [
+          {
+            messageId: 'preferOptionalChain',
+            suggestions: [
+              {
+                messageId: 'optionalChainSuggest',
+                output: `
+          declare const foo: { bar: number | null } | undefined;
+          foo?.bar === null;
+        `,
+              },
+            ],
+          },
+        ],
+      },
+      {
+        code: `
+          declare const foo: { bar: number | null } | undefined;
+          undefined === foo || null !== foo.bar;
+        `,
+        errors: [
+          {
+            messageId: 'preferOptionalChain',
+            suggestions: [
+              {
+                messageId: 'optionalChainSuggest',
+                output: `
+          declare const foo: { bar: number | null } | undefined;
+          null !== foo?.bar;
+        `,
+              },
+            ],
+          },
+        ],
+      },
+      {
+        code: `
+          declare const foo: { bar: number | null } | undefined;
+          undefined !== foo && null === foo.bar;
+        `,
+        errors: [
+          {
+            messageId: 'preferOptionalChain',
+            suggestions: [
+              {
+                messageId: 'optionalChainSuggest',
+                output: `
+          declare const foo: { bar: number | null } | undefined;
+          null === foo?.bar;
+        `,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    valid: [
+      `
+        declare const foo: { bar: number | null } | undefined;
+        foo === undefined || foo.bar === null;
+      `,
+      `
+        declare const foo: { bar: number | null } | undefined;
+        undefined === foo || null === foo.bar;
+      `,
+      `
+        declare const foo: { bar: number | null } | undefined;
+        foo !== undefined && foo.bar !== null;
+      `,
+      `
+        declare const foo: { bar: number | null } | undefined;
+        undefined !== foo && null !== foo.bar;
+      `,
+    ],
+  });
+});
+
 describe('chain ending with comparison', () => {
   ruleTester.run('prefer-optional-chain', rule, {
     invalid: [


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #11840
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

Avoid suggesting an optional chain when a strict `undefined` guard is followed by the opposite strict `null` comparison. Short-circuiting an optional chain produces `undefined`, so those rewrites can invert the expression result.

The analyzer now skips only the unsafe `|| ... === null` and symmetric `&& ... !== null` endings. Focused tests cover regular and Yoda comparisons, plus the safe opposite-polarity boundaries.

AI assistance was used for code analysis and implementation. I reviewed and validated the resulting changes.

💖