### PR TITLE
fix(eslint-plugin): dedupe union members in unified-signatures message

### DIFF
--- a/packages/eslint-plugin/src/rules/unified-signatures.ts
+++ b/packages/eslint-plugin/src/rules/unified-signatures.ts
@@ -136,6 +136,10 @@ export default createRule<Options, MessageIds>({
             const typeAnnotation1 = isTSParameterProperty(p1)
               ? p1.parameter.typeAnnotation
               : p1.typeAnnotation;
+            const typeMessageData = getUnionTypeMessageData(
+              typeAnnotation0?.typeAnnotation,
+              typeAnnotation1?.typeAnnotation,
+            );
 
             context.report({
               loc: p1.loc,
@@ -143,12 +147,8 @@ export default createRule<Options, MessageIds>({
               messageId: 'singleParameterDifference',
               data: {
                 failureStringStart: failureStringStart(lineOfOtherOverload),
-                type1: context.sourceCode.getText(
-                  typeAnnotation0?.typeAnnotation,
-                ),
-                type2: context.sourceCode.getText(
-                  typeAnnotation1?.typeAnnotation,
-                ),
+                type1: typeMessageData.type1,
+                type2: typeMessageData.type2,
               },
             });
             break;
@@ -254,6 +254,58 @@ export default createRule<Options, MessageIds>({
         signatureUsesTypeParameter(a, isTypeParameter) ===
           signatureUsesTypeParameter(b, isTypeParameter)
       );
+    }
+
+    function getUnionTypeMessageData(
+      type0: TSESTree.TypeNode | undefined,
+      type1: TSESTree.TypeNode | undefined,
+    ): { type1: string; type2: string } {
+      const parts: string[] = [];
+      const seen = new Set<string>();
+
+      for (const type of [
+        ...getTopLevelUnionTypes(type0),
+        ...getTopLevelUnionTypes(type1),
+      ]) {
+        const text = getTypeTextForMessage(type);
+        if (!seen.has(text)) {
+          seen.add(text);
+          parts.push(text);
+        }
+      }
+
+      return {
+        type1: parts[0] ?? '',
+        type2: parts.slice(1).join(' | '),
+      };
+    }
+
+    function getTopLevelUnionTypes(
+      type: TSESTree.TypeNode | undefined,
+    ): TSESTree.TypeNode[] {
+      return type == null
+        ? []
+        : type.type === AST_NODE_TYPES.TSUnionType
+          ? type.types
+          : [type];
+    }
+
+    function getTypeTextForMessage(type: TSESTree.TypeNode): string {
+      let text = context.sourceCode.getText(type);
+      const [start, end] = type.range;
+
+      for (const comment of [
+        ...context.sourceCode.getAllComments(),
+      ].reverse()) {
+        const [commentStart, commentEnd] = comment.range;
+        if (start <= commentStart && commentEnd <= end) {
+          text =
+            text.slice(0, commentStart - start) +
+            text.slice(commentEnd - start);
+        }
+      }
+
+      return text.replaceAll(/\s+/gu, ' ').trim();
     }
 
     /** Detect `a(x: number, y: number, z: number)` and `a(x: number, y: string, z: number)`. */

--- a/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
+++ b/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
@@ -774,6 +774,96 @@ interface I {
       ],
     },
     {
+      code: `
+function f(a: number | string): void;
+function f(a: string | boolean): void;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            type1: 'number',
+            type2: 'string | boolean',
+          },
+          endColumn: 31,
+          endLine: 3,
+          line: 3,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+      options: [{ ignoreDifferentlyNamedParameters: true }],
+    },
+    {
+      code: `
+function f(a: number | string): void;
+function f(a: 'hello | world' | string): void;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            type1: 'number',
+            type2: "string | 'hello | world'",
+          },
+          endColumn: 39,
+          endLine: 3,
+          line: 3,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+      options: [{ ignoreDifferentlyNamedParameters: true }],
+    },
+    {
+      code: `
+function f(a: number | /* Hey */ string): void;
+function f(a: string | boolean): void;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            type1: 'number',
+            type2: 'string | boolean',
+          },
+          endColumn: 31,
+          endLine: 3,
+          line: 3,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+      options: [{ ignoreDifferentlyNamedParameters: true }],
+    },
+    {
+      code: noFormat`
+function f(a: number | string & {
+  brand: true
+}): void;
+function f(a: string | boolean): void;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            type1: 'number',
+            type2: 'string & { brand: true } | string | boolean',
+          },
+          endColumn: 31,
+          endLine: 5,
+          line: 5,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+      options: [{ ignoreDifferentlyNamedParameters: true }],
+    },
+    {
       // Works with tuples.
       code: `
 interface I {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #~12504~
- [x] That issue was marked as accepting prs
- [x] Steps in Contributing were taken

## Overview

Fixes #~12504~.

`unified-signatures` now builds the diagnostic suggestion from top-level union members instead of concatenating both parameter type annotations. It preserves first-seen order, removes repeated members by normalized text, and strips comments and extra whitespace from diagnostic text. This keeps string literal pipes and intersection members intact while avoiding messages such as `number | string | string | boolean`.

## Validation

- `pnpm install --frozen-lockfile` - passed; postinstall build/typecheck tasks completed successfully
- `pnpm exec nx test eslint-plugin -- unified-signatures` - passed; 94 tests passed
- `pnpm exec nx test eslint-plugin` - passed; 181 files passed, 32,604 tests passed, 171 skipped
- `pnpm exec nx typecheck eslint-plugin` - passed
- `pnpm exec nx lint eslint-plugin` - passed
- `pnpm exec prettier --check packages/eslint-plugin/src/rules/unified-signatures.ts packages/eslint-plugin/tests/rules/unified-signatures.test.ts` - passed
- `git diff --check` - passed

## Blockers

None.

💖