### PR TITLE
fix(eslint-plugin): dedupe unified signatures union message

### DIFF
--- a/packages/eslint-plugin/src/rules/unified-signatures.ts
+++ b/packages/eslint-plugin/src/rules/unified-signatures.ts
@@ -137,18 +137,19 @@ export default createRule<Options, MessageIds>({
               ? p1.parameter.typeAnnotation
               : p1.typeAnnotation;
 
+            const unionTypes = getUniqueCombinedTypeTexts(
+              typeAnnotation0?.typeAnnotation,
+              typeAnnotation1?.typeAnnotation,
+            );
+
             context.report({
               loc: p1.loc,
               node: p1,
               messageId: 'singleParameterDifference',
               data: {
                 failureStringStart: failureStringStart(lineOfOtherOverload),
-                type1: context.sourceCode.getText(
-                  typeAnnotation0?.typeAnnotation,
-                ),
-                type2: context.sourceCode.getText(
-                  typeAnnotation1?.typeAnnotation,
-                ),
+                type1: unionTypes[0],
+                type2: unionTypes.slice(1).join(' | '),
               },
             });
             break;
@@ -498,6 +499,35 @@ export default createRule<Options, MessageIds>({
           context.sourceCode.getText(a.typeAnnotation) ===
             context.sourceCode.getText(b.typeAnnotation))
       );
+    }
+
+    function getUniqueCombinedTypeTexts(
+      a: TSESTree.TypeNode | undefined,
+      b: TSESTree.TypeNode | undefined,
+    ): string[] {
+      const seen = new Set<string>();
+      const types: string[] = [];
+
+      for (const typeNode of [a, b]) {
+        const typeNodes =
+          typeNode?.type === AST_NODE_TYPES.TSUnionType
+            ? typeNode.types
+            : [typeNode];
+
+        for (const typeNode of typeNodes) {
+          if (typeNode == null) {
+            continue;
+          }
+
+          const text = context.sourceCode.getText(typeNode);
+          if (!seen.has(text)) {
+            seen.add(text);
+            types.push(text);
+          }
+        }
+      }
+
+      return types;
     }
 
     function constraintsAreEqual(

--- a/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
+++ b/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
@@ -774,6 +774,29 @@ interface I {
       ],
     },
     {
+      // Deduplicate repeated union members in the suggested combined signature.
+      code: `
+function f(a: number | string): void;
+function f(a: string | boolean): void;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            type1: 'number',
+            type2: 'string | boolean',
+          },
+          endColumn: 31,
+          endLine: 3,
+          line: 3,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+      options: [{ ignoreDifferentlyNamedParameters: true }],
+    },
+    {
       // Works with tuples.
       code: `
 interface I {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #000
- [x] That issue was marked as accepting PRs
- [x] Tests were added or updated

## Overview

This fixes the `unified-signatures` diagnostic text when both overload parameter types are unions and share a member.

Before this change, the rule built the suggested combined type by concatenating the two parameter type texts. For overloads like `number | string` and `string | boolean`, that produced `number | string | string | boolean`.

The rule now expands union parameter types into their constituent type texts and keeps the first occurrence of each one, preserving the existing order while avoiding repeated members in the message.

## Checks

- [x] RED: `pnpm exec nx test eslint-plugin -- unified-signatures` failed on the new regression test before the fix, showing `number | string | string | boolean`
- [x] `pnpm exec nx test eslint-plugin -- unified-signatures`
- [x] `pnpm exec nx test eslint-plugin`
- [x] `pnpm exec nx typecheck eslint-plugin`
- [x] `pnpm exec nx lint eslint-plugin`
- [x] `pnpm exec prettier --check packages/eslint-plugin/src/rules/unified-signatures.ts packages/eslint-plugin/tests/rules/unified-signatures.test.ts`
- [x] `git diff --check`
