### PR TITLE
fix(eslint-plugin): deduplicate unified-signatures union messages

### DIFF
--- a/packages/eslint-plugin/src/rules/unified-signatures.ts
+++ b/packages/eslint-plugin/src/rules/unified-signatures.ts
@@ -4,7 +4,12 @@ import { AST_NODE_TYPES, AST_TOKEN_TYPES } from '@typescript-eslint/utils';
 
 import type { Equal } from '../util';
 
-import { arraysAreEqual, createRule, nullThrows } from '../util';
+import {
+  arraysAreEqual,
+  createRule,
+  nullThrows,
+  typeNodeRequiresParentheses,
+} from '../util';
 
 interface Failure {
   only2: boolean;
@@ -122,6 +127,53 @@ export default createRule<Options, MessageIds>({
       return `${overloads} can be combined into one signature`;
     }
 
+    function getTypeText(typeAnnotation: TSESTree.TypeNode): string {
+      const tokens = context.sourceCode.getTokens(typeAnnotation);
+      const text = tokens
+        .map((token, index) => {
+          const separator =
+            index > 0 && tokens[index - 1].range[1] < token.range[0] ? ' ' : '';
+          return `${separator}${token.value}`;
+        })
+        .join('');
+
+      return typeNodeRequiresParentheses(typeAnnotation, text)
+        ? `(${text})`
+        : text;
+    }
+
+    function getTypeTexts(typeAnnotation?: TSESTree.TypeNode): string[] {
+      if (typeAnnotation == null) {
+        return [];
+      }
+
+      if (typeAnnotation.type === AST_NODE_TYPES.TSUnionType) {
+        return typeAnnotation.types.flatMap(getTypeTexts);
+      }
+
+      return [getTypeText(typeAnnotation)];
+    }
+
+    function getTypeTextPair(
+      typeAnnotation0: TSESTree.TypeNode | undefined,
+      typeAnnotation1: TSESTree.TypeNode | undefined,
+    ): [string, string] | undefined {
+      const typeTexts0 = [...new Set(getTypeTexts(typeAnnotation0))];
+      const typeTexts = [
+        ...new Set([...typeTexts0, ...getTypeTexts(typeAnnotation1)]),
+      ];
+
+      if (typeTexts.length < 2) {
+        return undefined;
+      }
+
+      const splitIndex = Math.min(typeTexts0.length, typeTexts.length - 1);
+      return [
+        typeTexts.slice(0, splitIndex).join(' | '),
+        typeTexts.slice(splitIndex).join(' | '),
+      ];
+    }
+
     function addFailures(failures: Failure[]): void {
       for (const failure of failures) {
         const { only2, unify } = failure;
@@ -136,6 +188,14 @@ export default createRule<Options, MessageIds>({
             const typeAnnotation1 = isTSParameterProperty(p1)
               ? p1.parameter.typeAnnotation
               : p1.typeAnnotation;
+            const typeTextPair = getTypeTextPair(
+              typeAnnotation0?.typeAnnotation,
+              typeAnnotation1?.typeAnnotation,
+            );
+            if (typeTextPair == null) {
+              break;
+            }
+            const [type1, type2] = typeTextPair;
 
             context.report({
               loc: p1.loc,
@@ -143,12 +203,8 @@ export default createRule<Options, MessageIds>({
               messageId: 'singleParameterDifference',
               data: {
                 failureStringStart: failureStringStart(lineOfOtherOverload),
-                type1: context.sourceCode.getText(
-                  typeAnnotation0?.typeAnnotation,
-                ),
-                type2: context.sourceCode.getText(
-                  typeAnnotation1?.typeAnnotation,
-                ),
+                type1,
+                type2,
               },
             });
             break;

--- a/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
+++ b/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
@@ -408,6 +408,10 @@ function f(this: void, a: boolean): void;
 function f(this: {}, a: boolean): void;
 function f(this: void | {}, a: boolean): void {}
     `,
+    `
+function f(a: string | string): void;
+function f(a: string): void;
+    `,
   ],
   invalid: [
     {
@@ -426,6 +430,246 @@ function f(a: number | string): void {}
             type2: 'string',
           },
           line: 3,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+    },
+    {
+      code: `
+function f(a: number | string): void;
+function f(a: string | boolean): void;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            type1: 'number | string',
+            type2: 'boolean',
+          },
+          endColumn: 31,
+          endLine: 3,
+          line: 3,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+    },
+    {
+      code: `
+function f(a: number | (string | boolean)): void;
+function f(a: boolean | bigint): void;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            type1: 'number | string | boolean',
+            type2: 'bigint',
+          },
+          endColumn: 31,
+          endLine: 3,
+          line: 3,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+    },
+    {
+      code: `
+function f(a: (() => void) | string): void;
+function f(a: string | boolean): void;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            type1: '(() => void) | string',
+            type2: 'boolean',
+          },
+          endColumn: 31,
+          endLine: 3,
+          line: 3,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+    },
+    {
+      code: `
+function f(a: (new () => object) | string): void;
+function f(a: string | boolean): void;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            type1: '(new () => object) | string',
+            type2: 'boolean',
+          },
+          endColumn: 31,
+          endLine: 3,
+          line: 3,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+    },
+    {
+      code: `
+function f(a: (string extends unknown ? number : boolean) | string): void;
+function f(a: string | bigint): void;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            type1: '(string extends unknown ? number : boolean) | string',
+            type2: 'bigint',
+          },
+          endColumn: 30,
+          endLine: 3,
+          line: 3,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+    },
+    {
+      code: `
+function f(a: 'hello | world' | string): void;
+function f(a: string | boolean): void;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            type1: "'hello | world' | string",
+            type2: 'boolean',
+          },
+          endColumn: 31,
+          endLine: 3,
+          line: 3,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+    },
+    {
+      code: `
+function f(a: number | string): void;
+function f(a: string | boolean): void;
+function f(a: string | bigint): void;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: {
+            failureStringStart:
+              'This overload and the one on line 2 can be combined into one signature',
+            type1: 'number | string',
+            type2: 'boolean',
+          },
+          endColumn: 31,
+          endLine: 3,
+          line: 3,
+          messageId: 'singleParameterDifference',
+        },
+        {
+          column: 12,
+          data: {
+            failureStringStart:
+              'This overload and the one on line 2 can be combined into one signature',
+            type1: 'number | string',
+            type2: 'bigint',
+          },
+          endColumn: 30,
+          endLine: 4,
+          line: 4,
+          messageId: 'singleParameterDifference',
+        },
+        {
+          column: 12,
+          data: {
+            failureStringStart:
+              'This overload and the one on line 3 can be combined into one signature',
+            type1: 'string | boolean',
+            type2: 'bigint',
+          },
+          endColumn: 30,
+          endLine: 4,
+          line: 4,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+    },
+    {
+      code: noFormat`
+function f(a: number        |
+    string): void;
+function f(a: string | boolean): void;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            type1: 'number | string',
+            type2: 'boolean',
+          },
+          endColumn: 31,
+          endLine: 4,
+          line: 4,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+    },
+    {
+      code: noFormat`
+function f(a: number | string /* shared */ & { brand: true }): void;
+function f(a: string | boolean): void;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            type1: 'number | string & { brand: true }',
+            type2: 'string | boolean',
+          },
+          endColumn: 31,
+          endLine: 3,
+          line: 3,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+    },
+    {
+      code: noFormat`
+function f(a: number | string & {
+  brand: true
+}): void;
+function f(a: string | boolean): void;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            type1: 'number | string & { brand: true }',
+            type2: 'string | boolean',
+          },
+          endColumn: 31,
+          endLine: 5,
+          line: 5,
           messageId: 'singleParameterDifference',
         },
       ],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #000
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

When two overloads share a union constituent, `unified-signatures` no longer repeats it in the reported replacement type. The report also stays valid for nested, function, constructor, conditional, and intersection constituents.

Tests cover comments, literal pipe characters, unusual spacing, and groups of three overloads. If deduplication leaves one type, no difference is reported.

💖
