### PR TITLE
chore: stop measuring coverage change between commits

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,11 +5,11 @@ codecov:
 
 coverage:
   status:
-    patch: off
     project:
       default:
         target: auto
         threshold: 2%
+    patch: off
 
 comment:
   layout: diff, flags, files

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,9 +5,7 @@ codecov:
 
 coverage:
   status:
-    patch:
-      default:
-        target: 90%
+    patch: off
     project:
       default:
         target: auto


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

<!-- Description of what is changed and how the code change does that. -->

We should only care about project coverage.
I don't think coverage changes between commits are helpful, and it fails on every PR that changes AST (example https://github.com/typescript-eslint/typescript-eslint/pull/12609 ).
