### PR TITLE
fix(eslint-plugin): [no-unnecessary-type-parameters] handle type precedence in the suggestion fixer

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-parameters.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-parameters.ts
@@ -112,7 +112,10 @@ export default createRule({
                     const isWeakPrecedenceConstraint =
                       constraint?.type === AST_NODE_TYPES.TSUnionType ||
                       constraint?.type === AST_NODE_TYPES.TSIntersectionType ||
-                      constraint?.type === AST_NODE_TYPES.TSConditionalType;
+                      constraint?.type === AST_NODE_TYPES.TSConditionalType ||
+                      constraint?.type === AST_NODE_TYPES.TSTypeOperator ||
+                      constraint?.type === AST_NODE_TYPES.TSFunctionType ||
+                      constraint?.type === AST_NODE_TYPES.TSConstructorType;
 
                     const grandparent = nullThrows(
                       referenceNode.parent.parent,
@@ -124,6 +127,8 @@ export default createRule({
                       AST_NODE_TYPES.TSIndexedAccessType,
                       AST_NODE_TYPES.TSIntersectionType,
                       AST_NODE_TYPES.TSUnionType,
+                      AST_NODE_TYPES.TSConditionalType,
+                      AST_NODE_TYPES.TSTypeOperator,
                     ].some(type => grandparent.type === type);
 
                     if (

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-parameters.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-parameters.ts
@@ -121,14 +121,13 @@ export default createRule({
                       NullThrowsReasons.MissingParent,
                     );
 
-                    const isWeakPrecedenceTypeParent = [
-                      AST_NODE_TYPES.TSArrayType,
-                      AST_NODE_TYPES.TSIndexedAccessType,
-                      AST_NODE_TYPES.TSIntersectionType,
-                      AST_NODE_TYPES.TSUnionType,
-                      AST_NODE_TYPES.TSConditionalType,
-                      AST_NODE_TYPES.TSTypeOperator,
-                    ].some(type => grandparent.type === type);
+                    const isWeakPrecedenceTypeParent =
+                      grandparent.type === AST_NODE_TYPES.TSArrayType ||
+                      grandparent.type === AST_NODE_TYPES.TSIndexedAccessType ||
+                      grandparent.type === AST_NODE_TYPES.TSIntersectionType ||
+                      grandparent.type === AST_NODE_TYPES.TSUnionType ||
+                      grandparent.type === AST_NODE_TYPES.TSConditionalType ||
+                      grandparent.type === AST_NODE_TYPES.TSTypeOperator;
 
                     if (
                       isWeakPrecedenceConstraint &&

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-parameters.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-parameters.ts
@@ -113,13 +113,19 @@ export default createRule({
                       constraint?.type === AST_NODE_TYPES.TSUnionType ||
                       constraint?.type === AST_NODE_TYPES.TSIntersectionType ||
                       constraint?.type === AST_NODE_TYPES.TSConditionalType;
+
+                    const grandparent = nullThrows(
+                      referenceNode.parent.parent,
+                      NullThrowsReasons.MissingParent,
+                    );
+
                     const hasMatchingAncestorType = [
                       AST_NODE_TYPES.TSArrayType,
                       AST_NODE_TYPES.TSIndexedAccessType,
                       AST_NODE_TYPES.TSIntersectionType,
                       AST_NODE_TYPES.TSUnionType,
-                      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                    ].some(type => referenceNode.parent.parent!.type === type);
+                    ].some(type => grandparent.type === type);
+
                     if (isComplexType && hasMatchingAncestorType) {
                       const fixResult = getWrappingFixer({
                         node: referenceNode,

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-parameters.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-parameters.ts
@@ -109,7 +109,7 @@ export default createRule({
                 for (const reference of smTypeParameterVariable.references) {
                   if (reference.isTypeReference) {
                     const referenceNode = reference.identifier;
-                    const isComplexType =
+                    const isWeakPrecedenceConstraint =
                       constraint?.type === AST_NODE_TYPES.TSUnionType ||
                       constraint?.type === AST_NODE_TYPES.TSIntersectionType ||
                       constraint?.type === AST_NODE_TYPES.TSConditionalType;
@@ -119,14 +119,17 @@ export default createRule({
                       NullThrowsReasons.MissingParent,
                     );
 
-                    const hasMatchingAncestorType = [
+                    const isWeakPrecedenceTypeParent = [
                       AST_NODE_TYPES.TSArrayType,
                       AST_NODE_TYPES.TSIndexedAccessType,
                       AST_NODE_TYPES.TSIntersectionType,
                       AST_NODE_TYPES.TSUnionType,
                     ].some(type => grandparent.type === type);
 
-                    if (isComplexType && hasMatchingAncestorType) {
+                    if (
+                      isWeakPrecedenceConstraint &&
+                      isWeakPrecedenceTypeParent
+                    ) {
                       const fixResult = getWrappingFixer({
                         node: referenceNode,
                         innerNode: constraint,

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-parameters.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-parameters.ts
@@ -131,14 +131,17 @@ export default createRule({
                       isWeakPrecedenceTypeParent
                     ) {
                       const fixResult = getWrappingFixer({
-                        node: referenceNode,
+                        node: referenceNode.parent,
                         innerNode: constraint,
                         sourceCode: context.sourceCode,
                         wrap: constraintNode => constraintNode,
                       })(fixer);
                       yield fixResult;
                     } else {
-                      yield fixer.replaceText(referenceNode, constraintText);
+                      yield fixer.replaceText(
+                        referenceNode.parent,
+                        constraintText,
+                      );
                     }
                   }
                 }

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-parameters.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-parameters.ts
@@ -10,7 +10,6 @@ import type { MakeRequired } from '../util';
 import {
   createRule,
   getParserServices,
-  getWrappingFixer,
   nullThrows,
   NullThrowsReasons,
 } from '../util';
@@ -135,13 +134,10 @@ export default createRule({
                       isWeakPrecedenceConstraint &&
                       isWeakPrecedenceTypeParent
                     ) {
-                      const fixResult = getWrappingFixer({
-                        node: referenceNode.parent,
-                        innerNode: constraint,
-                        sourceCode: context.sourceCode,
-                        wrap: constraintNode => constraintNode,
-                      })(fixer);
-                      yield fixResult;
+                      yield fixer.replaceText(
+                        referenceNode.parent,
+                        `(${constraintText})`,
+                      );
                     } else {
                       yield fixer.replaceText(
                         referenceNode.parent,

--- a/packages/eslint-plugin/src/util/getWrappingFixer.ts
+++ b/packages/eslint-plugin/src/util/getWrappingFixer.ts
@@ -116,7 +116,6 @@ export function isStrongPrecedenceNode(innerNode: TSESTree.Node): boolean {
     innerNode.type === AST_NODE_TYPES.Literal ||
     innerNode.type === AST_NODE_TYPES.Identifier ||
     innerNode.type === AST_NODE_TYPES.TSTypeReference ||
-    innerNode.type === AST_NODE_TYPES.TSTypeOperator ||
     innerNode.type === AST_NODE_TYPES.ArrayExpression ||
     innerNode.type === AST_NODE_TYPES.ObjectExpression ||
     innerNode.type === AST_NODE_TYPES.MemberExpression ||

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-parameters.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-parameters.test.ts
@@ -1904,5 +1904,47 @@ declare function f(): (A extends B ? C : D) | null;
         },
       ],
     },
+    {
+      code: 'declare function foo<T extends () => number>(arg: T[]): void;',
+      errors: [
+        {
+          data: { descriptor: 'function', name: 'T', uses: 'used only once' },
+          messageId: 'sole',
+          suggestions: [
+            {
+              messageId: 'replaceUsagesWithConstraint',
+              output: 'declare function foo(arg: (() => number)[]): void;',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+interface Foo {
+  a: string;
+  b: number;
+}
+declare function foo<T extends keyof Foo>(arg: T[]): void;
+      `,
+      errors: [
+        {
+          data: { descriptor: 'function', name: 'T', uses: 'used only once' },
+          messageId: 'sole',
+          suggestions: [
+            {
+              messageId: 'replaceUsagesWithConstraint',
+              output: `
+interface Foo {
+  a: string;
+  b: number;
+}
+declare function foo(arg: (keyof Foo)[]): void;
+      `,
+            },
+          ],
+        },
+      ],
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-parameters.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-parameters.test.ts
@@ -1946,5 +1946,114 @@ declare function foo(arg: (keyof Foo)[]): void;
         },
       ],
     },
+    {
+      code: 'declare function foo<T extends () => void>(arg: T | string): void;',
+      errors: [
+        {
+          data: { descriptor: 'function', name: 'T', uses: 'used only once' },
+          messageId: 'sole',
+          suggestions: [
+            {
+              messageId: 'replaceUsagesWithConstraint',
+              output: 'declare function foo(arg: (() => void) | string): void;',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+interface A {
+  x: string;
+  shared: string;
+}
+interface B {
+  y: string;
+  shared: string;
+}
+declare function foo<T extends A | B>(k: keyof T): void;
+      `,
+      errors: [
+        {
+          data: { descriptor: 'function', name: 'T', uses: 'used only once' },
+          messageId: 'sole',
+          suggestions: [
+            {
+              messageId: 'replaceUsagesWithConstraint',
+              output: `
+interface A {
+  x: string;
+  shared: string;
+}
+interface B {
+  y: string;
+  shared: string;
+}
+declare function foo(k: keyof (A | B)): void;
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+class Foo {}
+declare function bar<T extends new () => Foo>(arg: T[]): void;
+      `,
+      errors: [
+        {
+          data: { descriptor: 'function', name: 'T', uses: 'used only once' },
+          messageId: 'sole',
+          suggestions: [
+            {
+              messageId: 'replaceUsagesWithConstraint',
+              output: `
+class Foo {}
+declare function bar(arg: (new () => Foo)[]): void;
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+declare function foo<T extends () => Promise<string>>(
+  arg: T extends () => Promise<infer R> ? R : never,
+): void;
+      `,
+      errors: [
+        {
+          data: { descriptor: 'function', name: 'T', uses: 'used only once' },
+          messageId: 'sole',
+          suggestions: [
+            {
+              messageId: 'replaceUsagesWithConstraint',
+              output: `
+declare function foo(
+  arg: (() => Promise<string>) extends () => Promise<infer R> ? R : never,
+): void;
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: 'declare function foo<T extends readonly string[]>(x: T[]): void;',
+      errors: [
+        {
+          data: { descriptor: 'function', name: 'T', uses: 'used only once' },
+          messageId: 'sole',
+          suggestions: [
+            {
+              messageId: 'replaceUsagesWithConstraint',
+              output: 'declare function foo(x: (readonly string[])[]): void;',
+            },
+          ],
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #12636
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview
The suggestion replaces a type parameter with its constraint without parenthesizing it, which can change what the type means:

```ts
interface Foo { a: string; b: number; }

function fn<T extends keyof Foo>(x: T[]) {}

// before: function fn(x: keyof Foo[]) {}
// after:  function fn(x: (keyof Foo)[]) {}
```

**To fix the bug, I made the following changes:**

- Added the `TSTypeOperator`, `TSFunctionType`, and `TSConstructorType` cases to `isWeakPrecedenceConstraint`.
- Added the `TSConditionalType` and `TSTypeOperator` cases to `isWeakPrecedenceTypeParent`.
- When both `isWeakPrecedenceConstraint` and `isWeakPrecedenceTypeParent` hold, parentheses are needed, so the fixer now adds them as it replaces the type reference.
    - As part of this, I switched from the `getWrappingFixer()` utility to a plain `fixer.replaceText()`.

Following the suggestion in the issue, I tried the `getWrappingFixer()` utilities first, but getting them right for types would mean listing every primitive type (and more) in `isStrongPrecedenceNode()`. (See the inline review comments for details.)
so I handled it locally in the rule instead. If there's a cleaner approach I've missed, I'm happy to rework it.

**To make the intent of the code clearer, I made the following changes:**

- Removed `TSTypeOperator` from `isStrongPrecedenceNode()`, since that utility marks nodes that never need parentheses regardless of their new parent — which isn't true of type operators (`keyof Foo` changes meaning under an array type, as in `keyof Foo[]`).
- Replaced the disable comment for`no-non-null-assertion` with the `nullThrows()` utility, making it explicit that `referenceNode.parent.parent` always exists.
- Renamed the two condition variables to describe what they actually check:
    - `isComplexType` → `isWeakPrecedenceConstraint`
    - `hasMatchingAncestorType` → `isWeakPrecedenceTypeParent`
- Rewrote `isWeakPrecedenceTypeParent` as direct type comparisons instead of an array `.some()` lookup, so both conditions read the same way.
- Changed every replacement target from `referenceNode` to `referenceNode.parent`, since what's actually being replaced is the `TSTypeReference`, not the identifier inside it.

💖