### PR TITLE
chore(types): fix `build` nx task inputs

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -70,9 +70,6 @@
       "build": {
         "dependsOn": [
           "copy-ast-spec"
-        ],
-        "inputs": [
-          "{projectRoot}/src/generated/**/*"
         ]
       },
       "copy-ast-spec": {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [X] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

So it's indeed a dependency (`inputs`) issue. From what I understood, adding `inputs` to the `build` task basically overrides all the default inputs that are defined in `nx.json`:

https://github.com/typescript-eslint/typescript-eslint/blob/0c94e088e9477c5c3ae64f4e02955cc719fe8773/nx.json#L85

Also, adding `"{projectRoot}/src/generated/**/*"` as an input doesn't do anything since it's gitignored, and nx doesn't glob these files for hashing

To fix this, we can set `inputs: [ "default" ]`, but it'd be the same as not having this at all. Also, since we already have `ast-spec` as an `implicitDependency` of this package, it'll bust the cache each time `ast-spec` is invalidated

(Correct me if I'm wrong, @JamesHenry)