### PR TITLE
fix(eslint-plugin): [no-floating-promises] setting `ignoreVoid: false` results in false negative in ArrowFunctionExpression

### DIFF
--- a/packages/eslint-plugin/src/rules/no-floating-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-floating-promises.ts
@@ -137,9 +137,7 @@ export default createRule<Options, MessageId>({
     /* eslint-enable @typescript-eslint/no-non-null-assertion */
 
     return {
-      'ArrowFunctionExpression:has(> UnaryExpression)'(
-        node: TSESTree.ArrowFunctionExpression,
-      ): void {
+      ArrowFunctionExpression(node): void {
         if (node.body.type === AST_NODE_TYPES.UnaryExpression) {
           checkNode(node.body, node.body);
         }

--- a/packages/eslint-plugin/src/rules/no-floating-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-floating-promises.ts
@@ -137,6 +137,14 @@ export default createRule<Options, MessageId>({
     /* eslint-enable @typescript-eslint/no-non-null-assertion */
 
     return {
+      'ArrowFunctionExpression:has(> UnaryExpression)'(
+        node: TSESTree.ArrowFunctionExpression,
+      ): void {
+        if (node.body.type === AST_NODE_TYPES.UnaryExpression) {
+          checkNode(node.body, node.body);
+        }
+      },
+
       ExpressionStatement(node): void {
         if (options.ignoreIIFE && isAsyncIife(node)) {
           return;
@@ -144,77 +152,84 @@ export default createRule<Options, MessageId>({
 
         const expression = skipChainExpression(node.expression);
 
-        if (isKnownSafePromiseCall(expression)) {
-          return;
-        }
-
-        const { isUnhandled, nonFunctionHandler, promiseArray } =
-          isUnhandledPromise(checker, expression);
-
-        if (isUnhandled) {
-          if (promiseArray) {
-            context.report({
-              node,
-              messageId: options.ignoreVoid
-                ? 'floatingPromiseArrayVoid'
-                : 'floatingPromiseArray',
-            });
-          } else if (options.ignoreVoid) {
-            context.report({
-              node,
-              messageId: nonFunctionHandler
-                ? 'floatingUselessRejectionHandlerVoid'
-                : 'floatingVoid',
-              suggest: [
-                {
-                  messageId: 'floatingFixVoid',
-                  fix(fixer): TSESLint.RuleFix | TSESLint.RuleFix[] {
-                    if (
-                      isParenthesized(expression, context.sourceCode) ||
-                      getOperatorPrecedenceForNode(expression) >
-                        OperatorPrecedence.Unary
-                    ) {
-                      return fixer.insertTextBefore(node, 'void ');
-                    }
-                    return [
-                      fixer.insertTextBefore(node, 'void ('),
-                      fixer.insertTextAfterRange(
-                        [expression.range[1], expression.range[1]],
-                        ')',
-                      ),
-                    ];
-                  },
-                },
-                {
-                  messageId: 'floatingFixAwait',
-                  fix: (fixer): TSESLint.RuleFix | TSESLint.RuleFix[] =>
-                    addAwait(fixer, expression, node),
-                },
-              ],
-            });
-          } else {
-            context.report({
-              node,
-              messageId: nonFunctionHandler
-                ? 'floatingUselessRejectionHandler'
-                : 'floating',
-              suggest: [
-                {
-                  messageId: 'floatingFixAwait',
-                  fix: (fixer): TSESLint.RuleFix | TSESLint.RuleFix[] =>
-                    addAwait(fixer, expression, node),
-                },
-              ],
-            });
-          }
-        }
+        checkNode(node, expression);
       },
     };
+
+    function checkNode(
+      node: TSESTree.Expression | TSESTree.ExpressionStatement,
+      expression: TSESTree.Expression,
+    ): void {
+      if (isKnownSafePromiseCall(expression)) {
+        return;
+      }
+
+      const { isUnhandled, nonFunctionHandler, promiseArray } =
+        isUnhandledPromise(checker, expression);
+
+      if (isUnhandled) {
+        if (promiseArray) {
+          context.report({
+            node,
+            messageId: options.ignoreVoid
+              ? 'floatingPromiseArrayVoid'
+              : 'floatingPromiseArray',
+          });
+        } else if (options.ignoreVoid) {
+          context.report({
+            node,
+            messageId: nonFunctionHandler
+              ? 'floatingUselessRejectionHandlerVoid'
+              : 'floatingVoid',
+            suggest: [
+              {
+                messageId: 'floatingFixVoid',
+                fix(fixer): TSESLint.RuleFix | TSESLint.RuleFix[] {
+                  if (
+                    isParenthesized(expression, context.sourceCode) ||
+                    getOperatorPrecedenceForNode(expression) >
+                      OperatorPrecedence.Unary
+                  ) {
+                    return fixer.insertTextBefore(node, 'void ');
+                  }
+                  return [
+                    fixer.insertTextBefore(node, 'void ('),
+                    fixer.insertTextAfterRange(
+                      [expression.range[1], expression.range[1]],
+                      ')',
+                    ),
+                  ];
+                },
+              },
+              {
+                messageId: 'floatingFixAwait',
+                fix: (fixer): TSESLint.RuleFix | TSESLint.RuleFix[] =>
+                  addAwait(fixer, expression, node),
+              },
+            ],
+          });
+        } else {
+          context.report({
+            node,
+            messageId: nonFunctionHandler
+              ? 'floatingUselessRejectionHandler'
+              : 'floating',
+            suggest: [
+              {
+                messageId: 'floatingFixAwait',
+                fix: (fixer): TSESLint.RuleFix | TSESLint.RuleFix[] =>
+                  addAwait(fixer, expression, node),
+              },
+            ],
+          });
+        }
+      }
+    }
 
     function addAwait(
       fixer: TSESLint.RuleFixer,
       expression: TSESTree.Expression,
-      node: TSESTree.ExpressionStatement,
+      node: TSESTree.Expression | TSESTree.ExpressionStatement,
     ): TSESLint.RuleFix | TSESLint.RuleFix[] {
       if (
         expression.type === AST_NODE_TYPES.UnaryExpression &&

--- a/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
@@ -868,6 +868,14 @@ myAsyncFunction();
       ],
     },
 
+    "document.addEventListener('click', () => void fetch('/api/click'));",
+
+    `
+      document.addEventListener('click', () => {
+        void fetch('/api/click');
+      });
+    `,
+
     // This code makes TypeScript type checker to crash with infinite recursion
     //
     // See:
@@ -5691,6 +5699,55 @@ await Promise.reject('foo').then(...[], () => {});
           ],
         },
       ],
+    },
+
+    {
+      code: "document.addEventListener('click', () => void fetch('/api/click'));",
+      errors: [
+        {
+          column: 42,
+          endColumn: 66,
+          endLine: 1,
+          line: 1,
+          messageId: 'floating',
+          suggestions: [
+            {
+              messageId: 'floatingFixAwait',
+              output:
+                "document.addEventListener('click', () => await fetch('/api/click'));",
+            },
+          ],
+        },
+      ],
+      options: [{ ignoreVoid: false }],
+    },
+
+    {
+      code: `
+        document.addEventListener('click', () => {
+          void fetch('/api/click');
+        });
+      `,
+      errors: [
+        {
+          column: 11,
+          endColumn: 36,
+          endLine: 3,
+          line: 3,
+          messageId: 'floating',
+          suggestions: [
+            {
+              messageId: 'floatingFixAwait',
+              output: `
+        document.addEventListener('click', () => {
+          await fetch('/api/click');
+        });
+      `,
+            },
+          ],
+        },
+      ],
+      options: [{ ignoreVoid: false }],
     },
   ],
 });


### PR DESCRIPTION


<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [X] Addresses an existing open issue: fixes #12643
- [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [X] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

We weren't checking `ArrowFunctionExpression`s because the selector was specific to `ExpressionStatement`s, that don't include arrow functions with direct return

Most of the diff is extracting the report logic to a `checkNode` function. No logic changes other than the new selector.

I'm slightly afraid that the new selector will affect performance. Not sure how to check it though.