### PR TITLE
docs: clarify checkTypePredicates assumptions

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
@@ -155,7 +155,7 @@ while (thisIsTrue) {
 
 ### `checkTypePredicates`
 
-{/* insert option description */}
+When this option is enabled, the rule assumes that type predicates are accurate in both directions: the predicate returns `true` if and only if the value has the asserted type. This is required for TypeScript's type narrowing to be sound, but it may not be obvious to everyone writing a type predicate. Assertion signatures (`asserts`) may require particular care, as their runtime checks do not always make the same guarantee.
 
 Example of additional incorrect code with `{ checkTypePredicates: true }`:
 

--- a/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
@@ -155,6 +155,8 @@ while (thisIsTrue) {
 
 ### `checkTypePredicates`
 
+{/* insert option description */}
+
 When this option is enabled, the rule assumes that type predicates are accurate in both directions: the predicate returns `true` if and only if the value has the asserted type. This is required for TypeScript's type narrowing to be sound, but it may not be obvious to everyone writing a type predicate. Assertion signatures (`asserts`) may require particular care, as their runtime checks do not always make the same guarantee.
 
 Example of additional incorrect code with `{ checkTypePredicates: true }`:


### PR DESCRIPTION
## Summary
- Explain that `checkTypePredicates` assumes type predicates are accurate in both directions.
- Call out that assertion signatures may need additional care because runtime checks do not always provide the same guarantee.

## Validation
- `git diff --check` passed.
- Prettier could not run because repository dependencies are not installed.

Closes #~12349~