### PR TITLE
fix(eslint-plugin): honor explicit typedefs option

### DIFF
--- a/packages/eslint-plugin/src/rules/no-use-before-define.ts
+++ b/packages/eslint-plugin/src/rules/no-use-before-define.ts
@@ -30,7 +30,7 @@ function parseOptions(options: string | Config | null): Required<Config> {
     variables = options.variables !== false;
     typedefs = options.typedefs !== false;
     ignoreTypeReferences = options.ignoreTypeReferences !== false;
-    allowNamedExports = options.allowNamedExports !== false;
+    allowNamedExports = options.allowNamedExports === true;
   }
 
   return {
@@ -276,19 +276,11 @@ export default createRule<Options, MessageIds>({
       },
     ],
   },
-  defaultOptions: [
-    {
-      allowNamedExports: false,
-      classes: true,
-      enums: true,
-      functions: true,
-      ignoreTypeReferences: true,
-      typedefs: true,
-      variables: true,
-    },
-  ],
-  create(context, optionsWithDefault) {
-    const options = parseOptions(optionsWithDefault[0]);
+  defaultOptions: [{}],
+  create(context, [firstOption]) {
+    const options = parseOptions(firstOption);
+    const isTypedefsOptionExplicitlyEnabled =
+      typeof firstOption === 'object' && firstOption.typedefs === true;
 
     /**
      * Determines whether a given use-before-define case should be reported according to the options.
@@ -299,6 +291,9 @@ export default createRule<Options, MessageIds>({
       variable: TSESLint.Scope.Variable,
       reference: TSESLint.Scope.Reference,
     ): boolean {
+      if (isTypedefsOptionExplicitlyEnabled && isTypedef(variable)) {
+        return true;
+      }
       if (options.ignoreTypeReferences && isTypeReference(reference)) {
         return false;
       }

--- a/packages/eslint-plugin/tests/rules/no-use-before-define.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-use-before-define.test.ts
@@ -1483,5 +1483,23 @@ var a = { b: 5 };
         },
       ],
     },
+    // https://github.com/typescript-eslint/typescript-eslint/issues/10389
+    {
+      code: `
+let myVar: StringOrNumber;
+type StringOrNumber = string | number;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: { name: 'StringOrNumber' },
+          endColumn: 26,
+          endLine: 2,
+          line: 2,
+          messageId: 'noUseBeforeDefine',
+        },
+      ],
+      options: [{ typedefs: true }],
+    },
   ],
 });


### PR DESCRIPTION
﻿## PR Checklist

- [x] Addresses an existing open issue: fixes #10389
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

Corrects the interaction between the `typedefs` and `ignoreTypeReferences` options in `no-use-before-define` while preserving existing defaults and other declaration handling.

## Summary

- preserve whether `typedefs` was explicitly supplied by the user
- let explicit `typedefs: true` take precedence for actual typedef definitions
- retain existing `ignoreTypeReferences`, default-option, and named-export behavior
- add a regression asserting the exact diagnostic, typedef name, and source range

Fixes #10389.

## Problem

With `typedefs: true`, a type alias declared after its use can remain unreported when `ignoreTypeReferences` handling returns before the rule evaluates the explicit typedef setting.

The rule previously received fully materialized default options, so it could not distinguish an explicitly supplied `typedefs: true` from a defaulted value.

## Root cause

Default materialization erased the provenance of the user-supplied `typedefs` option. The broad type-reference exclusion then ran before the rule could honor the explicit typedef decision.

## Change

Retain the raw option object for explicit-option checks while continuing to use `parseOptions` for semantic defaults.

Explicit `typedefs: true` takes precedence only when the reference is proven to be a typedef definition. Ordinary ignored type references remain ignored.

`allowNamedExports` remains disabled unless it is exactly `true`.

## Validation

- focused `no-use-before-define` rule file — 128/128 passed
- documentation tests — 2,295 passed, 169 skipped
- schema/config tests — 825 passed
- complete eslint-plugin suite with four workers — 181 files, 32,591 passed, 171 skipped
- targeted ESLint — passed
- targeted Prettier — passed
- package TypeScript typecheck — passed
- package build — passed
- `git show --check` — passed

Unconstrained full-suite attempts encountered unrelated ten-second Windows/Nx parallel timeouts. The complete eslint-plugin suite passed using the bounded four-worker invocation.

## Compatibility

No public API, option schema, exported type, dependency, lockfile, generated file, Node contract, browser behavior, ESM/CommonJS behavior, or release metadata changes are included.
