### PR TITLE
fix(eslint-plugin): [class-literal-property-style] preserve type annotations and don't drop decorators

### DIFF
--- a/packages/eslint-plugin/src/rules/class-literal-property-style.ts
+++ b/packages/eslint-plugin/src/rules/class-literal-property-style.ts
@@ -181,6 +181,8 @@ export default createRule<Options, MessageIds>({
             return;
           }
 
+          const getterBody = node.value.body;
+
           context.report({
             node: node.key,
             messageId: 'preferFieldStyle',
@@ -191,14 +193,22 @@ export default createRule<Options, MessageIds>({
                 fix(fixer): TSESLint.RuleFix {
                   const name = context.sourceCode.getText(node.key);
 
+                  const closingParen = nullThrows(
+                    context.sourceCode.getTokenBefore(
+                      node.value.returnType ?? getterBody,
+                    ),
+                    'Getter should have a closing parenthesis.',
+                  );
+                  const betweenParensAndBody = context.sourceCode
+                    .getText()
+                    .slice(closingParen.range[1], getterBody.range[0]);
+
                   let text = '';
 
                   text += printNodeModifiers(node, 'readonly');
                   text += node.computed ? `[${name}]` : name;
-                  if (node.value.returnType) {
-                    text += context.sourceCode.getText(node.value.returnType);
-                  }
-                  text += ` = ${context.sourceCode.getText(argument)};`;
+                  text += betweenParensAndBody;
+                  text += `= ${context.sourceCode.getText(argument)};`;
 
                   return fixer.replaceText(node, text);
                 },

--- a/packages/eslint-plugin/src/rules/class-literal-property-style.ts
+++ b/packages/eslint-plugin/src/rules/class-literal-property-style.ts
@@ -4,6 +4,7 @@ import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 
 import {
   createRule,
+  getFixOrSuggest,
   getStaticMemberAccessValue,
   isAssignee,
   isFunction,
@@ -183,8 +184,9 @@ export default createRule<Options, MessageIds>({
           context.report({
             node: node.key,
             messageId: 'preferFieldStyle',
-            suggest: [
-              {
+            ...getFixOrSuggest({
+              fixOrSuggest: node.decorators.length === 0 ? 'suggest' : 'none',
+              suggestion: {
                 messageId: 'preferFieldStyleSuggestion',
                 fix(fixer): TSESLint.RuleFix {
                   const name = context.sourceCode.getText(node.key);
@@ -193,12 +195,15 @@ export default createRule<Options, MessageIds>({
 
                   text += printNodeModifiers(node, 'readonly');
                   text += node.computed ? `[${name}]` : name;
+                  if (node.value.returnType) {
+                    text += context.sourceCode.getText(node.value.returnType);
+                  }
                   text += ` = ${context.sourceCode.getText(argument)};`;
 
                   return fixer.replaceText(node, text);
                 },
               },
-            ],
+            }),
           });
         },
       }),

--- a/packages/eslint-plugin/tests/rules/class-literal-property-style.test.ts
+++ b/packages/eslint-plugin/tests/rules/class-literal-property-style.test.ts
@@ -395,6 +395,54 @@ class Mx {
     {
       code: `
 class Mx {
+  public static get n(): 1 | 2 {
+    return 1;
+  }
+}
+      `,
+      errors: [
+        {
+          column: 21,
+          endColumn: 22,
+          endLine: 3,
+          line: 3,
+          messageId: 'preferFieldStyle',
+          suggestions: [
+            {
+              messageId: 'preferFieldStyleSuggestion',
+              output: `
+class Mx {
+  public static readonly n: 1 | 2 = 1;
+}
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+class Mx {
+  @logAccess
+  public static get foo(): number {
+    return 1;
+  }
+}
+      `,
+      errors: [
+        {
+          column: 21,
+          endColumn: 24,
+          endLine: 4,
+          line: 4,
+          messageId: 'preferFieldStyle',
+          suggestions: [],
+        },
+      ],
+    },
+    {
+      code: `
+class Mx {
   public get [myValue]() {
     return 'a literal value';
   }

--- a/packages/eslint-plugin/tests/rules/class-literal-property-style.test.ts
+++ b/packages/eslint-plugin/tests/rules/class-literal-property-style.test.ts
@@ -423,6 +423,34 @@ class Mx {
     {
       code: `
 class Mx {
+  public static get n() /* before */ : 1 | 2 /* after */ {
+    return 1;
+  }
+}
+      `,
+      errors: [
+        {
+          column: 21,
+          endColumn: 22,
+          endLine: 3,
+          line: 3,
+          messageId: 'preferFieldStyle',
+          suggestions: [
+            {
+              messageId: 'preferFieldStyleSuggestion',
+              output: `
+class Mx {
+  public static readonly n /* before */ : 1 | 2 /* after */ = 1;
+}
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+class Mx {
   @logAccess
   public static get foo(): number {
     return 1;


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #12616
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview


The `fields` suggestion now preserves getter return type annotations, so `get n(): 1 | 2` does not become a widened `readonly n = 1`

It also no longer suggests a fix for decorated getters, since moving a decorator from a getter to a field can change its meaning