### PR TITLE
chore(ast-spec): replace `vitest/snapshot` with `vitest/runtime`

### DIFF
--- a/packages/ast-spec/tests/fixtures.test.ts
+++ b/packages/ast-spec/tests/fixtures.test.ts
@@ -2,7 +2,7 @@ import { glob } from 'glob';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { pathToFileURL } from 'node:url';
-import { VitestSnapshotEnvironment } from 'vitest/snapshot';
+import { VitestSnapshotEnvironment } from 'vitest/runtime';
 
 import type { Fixture } from './util/parsers/parser-types.js';
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [X] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

Small one

Fix the warning that's printed when running `pnpm exec nx test ast-spec`:

```
Importing from "vitest/snapshot" is deprecated since Vitest 4.1. Please use "vitest/runtime" instead.
```
