### PR TITLE
fix(eslint-plugin): find redefined Boolean through the full scope chain in prefer-nullish-coalescing

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-nullish-coalescing.ts
+++ b/packages/eslint-plugin/src/rules/prefer-nullish-coalescing.ts
@@ -1,6 +1,10 @@
 import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
 
-import { AST_NODE_TYPES, AST_TOKEN_TYPES } from '@typescript-eslint/utils';
+import {
+  AST_NODE_TYPES,
+  AST_TOKEN_TYPES,
+  ASTUtils,
+} from '@typescript-eslint/utils';
 import * as tsutils from 'ts-api-utils';
 import * as ts from 'typescript';
 
@@ -705,7 +709,8 @@ function isBuiltInBooleanCall(
     node.arguments[0]
   ) {
     const scope = context.sourceCode.getScope(node);
-    const variable = scope.set.get(AST_TOKEN_TYPES.Boolean);
+    // eslint-disable-next-line @typescript-eslint/internal/prefer-ast-types-enum
+    const variable = ASTUtils.findVariable(scope, 'Boolean');
     return variable == null || variable.defs.length === 0;
   }
   return false;

--- a/packages/eslint-plugin/tests/rules/prefer-nullish-coalescing.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-nullish-coalescing.test.ts
@@ -10210,6 +10210,41 @@ const x = Boolean(a ?? b);
       ],
     },
     {
+      // a `Boolean` redefined in an outer scope is not the global builtin,
+      // even when called from a nested scope, so `ignoreBooleanCoercion`
+      // should not suppress this report
+      // https://github.com/typescript-eslint/typescript-eslint/issues/12524
+      code: `
+function outer() {
+  const Boolean = (x: unknown) => x;
+
+  return (a: string | null, b: string) => Boolean(a || b);
+}
+      `,
+      errors: [
+        {
+          messageId: 'preferNullishOverOr',
+          suggestions: [
+            {
+              messageId: 'suggestNullish',
+              output: `
+function outer() {
+  const Boolean = (x: unknown) => x;
+
+  return (a: string | null, b: string) => Boolean(a ?? b);
+}
+      `,
+            },
+          ],
+        },
+      ],
+      options: [
+        {
+          ignoreBooleanCoercion: true,
+        },
+      ],
+    },
+    {
       code: `
 let a: string | true | undefined;
 let b: string | boolean | undefined;


### PR DESCRIPTION
Fixes #12524

## Problem

Same root cause class as #12522 (see that fix for the detailed writeup), in a different rule: `prefer-nullish-coalescing`'s `isBuiltInBooleanCall` checks whether a call refers to the global `Boolean` via `scope.set.get(AST_TOKEN_TYPES.Boolean)`, which only looks in the exact current scope — not the parent chain. So a `Boolean` redefined in an outer scope isn't detected as shadowing the global when called from a nested function, and `ignoreBooleanCoercion` misfires on it.

## Fix

Use `ASTUtils.findVariable(scope, 'Boolean')` instead, matching the same already-correct pattern in `no-base-to-string.ts` (including its `eslint-disable-next-line @typescript-eslint/internal/prefer-ast-types-enum` comment for the raw string literal, per this repo's internal lint rule).

## Testing

Added a regression test: `Boolean` redefined in an outer function, called from a returned nested arrow function, with `ignoreBooleanCoercion: true` — should still report `preferNullishOverOr`. Ran the full `prefer-nullish-coalescing` test suite (620 tests) — all pass. Confirmed the new test catches the regression (fails with "should have 1 error but had 0" when the source fix is reverted, passes with it restored). Ran `eslint`/`tsc --noEmit` on the touched files — clean (eslint initially caught the missing internal-rule disable comment, which was then added to match the precedent file).
