### PR TITLE
chore: add docs-writing agent skill

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -12,4 +12,5 @@ skills/<name>/SKILL.md
 
 ## Available skills
 
+- [`docs-writing`](./docs-writing/SKILL.md) — write and review documentation with objective, verifiable claims and self-contained code examples.
 - [`rule-performance`](./rule-performance/SKILL.md) — defer expensive TypeScript type lookups behind cheap AST/syntactic guards when writing or reviewing typed lint rules.

--- a/.agents/skills/docs-writing/SKILL.md
+++ b/.agents/skills/docs-writing/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: docs-writing
+description: Write and review typescript-eslint documentation with objective, verifiable claims and self-contained code examples. Use when changing Markdown or MDX in docs or packages/eslint-plugin/docs.
+---
+
+# Writing verifiable documentation
+
+Documentation should describe behavior a reader can verify from the repository or an authoritative external source. Keep each claim precise, and give code examples enough context to demonstrate that claim on their own.
+
+## When to use
+
+Use this skill when writing or reviewing:
+
+- rule documentation in `packages/eslint-plugin/docs/rules`;
+- contributor, developer, package, troubleshooting, or user documentation in `docs`;
+- descriptions of rule behavior, options, configurations, or TypeScript and ESLint interactions.
+
+## Make claims objective
+
+Describe observable conditions and results instead of judging quality or intent.
+
+- Name the relevant rule, option, configuration, syntax, or version.
+- State what happens and under which conditions.
+- Separate repository behavior from recommendations for users.
+- Avoid promotional or subjective wording such as "powerful", "easy", or "best" unless the text defines a verifiable comparison.
+
+Prefer a bounded statement such as “The rule reports this expression when typed linting determines its condition is always truthy” over an unqualified statement such as “The rule catches unnecessary conditions.”
+
+## Verify claims before writing them
+
+Find the source that establishes each behavioral claim. Depending on the documentation, that may be:
+
+- the corresponding implementation and tests;
+- rule metadata, option schemas, and generated configuration data;
+- the repository's contributor documentation;
+- linked TypeScript or ESLint documentation for external behavior.
+
+Do not infer general behavior from a file name, a single issue report, or one test fixture. Preserve qualifiers for version-specific, configuration-dependent, or type-dependent behavior. If the available sources do not establish a claim, narrow or omit it instead of presenting it as fact.
+
+## Keep code blocks self-contained
+
+A reader should be able to understand why each block demonstrates the surrounding claim without reconstructing missing context.
+
+- Include declarations, types, options, and configuration that affect the demonstrated behavior.
+- Do not rely on identifiers defined only in another block.
+- Keep incorrect and correct examples independently understandable.
+- Avoid ellipses or omitted setup when the missing code could change the result.
+- Use a language identifier on every fenced block.
+- Demonstrate one logical point per block and remove unrelated code.
+
+An intentionally incorrect rule example may violate the documented rule, but it should not also fail because an unrelated import, declaration, or option is missing.
+
+For rule documentation, start from `packages/eslint-plugin/docs/rules/TEMPLATE.md` and check examples against the corresponding rule tests. Keep the Incorrect and Correct examples focused on the same behavior so readers can compare them directly.
+
+## Review before submitting
+
+1. Trace each behavioral claim to its implementation, tests, configuration, or linked authoritative source.
+2. Read every code block independently and check that all behavior-relevant context is present.
+3. Remove filler, unsupported absolutes, repeated explanations, and unrelated examples.
+4. Check links and repository paths.
+5. Run the repository's formatting, spelling, and Markdown validation commands.
+
+## References
+
+- Issue [#12370](https://github.com/typescript-eslint/typescript-eslint/issues/12370), which tracks repository-focused agent skills.
+- [Rule documentation template](../../../packages/eslint-plugin/docs/rules/TEMPLATE.md).
+- [Local development validation](../../../docs/contributing/Local_Development.mdx#validating-changes).
+- [Pull request guidance](../../../docs/contributing/Pull_Requests.mdx).

--- a/.agents/skills/docs-writing/SKILL.md
+++ b/.agents/skills/docs-writing/SKILL.md
@@ -7,20 +7,11 @@ description: Write and review typescript-eslint documentation with objective, ve
 
 Documentation should describe behavior a reader can verify from the repository or an authoritative external source. Keep each claim precise, and give code examples enough context to demonstrate that claim on their own.
 
-## When to use
-
-Use this skill when writing or reviewing:
-
-- rule documentation in `packages/eslint-plugin/docs/rules`;
-- contributor, developer, package, troubleshooting, or user documentation in `docs`;
-- descriptions of rule behavior, options, configurations, or TypeScript and ESLint interactions.
-
 ## Make claims objective
 
 Describe observable conditions and results instead of judging quality or intent.
 
-- Name the relevant rule, option, configuration, syntax, or version.
-- State what happens and under which conditions.
+- Name the rule, option, configuration, syntax, or version involved, and state what happens under which conditions.
 - Separate repository behavior from recommendations for users.
 - Avoid promotional or subjective wording such as "powerful", "easy", or "best" unless the text defines a verifiable comparison.
 
@@ -41,28 +32,20 @@ Do not infer general behavior from a file name, a single issue report, or one te
 
 A reader should be able to understand why each block demonstrates the surrounding claim without reconstructing missing context.
 
-- Include declarations, types, options, and configuration that affect the demonstrated behavior.
-- Do not rely on identifiers defined only in another block.
-- Keep incorrect and correct examples independently understandable.
+- Include declarations, types, options, and configuration that affect the demonstrated behavior, and do not rely on identifiers defined only in another block.
 - Avoid ellipses or omitted setup when the missing code could change the result.
-- Use a language identifier on every fenced block.
+- Use meaningful identifiers instead of placeholders such as `foo` or `bar`.
 - Demonstrate one logical point per block and remove unrelated code.
 
 An intentionally incorrect rule example may violate the documented rule, but it should not also fail because an unrelated import, declaration, or option is missing.
 
-For rule documentation, start from `packages/eslint-plugin/docs/rules/TEMPLATE.md` and check examples against the corresponding rule tests. Keep the Incorrect and Correct examples focused on the same behavior so readers can compare them directly.
+## Write rule documentation for comparison
 
-## Review before submitting
+Start from [`packages/eslint-plugin/docs/rules/TEMPLATE.md`](../../../packages/eslint-plugin/docs/rules/TEMPLATE.md) and check examples against the corresponding rule tests.
 
-1. Trace each behavioral claim to its implementation, tests, configuration, or linked authoritative source.
-2. Read every code block independently and check that all behavior-relevant context is present.
-3. Remove filler, unsupported absolutes, repeated explanations, and unrelated examples.
-4. Check links and repository paths.
-5. Run the repository's formatting, spelling, and Markdown validation commands.
+- Keep the Incorrect and Correct tabs focused on the same behavior. Use the same code snippet where possible, changing only what is needed to demonstrate the fix.
+- Add a section for each rule option when the rule has options to document.
+- Add a "When Not To Use It" section only for genuine cases where the rule is irrelevant or inappropriate.
+- Link relevant resources when useful, such as similar or complementary rules and TypeScript or ESLint documentation.
 
-## References
-
-- Issue [#12370](https://github.com/typescript-eslint/typescript-eslint/issues/12370), which tracks repository-focused agent skills.
-- [Rule documentation template](../../../packages/eslint-plugin/docs/rules/TEMPLATE.md).
-- [Local development validation](../../../docs/contributing/Local_Development.mdx#validating-changes).
-- [Pull request guidance](../../../docs/contributing/Pull_Requests.mdx).
+Before submitting, run the repository's [formatting, spelling, and Markdown validation commands](../../../docs/contributing/Local_Development.mdx#validating-changes).


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: refs #12370
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

> I'd like to work on the Docs skill suggested above. I'm thinking of adding `.agents/skills/docs-writing/SKILL.md` and updating the skills README.
