### PR TITLE
fix(eslint-plugin): find redefined builtins through the full scope chain in no-unnecessary-type-conversion

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-conversion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-conversion.ts
@@ -1,7 +1,7 @@
 import type { TSESTree } from '@typescript-eslint/utils';
 import type { RuleFix, RuleFixer } from '@typescript-eslint/utils/ts-eslint';
 
-import { AST_NODE_TYPES } from '@typescript-eslint/utils';
+import { AST_NODE_TYPES, ASTUtils } from '@typescript-eslint/utils';
 import * as tsutils from 'ts-api-utils';
 import * as ts from 'typescript';
 
@@ -258,7 +258,7 @@ export default createRule<Options, MessageIds>({
         const typeFlag =
           builtInTypeFlags[nodeCallee.name as keyof typeof builtInTypeFlags];
         const scope = context.sourceCode.getScope(node);
-        const variable = scope.set.get(nodeCallee.name);
+        const variable = ASTUtils.findVariable(scope, nodeCallee.name);
         if (
           !!variable?.defs.length ||
           !doesUnderlyingTypeMatchFlag(

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-conversion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-conversion.test.ts
@@ -60,6 +60,18 @@ ruleTester.run('no-unnecessary-type-conversion', rule, {
       BigInt(3n);
       export {};
     `,
+    // a builtin redefined in an outer scope is still not the global, even
+    // when called from a nested scope
+    // https://github.com/typescript-eslint/typescript-eslint/issues/12522
+    `
+      function String(value: unknown) {
+        return value;
+      }
+      function useString(value: string) {
+        return String(value);
+      }
+      export {};
+    `,
     `
       function toString(value: unknown) {
         return value;


### PR DESCRIPTION
Fixes #12522

## Problem

`no-unnecessary-type-conversion` checks whether a called identifier (`String`, `Number`, `Boolean`, `BigInt`) refers to the global builtin via `scope.set.get(name)`, which only looks in the exact current scope object — it does not walk the parent scope chain. So a builtin redefined in an OUTER scope isn't detected when the call happens in a nested function:

```ts
function String(value: unknown) {
  return value;
}
function useString(value: string) {
  return String(value); // incorrectly flagged as an unnecessary type conversion
}
```

## Fix

Use `ASTUtils.findVariable(scope, name)` instead, which correctly walks the scope chain. This matches the existing, already-correct pattern used for the identical check in `no-base-to-string.ts`.

## Testing

Added a regression test covering the issue's exact repro (builtin redefined at module scope, called from a nested function). Ran the full `no-unnecessary-type-conversion` test suite (67 tests) — all pass. Confirmed the new test actually catches the regression: reverting just the source change makes it fail with the expected "should have no errors but had 1" message; restoring the fix makes it pass again. Ran `eslint`/`tsc --noEmit` on the touched files — clean.
