### PR TITLE
fix(typescript-estree): don't force allowJs/checkJs onto the watch program's tsconfig

### DIFF
--- a/packages/typescript-estree/src/create-program/getWatchProgramsForProjects.ts
+++ b/packages/typescript-estree/src/create-program/getWatchProgramsForProjects.ts
@@ -9,8 +9,8 @@ import type { WatchCompilerHostOfConfigFile } from './WatchCompilerHostOfConfigF
 import { getCodeText } from '../source-files';
 import {
   canonicalDirname,
-  createDefaultCompilerOptionsFromExtra,
   createHash,
+  createWatchCompilerOptionsFromExtra,
   getCanonicalFileName,
 } from './shared';
 
@@ -250,7 +250,7 @@ function createWatchProgram(
   // create compiler host
   const watchCompilerHost = ts.createWatchCompilerHost(
     tsconfigPath,
-    createDefaultCompilerOptionsFromExtra(parseSettings),
+    createWatchCompilerOptionsFromExtra(parseSettings),
     ts.sys,
     ts.createAbstractBuilder,
     diagnosticReporter,

--- a/packages/typescript-estree/src/create-program/shared.ts
+++ b/packages/typescript-estree/src/create-program/shared.ts
@@ -17,12 +17,24 @@ export interface ASTAndDefiniteProgram {
 export type ASTAndProgram = ASTAndDefiniteProgram | ASTAndNoProgram;
 
 /**
+ * Compiler options for the watch program.
+ *
+ * These are passed to `ts.createWatchCompilerHost` as `optionsToExtend`, which
+ * takes precedence over the user's tsconfig, so this must stay limited to the
+ * options we genuinely require. In particular `allowJs`/`checkJs` are absent:
+ * the tsconfig decides those.
+ */
+const WATCH_COMPILER_OPTIONS: ts.CompilerOptions = {
+  ...CORE_COMPILER_OPTIONS,
+  allowNonTsExtensions: true,
+};
+
+/**
  * Default compiler options for program generation
  */
 const DEFAULT_COMPILER_OPTIONS: ts.CompilerOptions = {
-  ...CORE_COMPILER_OPTIONS,
+  ...WATCH_COMPILER_OPTIONS,
   allowJs: true,
-  allowNonTsExtensions: true,
   checkJs: true,
 };
 
@@ -48,6 +60,19 @@ export function createDefaultCompilerOptionsFromExtra(
   }
 
   return DEFAULT_COMPILER_OPTIONS;
+}
+
+export function createWatchCompilerOptionsFromExtra(
+  parseSettings: ParseSettings,
+): ts.CompilerOptions {
+  if (parseSettings.debugLevel.has('typescript')) {
+    return {
+      ...WATCH_COMPILER_OPTIONS,
+      extendedDiagnostics: true,
+    };
+  }
+
+  return WATCH_COMPILER_OPTIONS;
 }
 
 // This narrows the type so we can be sure we're passing canonical names in the correct places

--- a/packages/typescript-estree/tests/lib/parse.test.ts
+++ b/packages/typescript-estree/tests/lib/parse.test.ts
@@ -21,6 +21,9 @@ vi.mock(import('../../src/create-program/shared.js'), async importOriginal => {
     createDefaultCompilerOptionsFromExtra: vi.fn(
       sharedActual.createDefaultCompilerOptionsFromExtra,
     ),
+    createWatchCompilerOptionsFromExtra: vi.fn(
+      sharedActual.createWatchCompilerOptionsFromExtra,
+    ),
   };
 });
 
@@ -49,8 +52,8 @@ vi.mock('tinyglobby', async importOriginal => {
   };
 });
 
-const createDefaultCompilerOptionsFromExtra = vi.mocked(
-  sharedParserUtilsModule.createDefaultCompilerOptionsFromExtra,
+const createWatchCompilerOptionsFromExtra = vi.mocked(
+  sharedParserUtilsModule.createWatchCompilerOptionsFromExtra,
 );
 // eslint-disable-next-line @typescript-eslint/no-deprecated -- see #10215
 const globSyncMock = vi.mocked(tinyGlobbyModule.globSync);
@@ -765,8 +768,8 @@ describe(parser.parseAndGenerateServices, () => {
           }),
         ) // should throw because the file and tsconfig don't exist
           .toThrow();
-        expect(createDefaultCompilerOptionsFromExtra).toHaveBeenCalledOnce();
-        expect(createDefaultCompilerOptionsFromExtra).toHaveLastReturnedWith(
+        expect(createWatchCompilerOptionsFromExtra).toHaveBeenCalledOnce();
+        expect(createWatchCompilerOptionsFromExtra).toHaveLastReturnedWith(
           expect.objectContaining({
             extendedDiagnostics: true,
           }),

--- a/packages/typescript-estree/tests/lib/persistentParse.test.ts
+++ b/packages/typescript-estree/tests/lib/persistentParse.test.ts
@@ -411,4 +411,32 @@ describe('persistent parse', () => {
       );
     });
   });
