### PR TITLE
fix(eslint-plugin): handle computed ??= assignments with union keys

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -50,6 +50,15 @@ function isPossiblyNullish(type: ts.Type): boolean {
     .some(t => isNullishType(t) || isTypeFlagSet(t, ts.TypeFlags.Void));
 }
 
+function isPossiblyNonNullish(type: ts.Type): boolean {
+  return tsutils
+    .unionConstituents(type)
+    .some(
+      t =>
+        !isTypeFlagSet(t, nullishFlag | ts.TypeFlags.Void | ts.TypeFlags.Never),
+    );
+}
+
 function toStaticValue(
   type: ts.Type,
 ):
@@ -399,7 +408,10 @@ export default createRule<Options, MessageId>({
       }
     }
 
-    function checkNodeForNullish(node: TSESTree.Expression): void {
+    function checkNodeForNullish(
+      node: TSESTree.Expression,
+      isAssignmentTarget = false,
+    ): void {
       const type = getConstrainedTypeAtLocation(services, node);
 
       // Conditional is always necessary if it involves `any`, `unknown` or a naked type parameter
@@ -439,7 +451,20 @@ export default createRule<Options, MessageId>({
         ) {
           messageId = 'neverNullish';
         }
-      } else if (isAlwaysNullish(type)) {
+      } else if (
+        isAlwaysNullish(type) &&
+        !(
+          // For indexed compound assignments, TypeScript exposes the write type.
+          // Disjoint property types can intersect away non-nullish read types.
+          isAssignmentTarget &&
+          node.type === AST_NODE_TYPES.MemberExpression &&
+          node.computed &&
+          isPossiblyNonNullishPropertyType(
+            getConstrainedTypeAtLocation(services, node.object),
+            getConstrainedTypeAtLocation(services, node.property),
+          )
+        )
+      ) {
         messageId = 'alwaysNullish';
       }
 
@@ -739,6 +764,35 @@ export default createRule<Options, MessageId>({
       return false;
     }
 
+    function isPossiblyNonNullishPropertyType(
+      objType: ts.Type,
+      propertyType: ts.Type,
+    ): boolean {
+      if (propertyType.isUnion()) {
+        return propertyType.types.some(type =>
+          isPossiblyNonNullishPropertyType(objType, type),
+        );
+      }
+      if (propertyType.isNumberLiteral() || propertyType.isStringLiteral()) {
+        const propType = getTypeOfPropertyOfName(
+          checker,
+          objType,
+          propertyType.value.toString(),
+        );
+        if (propType) {
+          return isPossiblyNonNullish(propType);
+        }
+      }
+      const typeName = getTypeName(checker, propertyType);
+      return checker
+        .getIndexInfosOfType(objType)
+        .some(
+          info =>
+            getTypeName(checker, info.keyType) === typeName &&
+            isPossiblyNonNullish(info.type),
+        );
+    }
+
     function isNullablePropertyType(
       objType: ts.Type,
       propertyType: ts.Type,
@@ -913,7 +967,7 @@ export default createRule<Options, MessageId>({
       if (['&&=', '||='].includes(node.operator)) {
         checkNode(node.left);
       } else if (node.operator === '??=') {
-        checkNodeForNullish(node.left);
+        checkNodeForNullish(node.left, true);
       }
     }
 

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -1037,6 +1037,28 @@ for (const key of ['hello', 'world'] as const) {
 }
     `,
     `
+type Fields = {
+  0?: number;
+  1?: boolean;
+};
+
+let fields: Fields = {};
+
+for (const key of [0, 1] as const) {
+  fields[key] ??= undefined;
+}
+    `,
+    `
+type Fields = {
+  [key: string]: number | undefined;
+  [key: symbol]: boolean | undefined;
+};
+
+declare const fields: Fields;
+declare const key: string | symbol;
+fields[key] ??= undefined;
+    `,
+    `
 enum Keys {
   A = 'A',
   B = 'B',
@@ -3472,6 +3494,26 @@ for (const key of ['hello', 'world'] as const) {
           endColumn: 14,
           endLine: 10,
           line: 10,
+          messageId: 'alwaysNullish',
+        },
+      ],
+    },
+    {
+      code: `
+type Fields = {
+  [key: string]: undefined;
+};
+
+declare const fields: Fields;
+declare const key: 'hello';
+fields[key] ??= undefined;
+      `,
+      errors: [
+        {
+          column: 1,
+          endColumn: 12,
+          endLine: 8,
+          line: 8,
           messageId: 'alwaysNullish',
         },
       ],

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -1025,6 +1025,18 @@ declare const key: Key;
 foo.bar[key] ??= 1;
     `,
     `
+type Fields = {
+  hello?: number;
+  world?: boolean;
+};
+
+let fields: Fields = {};
+
+for (const key of ['hello', 'world'] as const) {
+  fields[key] ??= undefined;
+}
+    `,
+    `
 enum Keys {
   A = 'A',
   B = 'B',
@@ -3437,6 +3449,29 @@ foo ??= null;
           endColumn: 4,
           endLine: 3,
           line: 3,
+          messageId: 'alwaysNullish',
+        },
+      ],
+    },
+    {
+      code: `
+type Fields = {
+  hello?: undefined;
+  world?: null;
+};
+
+const fields: Fields = {};
+
+for (const key of ['hello', 'world'] as const) {
+  fields[key] ??= undefined;
+}
+      `,
+      errors: [
+        {
+          column: 3,
+          endColumn: 14,
+          endLine: 10,
+          line: 10,
           messageId: 'alwaysNullish',
         },
       ],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #~12556~
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Issue

- Fixes #~12556~
- The rule reports `alwaysNullish` for computed `??=` assignments when the key is a union of properties with different value types.

## Problem

TypeScript evaluates a computed assignment target in a write context.

For properties such as `number | undefined` and `boolean | undefined`, the non-nullish types have no overlap. The resulting write type collapses to `undefined`.

`no-unnecessary-condition` then incorrectly concludes that the left-hand side of `??=` is always nullish.

## Solution

- Keep the existing type check for ordinary nullish expressions.
- For computed `??=` assignment targets, also inspect the possible property read types.
- Do not report `alwaysNullish` when any selected property may contain a non-nullish value.
- Continue reporting when every possible property is only `null` or `undefined`.

## Tests

- Added the exact regression case from #12556.
- Added a control case where all selected properties are nullish, confirming that the existing diagnostic remains intact.

## Validation

- Focused `no-unnecessary-condition` tests: 301 passed
- Full `eslint-plugin` tests: 32,592 passed, 171 skipped
- `eslint-plugin` lint: passed
- `eslint-plugin` typecheck: passed
- Prettier and `git diff` checks: passed

👾
