### PR TITLE
fix(eslint-plugin): deduplicate unified signature union types

### DIFF
--- a/packages/eslint-plugin/src/rules/unified-signatures.ts
+++ b/packages/eslint-plugin/src/rules/unified-signatures.ts
@@ -4,7 +4,12 @@ import { AST_NODE_TYPES, AST_TOKEN_TYPES } from '@typescript-eslint/utils';
 
 import type { Equal } from '../util';
 
-import { arraysAreEqual, createRule, nullThrows } from '../util';
+import {
+  arraysAreEqual,
+  createRule,
+  nullThrows,
+  typeNodeRequiresParentheses,
+} from '../util';
 
 interface Failure {
   only2: boolean;
@@ -122,6 +127,29 @@ export default createRule<Options, MessageIds>({
       return `${overloads} can be combined into one signature`;
     }
 
+    function getUnifiedTypeParts(
+      ...types: (TSESTree.TypeNode | undefined)[]
+    ): [string, string] {
+      const seen = new Set<string>();
+      const parts: string[] = [];
+
+      for (const type of types.flatMap(type =>
+        type?.type === AST_NODE_TYPES.TSUnionType ? type.types : [type],
+      )) {
+        const text = context.sourceCode.getText(type);
+        if (!seen.has(text)) {
+          seen.add(text);
+          parts.push(
+            type != null && typeNodeRequiresParentheses(type, text)
+              ? `(${text})`
+              : text,
+          );
+        }
+      }
+
+      return [parts.slice(0, -1).join(' | '), parts.at(-1) ?? ''];
+    }
+
     function addFailures(failures: Failure[]): void {
       for (const failure of failures) {
         const { only2, unify } = failure;
@@ -136,6 +164,10 @@ export default createRule<Options, MessageIds>({
             const typeAnnotation1 = isTSParameterProperty(p1)
               ? p1.parameter.typeAnnotation
               : p1.typeAnnotation;
+            const [type1, type2] = getUnifiedTypeParts(
+              typeAnnotation0?.typeAnnotation,
+              typeAnnotation1?.typeAnnotation,
+            );
 
             context.report({
               loc: p1.loc,
@@ -143,12 +175,8 @@ export default createRule<Options, MessageIds>({
               messageId: 'singleParameterDifference',
               data: {
                 failureStringStart: failureStringStart(lineOfOtherOverload),
-                type1: context.sourceCode.getText(
-                  typeAnnotation0?.typeAnnotation,
-                ),
-                type2: context.sourceCode.getText(
-                  typeAnnotation1?.typeAnnotation,
-                ),
+                type1,
+                type2,
               },
             });
             break;

--- a/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
+++ b/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
@@ -742,6 +742,90 @@ interface I {
       ],
     },
     {
+      code: `
+function f(a: number | string): void;
+function f(a: string | boolean): void;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            type1: 'number | string',
+            type2: 'boolean',
+          },
+          endColumn: 31,
+          endLine: 3,
+          line: 3,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+    },
+    {
+      code: `
+function f(a: string): void;
+function f(a: number | string): void;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            type1: 'string',
+            type2: 'number',
+          },
+          endColumn: 30,
+          endLine: 3,
+          line: 3,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+    },
+    {
+      code: `
+function f(a: boolean | string): void;
+function f(a: number | boolean): void;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            type1: 'boolean | string',
+            type2: 'number',
+          },
+          endColumn: 31,
+          endLine: 3,
+          line: 3,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+    },
+    {
+      code: `
+function f(a: () => void): void;
+function f(a: string | (() => void)): void;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            type1: '(() => void)',
+            type2: 'string',
+          },
+          endColumn: 36,
+          endLine: 3,
+          line: 3,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+    },
+    {
       // Works with tuples.
       code: `
 interface I {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #000
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

The `unified-signatures` diagnostic now flattens union parameter types and removes repeated constituents while preserving their first-seen order. It also adds parentheses around function-like and other precedence-sensitive constituent types so that the suggested union remains unambiguous.

This changes only the diagnostic formatting; overload detection is unchanged. Tests cover overlapping unions, a non-union overlapping a union, constituent ordering, and a function-type constituent.

AI assistance was used to inspect the repository, implement the change, and run validation. I reviewed and understand the resulting code and tests.

Validation:

- `pnpm exec vitest run packages/eslint-plugin/tests/rules/unified-signatures.test.ts`
- `pnpm exec nx typecheck eslint-plugin`
- Prettier checks for the changed files and the full `eslint-plugin` package
- ESLint for the changed files (with the pre-existing `require-test-error-positions` violations in this legacy test file excluded)

💖
