### PR TITLE
chore: include snapshots in test task `outputs`

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -17,6 +17,7 @@
     {
       "plugin": "@nx/vitest",
       "exclude": ["*"],
+      "outputs": ["{projectRoot}/coverage", "{projectRoot}/**/*.shot"],
       "options": {
         "testTargetName": "test",
         "typecheckTargetName": "vitest:typecheck"


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [X] Addresses an existing open issue: fixes #12642
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [X] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

From what I understand, NX didn't run the tests and replayed them from cache without recreating the snapshots.
This PR adds the snapshots as `outputs` of the `test` tasks, ensuring they are recreated on replays.

I think it should fix the caching issue we have with the new snapshots CI checks