### PR TITLE
chore: [ci] unlink issues from AI slop PRs

### DIFF
--- a/.github/workflows/slop-unlink-issues.yml
+++ b/.github/workflows/slop-unlink-issues.yml
@@ -51,7 +51,7 @@ jobs:
           body=$(gh pr view "$PR" --repo "$REPO" --json body --jq .body)
 
           for issue in $issues; do
-            body=$(printf '%s' "$body" | perl -pe "s/#$issue\b/#000/g")
+            body=$(printf '%s' "$body" | perl -pe "s/#$issue\b/#~$issue~/g")
           done
 
           gh pr edit "$PR" --repo "$REPO" --body "$body"

--- a/.github/workflows/slop-unlink-issues.yml
+++ b/.github/workflows/slop-unlink-issues.yml
@@ -50,8 +50,8 @@ jobs:
 
           body=$(gh pr view "$PR" --repo "$REPO" --json body --jq .body)
 
-          for number in $issues; do
-            body=$(printf '%s' "$body" | perl -pe "s/#$number\b/#000/g")
+          for issue in $issues; do
+            body=$(printf '%s' "$body" | perl -pe "s/#$issue\b/#000/g")
           done
 
           gh pr edit "$PR" --repo "$REPO" --body "$body"

--- a/.github/workflows/slop-unlink-issues.yml
+++ b/.github/workflows/slop-unlink-issues.yml
@@ -1,0 +1,57 @@
+name: Slop Unlink Issues
+
+on:
+  # WARNING: Using pull_request_target here because we need write permissions to
+  # edit PRs from forks.
+  #
+  # NEVER EVER execute any code from the fork (including checkout, install, scripts, etc.)
+  pull_request_target:
+    types: [closed] # zizmor: ignore[dangerous-triggers] See warning above.
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  unlink-issues:
+    name: Unlink Issues
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    # Include only non-merged PRs with AI slop labels.
+    if: >-
+      github.event.pull_request.merged == false
+      && (contains(github.event.pull_request.labels.*.name, 'AI Slop')
+      || contains(github.event.pull_request.labels.*.name, 'spam:automated-account')
+      || contains(github.event.pull_request.labels.*.name, 'spam:community-flagged')
+      || contains(github.event.pull_request.labels.*.name, 'spam:likely-slop')
+      || contains(github.event.pull_request.labels.*.name, 'spam:mixed-signals'))
+
+    steps:
+      # There is no API to unlink an issue from a PR, so we need to manually edit
+      # the PR description and replace the linked issues with a placeholder.
+      - name: Unlink issues from slop PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          issues=$(gh pr view "$PR" --repo "$REPO" --json closingIssuesReferences --jq '.closingIssuesReferences[].number')
+
+          if [ -z "$issues" ]; then
+            echo 'No linked issues.'
+            exit 0
+          fi
+
+          echo "Unlinking: $issues"
+
+          body=$(gh pr view "$PR" --repo "$REPO" --json body --jq .body)
+
+          for number in $issues; do
+            body=$(printf '%s' "$body" | perl -pe "s/#$number\b/#000/g")
+          done
+
+          gh pr edit "$PR" --repo "$REPO" --body "$body"


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [X] Addresses an existing open issue: fixes #12629 
- [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [X] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

When working on this, I thought maybe we should unlink issues on any PR close. But then it means that a legitimate PR that was closed due to being stale, for example, and then reopened, will lose its linked issue.

Are we ok with that?

See it in aciton in my fork

https://github.com/StyleShit/typescript-eslint/pull/12

EDIT: I changed it since the test in my fork to replace `#123` with `#~123~`, so we can keep reference to the original issue, if needed
