### PR TITLE
fix(website): list `onUnsupportedTypeScriptVersion` in parser options

### DIFF
--- a/docs/packages/Parser.mdx
+++ b/docs/packages/Parser.mdx
@@ -46,12 +46,13 @@ interface ParserOptions {
   ecmaVersion?: number | 'latest';
   emitDecoratorMetadata?: boolean;
   experimentalDecorators?: boolean;
-  isolatedDeclarations?: boolean;
   extraFileExtensions?: string[];
+  isolatedDeclarations?: boolean;
   jsDocParsingMode?: 'all' | 'none' | 'type-info';
   jsxFragmentName?: string | null;
   jsxPragma?: string | null;
   lib?: string[];
+  onUnsupportedTypeScriptVersion?: 'warn' | 'error' | 'ignore';
   programs?: import('typescript').Program[];
   project?: string | string[] | boolean | null;
   projectFolderIgnoreList?: string[];


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes https://github.com/typescript-eslint/typescript-eslint/pull/12465#discussion_r3620264386
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [ ] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

Added the missing new parser option `onUnsupportedTypeScriptVersion` to the overview list of all options.
Also fixed an alphabetical sorting issue of `isolatedDeclarations`.