+
+  // https://github.com/typescript-eslint/typescript-eslint/issues/10013
+  describe.skipIf(process.env.TYPESCRIPT_ESLINT_PROJECT_SERVICE === 'true')(
+    'tsconfig compilerOptions',
+    () => {
+      it.for([false, true] as const)(
+        'lets the tsconfig decide allowJs when it is %s',
+        async (allowJs, { expect }) => {
+          const PROJECT_DIR = await setup({
+            compilerOptions: { allowJs },
+            include: ['./**/*'],
+          });
+
+          const result = parseAndGenerateServices(CONTENTS.foo, {
+            disallowAutomaticSingleRunInference: true,
+            filePath: path.join(PROJECT_DIR, 'src', 'foo.ts'),
+            project: './tsconfig.json',
+            tsconfigRootDir: PROJECT_DIR,
+          });
+
+          assert.isNotNull(result.services.program);
+          expect(result.services.program.getCompilerOptions().allowJs).toBe(
+            allowJs,
+          );
+        },
+      );
+    },
+  );
 });


### PR DESCRIPTION
Fixes #10013

## The asymmetry

`eslint file.ts` and `eslint --fix file.ts` build the TypeScript Program by two different code paths that disagree on compiler options:

- **single-run** (no `--fix`) → `createProgramFromConfigFile`, which passes only `CORE_COMPILER_OPTIONS` (`noEmit`, `noUnusedLocals`, `noUnusedParameters`) as `existingOptions`. The tsconfig wins.
- **non-single-run** (`--fix`, and editors) → `getWatchProgramsForProjects`, which passes `createDefaultCompilerOptionsFromExtra(...)` as `ts.createWatchCompilerHost`'s `optionsToExtend`.

`optionsToExtend` takes precedence over the tsconfig — `parseJsonConfigFileContentWorker` does `extend(existingOptions, parsedConfig.options)`, and `extend(first, second)` lets `first` overwrite. So `allowJs: true` and `checkJs: true` are force-enabled under `--fix` even when the user's tsconfig sets them `false`.

In the reporter's repro that means an untyped `./untyped` `.js` import resolves to a real type instead of `error`, `no-unsafe-member-access` stops firing, and `reportUnusedDisableDirectives` concludes the `// eslint-disable-next-line` comment is unused and **deletes it**. Re-running without `--fix` brings the error back, now unsuppressed.

This is the change @auvred proposed in the thread ("I think we should exclude `allowJs` from watch compiler host options. WDYT?"), which went unanswered.

## Change

Split the watch host's `optionsToExtend` from the isolated-program defaults:

- `WATCH_COMPILER_OPTIONS` = `CORE_COMPILER_OPTIONS` + `allowNonTsExtensions`. Used by `getWatchProgramsForProjects`, so the tsconfig decides `allowJs`/`checkJs`.
- `DEFAULT_COMPILER_OPTIONS` = the above + `allowJs`/`checkJs`. Still used by `createIsolatedProgram`, which has no tsconfig to defer to.

`allowNonTsExtensions` stays on the watch path deliberately: `inferSingleRun` returns `false` whenever `extraFileExtensions` is set together with `project`, so the watch host is the only path `.vue`/`.svelte` ever take. `noEmit` / `noUnusedLocals` / `noUnusedParameters` also stay — the latter two are what make `no-unused-vars` work.

`allowJs` and `checkJs` are removed together on purpose: TS raises TS5052 when `checkJs: true` meets an explicit `allowJs: false`, and `getAllowJSCompilerOption` treats `allowJs: undefined` + `checkJs: true` as allowJs-on.

The existing debug-flag assertion in `parse.test.ts` ("should turn on typescript debugger") drives the watch path, so it now asserts on `createWatchCompilerOptionsFromExtra` instead. Behaviour of that test is unchanged — `extendedDiagnostics: true` still propagates.

## Behaviour change — please weigh in

This is a real behaviour change for `parserOptions.project` users in editors, since the watch path is always taken when not single-run. Anyone whose tsconfig omits `allowJs` and who currently gets typed linting on `.js` files in VS Code will start seeing "was not found by the project".

That is consistent with what's documented — `docs/troubleshooting/typed-linting/index.mdx` says "If the file is a `.cjs`, `.js`, or `.mjs` file, make sure `allowJs` is enabled", and `docs/packages/Parser.mdx` notes that projectService can compute types for JS files *unlike* `project: true` — and it matches the closed #9749, which was treated as expected.

But if you'd rather have the mirror fix — add the defaults to the single-run path so both agree the *other* way — or hold this for a major, say the word and I'll rework it.

## Testing

Added a parameterized case to `persistentParse.test.ts`, which drives the real watch program against a real tsconfig via `disallowAutomaticSingleRunInference: true`. It asserts the program's `allowJs` matches the tsconfig for **both** values, so it covers the removal of the override without asserting that `allowJs` is simply off.

On `main`, the `false` case fails and the `true` case passes:

```
× lets the tsconfig decide allowJs when it is false
    AssertionError: expected true to be false
✓ lets the tsconfig decide allowJs when it is true
```

With this change the whole `typescript-estree` project is green (18 files / 396 tests), as is `eslint-plugin`. `eslint` is clean on all four changed files.
