### PR TITLE
fix(eslint-plugin): [unified-signatures] deduplicate types in report

### DIFF
--- a/packages/eslint-plugin/src/rules/unified-signatures.ts
+++ b/packages/eslint-plugin/src/rules/unified-signatures.ts
@@ -11,7 +11,6 @@ import type { Equal } from '../util';
 import {
   arraysAreEqual,
   createRule,
-  getTextWithParentheses,
   isParenthesized,
   nullThrows,
 } from '../util';
@@ -376,13 +375,13 @@ export default createRule<Options, MessageIds>({
     }
 
     function getUnionMemberText(type: TSESTree.TypeNode): string {
-      const text = getTextWithParentheses(context.sourceCode, type);
+      const text = context.sourceCode.getText(type);
       const needsParentheses =
         type.type === AST_NODE_TYPES.TSConditionalType ||
         type.type === AST_NODE_TYPES.TSConstructorType ||
         type.type === AST_NODE_TYPES.TSFunctionType;
 
-      return needsParentheses && !isParenthesized(type, context.sourceCode)
+      return needsParentheses || isParenthesized(type, context.sourceCode)
         ? `(${text})`
         : text;
     }

--- a/packages/eslint-plugin/src/rules/unified-signatures.ts
+++ b/packages/eslint-plugin/src/rules/unified-signatures.ts
@@ -403,8 +403,6 @@ export default createRule<Options, MessageIds>({
         ]),
       );
 
-      return nodesAreEqual(a, b);
-
       function nodesAreEqual(left: unknown, right: unknown): boolean {
         if (left === right) {
           return true;
@@ -413,7 +411,7 @@ export default createRule<Options, MessageIds>({
           return false;
         }
         if (typeof left !== 'object') {
-          return left === right;
+          return false;
         }
         if (Array.isArray(left) || Array.isArray(right)) {
           return (
@@ -424,18 +422,18 @@ export default createRule<Options, MessageIds>({
           );
         }
 
-        const leftNode = left as Record<string, unknown>;
-        const rightNode = right as Record<string, unknown>;
-        if (leftNode.type !== rightNode.type) {
+        const leftType = getObjectProperty(left, 'type');
+        const rightType = getObjectProperty(right, 'type');
+        if (leftType !== rightType) {
           return false;
         }
 
         if (
-          leftNode.type === AST_NODE_TYPES.TSTypeReference &&
-          rightNode.type === AST_NODE_TYPES.TSTypeReference
+          leftType === AST_NODE_TYPES.TSTypeReference &&
+          rightType === AST_NODE_TYPES.TSTypeReference
         ) {
-          const leftName = leftNode.typeName;
-          const rightName = rightNode.typeName;
+          const leftName = getObjectProperty(left, 'typeName');
+          const rightName = getObjectProperty(right, 'typeName');
           if (!typeReferenceNamesAreEqual(leftName, rightName)) {
             return false;
           }
@@ -449,19 +447,20 @@ export default createRule<Options, MessageIds>({
           'raw',
           'tokens',
         ]);
-        const keys = new Set([
-          ...Object.keys(leftNode),
-          ...Object.keys(rightNode),
-        ]);
+        const keys = new Set([...Object.keys(left), ...Object.keys(right)]);
         for (const key of keys) {
           if (
             ignoredKeys.has(key) ||
-            (key === 'typeName' &&
-              leftNode.type === AST_NODE_TYPES.TSTypeReference)
+            (key === 'typeName' && leftType === AST_NODE_TYPES.TSTypeReference)
           ) {
             continue;
           }
-          if (!nodesAreEqual(leftNode[key], rightNode[key])) {
+          if (
+            !nodesAreEqual(
+              getObjectProperty(left, key),
+              getObjectProperty(right, key),
+            )
+          ) {
             return false;
           }
         }
@@ -499,9 +498,16 @@ export default createRule<Options, MessageIds>({
         return (
           typeof value === 'object' &&
           value != null &&
-          (value as { type?: unknown }).type === AST_NODE_TYPES.Identifier
+          'type' in value &&
+          value.type === AST_NODE_TYPES.Identifier
         );
       }
+
+      function getObjectProperty(value: object, key: string): unknown {
+        return Reflect.get(value, key) as unknown;
+      }
+
+      return nodesAreEqual(a, b);
     }
 
     function isThisParam(param: TSESTree.Parameter | undefined): boolean {

--- a/packages/eslint-plugin/src/rules/unified-signatures.ts
+++ b/packages/eslint-plugin/src/rules/unified-signatures.ts
@@ -1,10 +1,20 @@
 import type { TSESTree } from '@typescript-eslint/utils';
 
-import { AST_NODE_TYPES, AST_TOKEN_TYPES } from '@typescript-eslint/utils';
+import {
+  AST_NODE_TYPES,
+  AST_TOKEN_TYPES,
+  ASTUtils,
+} from '@typescript-eslint/utils';
 
 import type { Equal } from '../util';
 
-import { arraysAreEqual, createRule, nullThrows } from '../util';
+import {
+  arraysAreEqual,
+  createRule,
+  getTextWithParentheses,
+  isParenthesized,
+  nullThrows,
+} from '../util';
 
 interface Failure {
   only2: boolean;
@@ -21,6 +31,8 @@ type Unify =
       kind: 'single-parameter-difference';
       p0: TSESTree.Parameter;
       p1: TSESTree.Parameter;
+      typeParameters0?: TSESTree.TSTypeParameterDeclaration;
+      typeParameters1?: TSESTree.TSTypeParameterDeclaration;
     };
 
 /**
@@ -77,8 +89,7 @@ export default createRule<Options, MessageIds>({
       omittingRestParameter: '{{failureStringStart}} with a rest parameter.',
       omittingSingleParameter:
         '{{failureStringStart}} with an optional parameter.',
-      singleParameterDifference:
-        '{{failureStringStart}} taking `{{type1}} | {{type2}}`.',
+      singleParameterDifference: '{{failureStringStart}} taking `{{types}}`.',
     },
     schema: [
       {
@@ -130,12 +141,8 @@ export default createRule<Options, MessageIds>({
             const { p0, p1 } = unify;
             const lineOfOtherOverload = only2 ? undefined : p0.loc.start.line;
 
-            const typeAnnotation0 = isTSParameterProperty(p0)
-              ? p0.parameter.typeAnnotation
-              : p0.typeAnnotation;
-            const typeAnnotation1 = isTSParameterProperty(p1)
-              ? p1.parameter.typeAnnotation
-              : p1.typeAnnotation;
+            const type0 = getParameterType(p0);
+            const type1 = getParameterType(p1);
 
             context.report({
               loc: p1.loc,
@@ -143,11 +150,11 @@ export default createRule<Options, MessageIds>({
               messageId: 'singleParameterDifference',
               data: {
                 failureStringStart: failureStringStart(lineOfOtherOverload),
-                type1: context.sourceCode.getText(
-                  typeAnnotation0?.typeAnnotation,
-                ),
-                type2: context.sourceCode.getText(
-                  typeAnnotation1?.typeAnnotation,
+                types: getUnifiedTypeText(
+                  type0,
+                  type1,
+                  unify.typeParameters0,
+                  unify.typeParameters1,
                 ),
               },
             });
@@ -209,7 +216,7 @@ export default createRule<Options, MessageIds>({
       }
 
       return a.params.length === b.params.length
-        ? signaturesDifferBySingleParameter(a.params, b.params)
+        ? signaturesDifferBySingleParameter(a, b)
         : signaturesDifferByOptionalOrRestParameter(a, b);
     }
 
@@ -258,9 +265,11 @@ export default createRule<Options, MessageIds>({
 
     /** Detect `a(x: number, y: number, z: number)` and `a(x: number, y: string, z: number)`. */
     function signaturesDifferBySingleParameter(
-      types1: readonly TSESTree.Parameter[],
-      types2: readonly TSESTree.Parameter[],
+      signature0: SignatureDefinition,
+      signature1: SignatureDefinition,
     ): Unify | undefined {
+      const types1 = signature0.params;
+      const types2 = signature1.params;
       const firstParam1 = types1[0];
       const firstParam2 = types2[0];
 
@@ -295,8 +304,204 @@ export default createRule<Options, MessageIds>({
       // See https://github.com/Microsoft/TypeScript/issues/5077
       return parametersHaveEqualSigils(a, b) &&
         a.type !== AST_NODE_TYPES.RestElement
-        ? { kind: 'single-parameter-difference', p0: a, p1: b }
+        ? {
+            kind: 'single-parameter-difference',
+            p0: a,
+            p1: b,
+            typeParameters0: signature0.typeParameters,
+            typeParameters1: signature1.typeParameters,
+          }
         : undefined;
+    }
+
+    function getParameterType(
+      parameter: TSESTree.Parameter,
+    ): TSESTree.TypeNode | undefined {
+      return (
+        isTSParameterProperty(parameter)
+          ? parameter.parameter.typeAnnotation
+          : parameter.typeAnnotation
+      )?.typeAnnotation;
+    }
+
+    function getUnifiedTypeText(
+      type0: TSESTree.TypeNode | undefined,
+      type1: TSESTree.TypeNode | undefined,
+      typeParameters0?: TSESTree.TSTypeParameterDeclaration,
+      typeParameters1?: TSESTree.TSTypeParameterDeclaration,
+    ): string {
+      if (type0 == null || type1 == null) {
+        return '';
+      }
+
+      const members = [
+        ...getUnionMembers(type0).map(type => ({
+          type,
+          typeParameters: typeParameters0,
+        })),
+        ...getUnionMembers(type1).map(type => ({
+          type,
+          typeParameters: typeParameters1,
+        })),
+      ];
+      const uniqueMembers: typeof members = [];
+
+      for (const member of members) {
+        if (
+          !uniqueMembers.some(other =>
+            typeNodesAreEqual(
+              other.type,
+              member.type,
+              other.typeParameters,
+              member.typeParameters,
+            ),
+          )
+        ) {
+          uniqueMembers.push(member);
+        }
+      }
+
+      return uniqueMembers
+        .map(member => getUnionMemberText(member.type))
+        .join(' | ');
+    }
+
+    function getUnionMembers(type: TSESTree.TypeNode): TSESTree.TypeNode[] {
+      return type.type === AST_NODE_TYPES.TSUnionType
+        ? type.types.flatMap(getUnionMembers)
+        : [type];
+    }
+
+    function getUnionMemberText(type: TSESTree.TypeNode): string {
+      const text = getTextWithParentheses(context.sourceCode, type);
+      const needsParentheses =
+        type.type === AST_NODE_TYPES.TSConditionalType ||
+        type.type === AST_NODE_TYPES.TSConstructorType ||
+        type.type === AST_NODE_TYPES.TSFunctionType;
+
+      return needsParentheses && !isParenthesized(type, context.sourceCode)
+        ? `(${text})`
+        : text;
+    }
+
+    function typeNodesAreEqual(
+      a: TSESTree.TypeNode,
+      b: TSESTree.TypeNode,
+      typeParameters0?: TSESTree.TSTypeParameterDeclaration,
+      typeParameters1?: TSESTree.TSTypeParameterDeclaration,
+    ): boolean {
+      const typeParameterIndices0 = new Map(
+        typeParameters0?.params.map((parameter, index) => [
+          parameter.name.name,
+          index,
+        ]),
+      );
+      const typeParameterIndices1 = new Map(
+        typeParameters1?.params.map((parameter, index) => [
+          parameter.name.name,
+          index,
+        ]),
+      );
+
+      return nodesAreEqual(a, b);
+
+      function nodesAreEqual(left: unknown, right: unknown): boolean {
+        if (left === right) {
+          return true;
+        }
+        if (left == null || right == null || typeof left !== typeof right) {
+          return false;
+        }
+        if (typeof left !== 'object') {
+          return left === right;
+        }
+        if (Array.isArray(left) || Array.isArray(right)) {
+          return (
+            Array.isArray(left) &&
+            Array.isArray(right) &&
+            left.length === right.length &&
+            left.every((value, index) => nodesAreEqual(value, right[index]))
+          );
+        }
+
+        const leftNode = left as Record<string, unknown>;
+        const rightNode = right as Record<string, unknown>;
+        if (leftNode.type !== rightNode.type) {
+          return false;
+        }
+
+        if (
+          leftNode.type === AST_NODE_TYPES.TSTypeReference &&
+          rightNode.type === AST_NODE_TYPES.TSTypeReference
+        ) {
+          const leftName = leftNode.typeName;
+          const rightName = rightNode.typeName;
+          if (!typeReferenceNamesAreEqual(leftName, rightName)) {
+            return false;
+          }
+        }
+
+        const ignoredKeys = new Set([
+          'comments',
+          'loc',
+          'parent',
+          'range',
+          'raw',
+          'tokens',
+        ]);
+        const keys = new Set([
+          ...Object.keys(leftNode),
+          ...Object.keys(rightNode),
+        ]);
+        for (const key of keys) {
+          if (
+            ignoredKeys.has(key) ||
+            (key === 'typeName' &&
+              leftNode.type === AST_NODE_TYPES.TSTypeReference)
+          ) {
+            continue;
+          }
+          if (!nodesAreEqual(leftNode[key], rightNode[key])) {
+            return false;
+          }
+        }
+        return true;
+      }
+
+      function typeReferenceNamesAreEqual(
+        left: unknown,
+        right: unknown,
+      ): boolean {
+        if (!isIdentifierNode(left) || !isIdentifierNode(right)) {
+          return nodesAreEqual(left, right);
+        }
+
+        const leftIndex = typeParameterIndices0.get(left.name);
+        const rightIndex = typeParameterIndices1.get(right.name);
+        if (leftIndex != null || rightIndex != null) {
+          return leftIndex === rightIndex;
+        }
+
+        return (
+          left.name === right.name &&
+          ASTUtils.findVariable(
+            context.sourceCode.getScope(left),
+            left.name,
+          ) ===
+            ASTUtils.findVariable(
+              context.sourceCode.getScope(right),
+              right.name,
+            )
+        );
+      }
+
+      function isIdentifierNode(value: unknown): value is TSESTree.Identifier {
+        return (
+          typeof value === 'object' &&
+          value != null &&
+          (value as { type?: unknown }).type === AST_NODE_TYPES.Identifier
+        );
+      }
     }
 
     function isThisParam(param: TSESTree.Parameter | undefined): boolean {

--- a/packages/eslint-plugin/src/rules/unified-signatures.ts
+++ b/packages/eslint-plugin/src/rules/unified-signatures.ts
@@ -323,7 +323,7 @@ export default createRule<Options, MessageIds>({
       }
 
       const members = [...getUnionMembers(type0), ...getUnionMembers(type1)];
-      const uniqueMembers: typeof members = [];
+      const uniqueMembers: TSESTree.TypeNode[] = [];
 
       for (const member of members) {
         if (!uniqueMembers.some(other => typesAreEqual(other, member))) {

--- a/packages/eslint-plugin/src/rules/unified-signatures.ts
+++ b/packages/eslint-plugin/src/rules/unified-signatures.ts
@@ -303,11 +303,9 @@ export default createRule<Options, MessageIds>({
     function getParameterTypeAnnotation(
       parameter: TSESTree.Parameter,
     ): TSESTree.TypeNode | undefined {
-      return (
-        isTSParameterProperty(parameter)
-          ? parameter.parameter.typeAnnotation
-          : parameter.typeAnnotation
-      )?.typeAnnotation;
+      return isTSParameterProperty(parameter)
+        ? parameter.parameter.typeAnnotation?.typeAnnotation
+        : parameter.typeAnnotation?.typeAnnotation;
     }
 
     function getUnifiedTypeText(

--- a/packages/eslint-plugin/src/rules/unified-signatures.ts
+++ b/packages/eslint-plugin/src/rules/unified-signatures.ts
@@ -312,13 +312,14 @@ export default createRule<Options, MessageIds>({
       type0: TSESTree.TypeNode | undefined,
       type1: TSESTree.TypeNode | undefined,
     ): string {
-      if (type0 == null) {
+      // When a signature's parameter has no type annotation
+      if (type0 == null || type1 == null) {
         return getUnionMemberText(
-          nullThrows(type1, 'Expected the other parameter type to be defined'),
+          nullThrows(
+            type0 ?? type1,
+            'Expected a type annotation for one of the parameters, but both were undefined',
+          ),
         );
-      }
-      if (type1 == null) {
-        return getUnionMemberText(type0);
       }
 
       const members = [...getUnionMembers(type0), ...getUnionMembers(type1)];

--- a/packages/eslint-plugin/src/rules/unified-signatures.ts
+++ b/packages/eslint-plugin/src/rules/unified-signatures.ts
@@ -292,11 +292,7 @@ export default createRule<Options, MessageIds>({
       // See https://github.com/Microsoft/TypeScript/issues/5077
       return parametersHaveEqualSigils(a, b) &&
         a.type !== AST_NODE_TYPES.RestElement
-        ? {
-            kind: 'single-parameter-difference',
-            p0: a,
-            p1: b,
-          }
+        ? { kind: 'single-parameter-difference', p0: a, p1: b }
         : undefined;
     }
 

--- a/packages/eslint-plugin/src/rules/unified-signatures.ts
+++ b/packages/eslint-plugin/src/rules/unified-signatures.ts
@@ -1,10 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/utils';
 
-import {
-  AST_NODE_TYPES,
-  AST_TOKEN_TYPES,
-  ASTUtils,
-} from '@typescript-eslint/utils';
+import { AST_NODE_TYPES, AST_TOKEN_TYPES } from '@typescript-eslint/utils';
 
 import type { Equal } from '../util';
 
@@ -30,8 +26,6 @@ type Unify =
       kind: 'single-parameter-difference';
       p0: TSESTree.Parameter;
       p1: TSESTree.Parameter;
-      typeParameters0?: TSESTree.TSTypeParameterDeclaration;
-      typeParameters1?: TSESTree.TSTypeParameterDeclaration;
     };
 
 /**
@@ -149,12 +143,7 @@ export default createRule<Options, MessageIds>({
               messageId: 'singleParameterDifference',
               data: {
                 failureStringStart: failureStringStart(lineOfOtherOverload),
-                types: getUnifiedTypeText(
-                  typeAnnotation0,
-                  typeAnnotation1,
-                  unify.typeParameters0,
-                  unify.typeParameters1,
-                ),
+                types: getUnifiedTypeText(typeAnnotation0, typeAnnotation1),
               },
             });
             break;
@@ -307,8 +296,6 @@ export default createRule<Options, MessageIds>({
             kind: 'single-parameter-difference',
             p0: a,
             p1: b,
-            typeParameters0: signature0.typeParameters,
-            typeParameters1: signature1.typeParameters,
           }
         : undefined;
     }
@@ -326,8 +313,6 @@ export default createRule<Options, MessageIds>({
     function getUnifiedTypeText(
       type0: TSESTree.TypeNode | undefined,
       type1: TSESTree.TypeNode | undefined,
-      typeParameters0?: TSESTree.TSTypeParameterDeclaration,
-      typeParameters1?: TSESTree.TSTypeParameterDeclaration,
     ): string {
       if (type0 == null) {
         return getUnionMemberText(
@@ -338,35 +323,17 @@ export default createRule<Options, MessageIds>({
         return getUnionMemberText(type0);
       }
 
-      const members = [
-        ...getUnionMembers(type0).map(type => ({
-          type,
-          typeParameters: typeParameters0,
-        })),
-        ...getUnionMembers(type1).map(type => ({
-          type,
-          typeParameters: typeParameters1,
-        })),
-      ];
+      const members = [...getUnionMembers(type0), ...getUnionMembers(type1)];
       const uniqueMembers: typeof members = [];
 
       for (const member of members) {
-        if (
-          !uniqueMembers.some(other =>
-            typeNodesAreEqual(
-              other.type,
-              member.type,
-              other.typeParameters,
-              member.typeParameters,
-            ),
-          )
-        ) {
+        if (!uniqueMembers.some(other => typesAreEqual(other, member))) {
           uniqueMembers.push(member);
         }
       }
 
       return uniqueMembers
-        .map(member => getUnionMemberText(member.type))
+        .map(member => getUnionMemberText(member))
         .join(' | ');
     }
 
@@ -386,132 +353,6 @@ export default createRule<Options, MessageIds>({
       return needsParentheses || isParenthesized(type, context.sourceCode)
         ? `(${text})`
         : text;
-    }
-
-    function typeNodesAreEqual(
-      a: TSESTree.TypeNode,
-      b: TSESTree.TypeNode,
-      typeParameters0?: TSESTree.TSTypeParameterDeclaration,
-      typeParameters1?: TSESTree.TSTypeParameterDeclaration,
-    ): boolean {
-      const typeParameterIndices0 = new Map(
-        typeParameters0?.params.map((parameter, index) => [
-          parameter.name.name,
-          index,
-        ]),
-      );
-      const typeParameterIndices1 = new Map(
-        typeParameters1?.params.map((parameter, index) => [
-          parameter.name.name,
-          index,
-        ]),
-      );
-
-      function nodesAreEqual(left: unknown, right: unknown): boolean {
-        if (left === right) {
-          return true;
-        }
-        if (left == null || right == null || typeof left !== typeof right) {
-          return false;
-        }
-        if (typeof left !== 'object') {
-          return false;
-        }
-        if (Array.isArray(left) || Array.isArray(right)) {
-          return (
-            Array.isArray(left) &&
-            Array.isArray(right) &&
-            left.length === right.length &&
-            left.every((value, index) => nodesAreEqual(value, right[index]))
-          );
-        }
-
-        const leftType = getObjectProperty(left, 'type');
-        const rightType = getObjectProperty(right, 'type');
-        if (leftType !== rightType) {
-          return false;
-        }
-
-        if (
-          leftType === AST_NODE_TYPES.TSTypeReference &&
-          rightType === AST_NODE_TYPES.TSTypeReference
-        ) {
-          const leftName = getObjectProperty(left, 'typeName');
-          const rightName = getObjectProperty(right, 'typeName');
-          if (!typeReferenceNamesAreEqual(leftName, rightName)) {
-            return false;
-          }
-        }
-
-        const ignoredKeys = new Set([
-          'comments',
-          'loc',
-          'parent',
-          'range',
-          'raw',
-          'tokens',
-        ]);
-        const keys = new Set([...Object.keys(left), ...Object.keys(right)]);
-        for (const key of keys) {
-          if (
-            ignoredKeys.has(key) ||
-            (key === 'typeName' && leftType === AST_NODE_TYPES.TSTypeReference)
-          ) {
-            continue;
-          }
-          if (
-            !nodesAreEqual(
-              getObjectProperty(left, key),
-              getObjectProperty(right, key),
-            )
-          ) {
-            return false;
-          }
-        }
-        return true;
-      }
-
-      function typeReferenceNamesAreEqual(
-        left: unknown,
-        right: unknown,
-      ): boolean {
-        if (!isIdentifierNode(left) || !isIdentifierNode(right)) {
-          return nodesAreEqual(left, right);
-        }
-
-        const leftIndex = typeParameterIndices0.get(left.name);
-        const rightIndex = typeParameterIndices1.get(right.name);
-        if (leftIndex != null || rightIndex != null) {
-          return leftIndex === rightIndex;
-        }
-
-        return (
-          left.name === right.name &&
-          ASTUtils.findVariable(
-            context.sourceCode.getScope(left),
-            left.name,
-          ) ===
-            ASTUtils.findVariable(
-              context.sourceCode.getScope(right),
-              right.name,
-            )
-        );
-      }
-
-      function isIdentifierNode(value: unknown): value is TSESTree.Identifier {
-        return (
-          typeof value === 'object' &&
-          value != null &&
-          'type' in value &&
-          value.type === AST_NODE_TYPES.Identifier
-        );
-      }
-
-      function getObjectProperty(value: object, key: string): unknown {
-        return Reflect.get(value, key) as unknown;
-      }
-
-      return nodesAreEqual(a, b);
     }
 
     function isThisParam(param: TSESTree.Parameter | undefined): boolean {
@@ -703,15 +544,20 @@ export default createRule<Options, MessageIds>({
     }
 
     function typesAreEqual(
-      a: TSESTree.TSTypeAnnotation | undefined,
-      b: TSESTree.TSTypeAnnotation | undefined,
+      a: TSESTree.TSTypeAnnotation | TSESTree.TypeNode | undefined,
+      b: TSESTree.TSTypeAnnotation | TSESTree.TypeNode | undefined,
     ): boolean {
+      const typeA =
+        a?.type === AST_NODE_TYPES.TSTypeAnnotation ? a.typeAnnotation : a;
+      const typeB =
+        b?.type === AST_NODE_TYPES.TSTypeAnnotation ? b.typeAnnotation : b;
+
       return (
-        a === b ||
-        (a != null &&
-          b != null &&
-          context.sourceCode.getText(a.typeAnnotation) ===
-            context.sourceCode.getText(b.typeAnnotation))
+        typeA === typeB ||
+        (typeA != null &&
+          typeB != null &&
+          context.sourceCode.getText(typeA) ===
+            context.sourceCode.getText(typeB))
       );
     }
 

--- a/packages/eslint-plugin/src/rules/unified-signatures.ts
+++ b/packages/eslint-plugin/src/rules/unified-signatures.ts
@@ -237,7 +237,10 @@ export default createRule<Options, MessageIds>({
       }
 
       return (
-        typesAreEqual(a.returnType, b.returnType) &&
+        typesAreEqual(
+          a.returnType?.typeAnnotation,
+          b.returnType?.typeAnnotation,
+        ) &&
         // Must take the same type parameters.
         // If one uses a type parameter (from outside) and the other doesn't, they shouldn't be joined.
         arraysAreEqual(aTypeParams, bTypeParams, typeParametersAreEqual) &&
@@ -394,16 +397,12 @@ export default createRule<Options, MessageIds>({
       }
 
       for (let i = 0; i < minLength; i++) {
-        const sig1i = sig1[i];
-        const sig2i = sig2[i];
-        const typeAnnotation1 = isTSParameterProperty(sig1i)
-          ? sig1i.parameter.typeAnnotation
-          : sig1i.typeAnnotation;
-        const typeAnnotation2 = isTSParameterProperty(sig2i)
-          ? sig2i.parameter.typeAnnotation
-          : sig2i.typeAnnotation;
-
-        if (!typesAreEqual(typeAnnotation1, typeAnnotation2)) {
+        if (
+          !typesAreEqual(
+            getParameterTypeAnnotation(sig1[i]),
+            getParameterTypeAnnotation(sig2[i]),
+          )
+        ) {
           return undefined;
         }
       }
@@ -481,16 +480,12 @@ export default createRule<Options, MessageIds>({
       a: TSESTree.Parameter,
       b: TSESTree.Parameter,
     ): boolean {
-      const typeAnnotationA = isTSParameterProperty(a)
-        ? a.parameter.typeAnnotation
-        : a.typeAnnotation;
-      const typeAnnotationB = isTSParameterProperty(b)
-        ? b.parameter.typeAnnotation
-        : b.typeAnnotation;
-
       return (
         parametersHaveEqualSigils(a, b) &&
-        typesAreEqual(typeAnnotationA, typeAnnotationB)
+        typesAreEqual(
+          getParameterTypeAnnotation(a),
+          getParameterTypeAnnotation(b),
+        )
       );
     }
 
@@ -532,20 +527,14 @@ export default createRule<Options, MessageIds>({
     }
 
     function typesAreEqual(
-      a: TSESTree.TSTypeAnnotation | TSESTree.TypeNode | undefined,
-      b: TSESTree.TSTypeAnnotation | TSESTree.TypeNode | undefined,
+      a: TSESTree.TypeNode | undefined,
+      b: TSESTree.TypeNode | undefined,
     ): boolean {
-      const typeA =
-        a?.type === AST_NODE_TYPES.TSTypeAnnotation ? a.typeAnnotation : a;
-      const typeB =
-        b?.type === AST_NODE_TYPES.TSTypeAnnotation ? b.typeAnnotation : b;
-
       return (
-        typeA === typeB ||
-        (typeA != null &&
-          typeB != null &&
-          context.sourceCode.getText(typeA) ===
-            context.sourceCode.getText(typeB))
+        a === b ||
+        (a != null &&
+          b != null &&
+          context.sourceCode.getText(a) === context.sourceCode.getText(b))
       );
     }
 

--- a/packages/eslint-plugin/src/rules/unified-signatures.ts
+++ b/packages/eslint-plugin/src/rules/unified-signatures.ts
@@ -4,12 +4,7 @@ import { AST_NODE_TYPES, AST_TOKEN_TYPES } from '@typescript-eslint/utils';
 
 import type { Equal } from '../util';
 
-import {
-  arraysAreEqual,
-  createRule,
-  isParenthesized,
-  nullThrows,
-} from '../util';
+import { arraysAreEqual, createRule, nullThrows } from '../util';
 
 interface Failure {
   only2: boolean;
@@ -345,9 +340,7 @@ export default createRule<Options, MessageIds>({
         type.type === AST_NODE_TYPES.TSConstructorType ||
         type.type === AST_NODE_TYPES.TSFunctionType;
 
-      return needsParentheses || isParenthesized(type, context.sourceCode)
-        ? `(${text})`
-        : text;
+      return needsParentheses ? `(${text})` : text;
     }
 
     function isThisParam(param: TSESTree.Parameter | undefined): boolean {

--- a/packages/eslint-plugin/src/rules/unified-signatures.ts
+++ b/packages/eslint-plugin/src/rules/unified-signatures.ts
@@ -330,8 +330,11 @@ export default createRule<Options, MessageIds>({
       typeParameters0?: TSESTree.TSTypeParameterDeclaration,
       typeParameters1?: TSESTree.TSTypeParameterDeclaration,
     ): string {
-      if (type0 == null || type1 == null) {
-        return '';
+      if (type0 == null) {
+        return getUnionMemberText(type1!);
+      }
+      if (type1 == null) {
+        return getUnionMemberText(type0);
       }
 
       const members = [

--- a/packages/eslint-plugin/src/rules/unified-signatures.ts
+++ b/packages/eslint-plugin/src/rules/unified-signatures.ts
@@ -141,8 +141,8 @@ export default createRule<Options, MessageIds>({
             const { p0, p1 } = unify;
             const lineOfOtherOverload = only2 ? undefined : p0.loc.start.line;
 
-            const type0 = getParameterType(p0);
-            const type1 = getParameterType(p1);
+            const typeAnnotation0 = getParameterTypeAnnotation(p0);
+            const typeAnnotation1 = getParameterTypeAnnotation(p1);
 
             context.report({
               loc: p1.loc,
@@ -151,8 +151,8 @@ export default createRule<Options, MessageIds>({
               data: {
                 failureStringStart: failureStringStart(lineOfOtherOverload),
                 types: getUnifiedTypeText(
-                  type0,
-                  type1,
+                  typeAnnotation0,
+                  typeAnnotation1,
                   unify.typeParameters0,
                   unify.typeParameters1,
                 ),
@@ -314,7 +314,7 @@ export default createRule<Options, MessageIds>({
         : undefined;
     }
 
-    function getParameterType(
+    function getParameterTypeAnnotation(
       parameter: TSESTree.Parameter,
     ): TSESTree.TypeNode | undefined {
       return (

--- a/packages/eslint-plugin/src/rules/unified-signatures.ts
+++ b/packages/eslint-plugin/src/rules/unified-signatures.ts
@@ -330,7 +330,9 @@ export default createRule<Options, MessageIds>({
       typeParameters1?: TSESTree.TSTypeParameterDeclaration,
     ): string {
       if (type0 == null) {
-        return getUnionMemberText(type1!);
+        return getUnionMemberText(
+          nullThrows(type1, 'Expected the other parameter type to be defined'),
+        );
       }
       if (type1 == null) {
         return getUnionMemberText(type0);

--- a/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
+++ b/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
@@ -1335,6 +1335,38 @@ function f(x: number | boolean): void;
     },
     {
       code: `
+function f(value): void;
+function f(value: string): void;
+      `,
+      errors: [
+        {
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            types: 'string',
+          },
+          messageId: 'singleParameterDifference',
+        },
+      ],
+    },
+    {
+      code: `
+function f(value: string): void;
+function f(value): void;
+      `,
+      errors: [
+        {
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            types: 'string',
+          },
+          messageId: 'singleParameterDifference',
+        },
+      ],
+    },
+    {
+      code: `
 type Alias = string;
 function f(x: Alias): void;
 function f(x: Alias | number): void;

--- a/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
+++ b/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
@@ -1496,7 +1496,7 @@ declare function fn(a: (/* before */ string /* after */)): void;
       ],
     },
     {
-      // To avoid complex type comparisons when resolving #12504, allows duplicate union members when comments make their source text differ.
+      // To avoid complex type comparisons when resolving #12504, allow duplicate union members when their source text differs.
       code: noFormat`
 function f(x: string & { brand: true }): void;
 function f(x: number | string & /* brand */ { brand: true }): void;

--- a/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
+++ b/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
@@ -1475,6 +1475,26 @@ function f(x: number | /* second */ string): void;
       ],
     },
     {
+      code: noFormat`
+declare function fn(a: number): void;
+declare function fn(a: (/* before */ string /* after */)): void;
+      `,
+      errors: [
+        {
+          column: 21,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            types: 'number | string',
+          },
+          endColumn: 57,
+          endLine: 3,
+          line: 3,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+    },
+    {
       // To avoid complex type comparisons when resolving #12504, allow duplicate union members when their source text differs.
       code: noFormat`
 function f(x: string & { brand: true }): void;

--- a/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
+++ b/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
@@ -422,8 +422,7 @@ function f(a: number | string): void {}
           data: {
             failureStringStart:
               'These overloads can be combined into one signature',
-            type1: 'number',
-            type2: 'string',
+            types: 'number | string',
           },
           endColumn: 21,
           endLine: 3,
@@ -446,8 +445,7 @@ function f(x: any): any {
           data: {
             failureStringStart:
               'These overloads can be combined into one signature',
-            type1: 'number',
-            type2: 'string',
+            types: 'number | string',
           },
           endColumn: 21,
           endLine: 3,
@@ -470,8 +468,7 @@ function f(x: any): any {
           data: {
             failureStringStart:
               'These overloads can be combined into one signature',
-            type1: 'number',
-            type2: 'string',
+            types: 'number | string',
           },
           endColumn: 21,
           endLine: 3,
@@ -650,8 +647,7 @@ interface I {
           data: {
             failureStringStart:
               'These overloads can be combined into one signature',
-            type1: 'number',
-            type2: 'string',
+            types: 'number | string',
           },
           endColumn: 16,
           endLine: 4,
@@ -674,8 +670,7 @@ interface I {
           data: {
             failureStringStart:
               'These overloads can be combined into one signature',
-            type1: 'number',
-            type2: 'string',
+            types: 'number | string',
           },
           endColumn: 14,
           endLine: 4,
@@ -763,8 +758,7 @@ interface I {
           data: {
             failureStringStart:
               'These overloads can be combined into one signature',
-            type1: 'number',
-            type2: 'string | boolean',
+            types: 'number | string | boolean',
           },
           endColumn: 24,
           endLine: 4,
@@ -787,8 +781,7 @@ interface I {
           data: {
             failureStringStart:
               'These overloads can be combined into one signature',
-            type1: 'number',
-            type2: '[string, boolean]',
+            types: 'number | [string, boolean]',
           },
           endColumn: 25,
           endLine: 4,
@@ -810,8 +803,7 @@ interface Generic<T> {
           data: {
             failureStringStart:
               'These overloads can be combined into one signature',
-            type1: 'T[]',
-            type2: 'T',
+            types: 'T[] | T',
           },
           endColumn: 9,
           endLine: 4,
@@ -832,8 +824,7 @@ function f<T>(x: T): void;
           data: {
             failureStringStart:
               'These overloads can be combined into one signature',
-            type1: 'T[]',
-            type2: 'T',
+            types: 'T[] | T',
           },
           endColumn: 19,
           endLine: 3,
@@ -854,8 +845,7 @@ function f<T extends number>(x: T): void;
           data: {
             failureStringStart:
               'These overloads can be combined into one signature',
-            type1: 'T[]',
-            type2: 'T',
+            types: 'T[] | T',
           },
           endColumn: 34,
           endLine: 3,
@@ -878,8 +868,7 @@ abstract class Foo {
           data: {
             failureStringStart:
               'These overloads can be combined into one signature',
-            type1: 'number',
-            type2: 'string',
+            types: 'number | string',
           },
           endColumn: 30,
           endLine: 4,
@@ -904,8 +893,7 @@ abstract class C {
           data: {
             failureStringStart:
               'These overloads can be combined into one signature',
-            type1: 'string',
-            type2: 'number',
+            types: 'string | number',
           },
           endColumn: 14,
           endLine: 7,
@@ -928,8 +916,7 @@ interface Foo {
           data: {
             failureStringStart:
               'These overloads can be combined into one signature',
-            type1: 'string',
-            type2: 'number',
+            types: 'string | number',
           },
           endColumn: 16,
           endLine: 4,
@@ -952,8 +939,7 @@ interface Foo {
           data: {
             failureStringStart:
               'These overloads can be combined into one signature',
-            type1: 'string',
-            type2: 'number',
+            types: 'string | number',
           },
           endColumn: 17,
           endLine: 4,
@@ -980,8 +966,7 @@ interface IFoo {
           data: {
             failureStringStart:
               'These overloads can be combined into one signature',
-            type1: 'string',
-            type2: 'number',
+            types: 'string | number',
           },
           endColumn: 24,
           endLine: 8,
@@ -1075,8 +1060,7 @@ declare function f(x: boolean): void;
           data: {
             failureStringStart:
               'This overload and the one on line 6 can be combined into one signature',
-            type1: 'number',
-            type2: 'boolean',
+            types: 'number | boolean',
           },
           endColumn: 30,
           endLine: 7,
@@ -1104,8 +1088,7 @@ declare function f(x: boolean): void;
           data: {
             failureStringStart:
               'This overload and the one on line 5 can be combined into one signature',
-            type1: 'string',
-            type2: 'number',
+            types: 'string | number',
           },
           endColumn: 29,
           endLine: 9,
@@ -1133,8 +1116,7 @@ declare function f(x: boolean): void;
           data: {
             failureStringStart:
               'This overload and the one on line 6 can be combined into one signature',
-            type1: 'number',
-            type2: 'boolean',
+            types: 'number | boolean',
           },
           endColumn: 30,
           endLine: 10,
@@ -1162,8 +1144,7 @@ export function f(x: boolean): void;
           data: {
             failureStringStart:
               'This overload and the one on line 6 can be combined into one signature',
-            type1: 'number',
-            type2: 'boolean',
+            types: 'number | boolean',
           },
           endColumn: 29,
           endLine: 10,
@@ -1195,8 +1176,7 @@ function f(x: string): void;
           data: {
             failureStringStart:
               'These overloads can be combined into one signature',
-            type1: 'number',
-            type2: 'string',
+            types: 'number | string',
           },
           endColumn: 21,
           endLine: 14,
@@ -1226,8 +1206,7 @@ interface I {
           data: {
             failureStringStart:
               'This overload and the one on line 7 can be combined into one signature',
-            type1: 'number',
-            type2: 'boolean',
+            types: 'number | boolean',
           },
           endColumn: 15,
           endLine: 11,
@@ -1249,8 +1228,7 @@ declare function f(x: boolean): unknown;
           data: {
             failureStringStart:
               'These overloads can be combined into one signature',
-            type1: 'number',
-            type2: 'boolean',
+            types: 'number | boolean',
           },
           endColumn: 30,
           endLine: 4,
@@ -1304,8 +1282,7 @@ function f(this: string | number): void {}
           data: {
             failureStringStart:
               'These overloads can be combined into one signature',
-            type1: 'string',
-            type2: 'number',
+            types: 'string | number',
           },
           endColumn: 24,
           endLine: 3,
@@ -1326,12 +1303,227 @@ function f(this: string | number, a: boolean): void {}
           data: {
             failureStringStart:
               'These overloads can be combined into one signature',
-            type1: 'string',
-            type2: 'number',
+            types: 'string | number',
           },
           endColumn: 24,
           endLine: 3,
           line: 3,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+    },
+    {
+      // https://github.com/typescript-eslint/typescript-eslint/issues/12504
+      code: `
+function f(x: string | number): void;
+function f(x: number | boolean): void;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            types: 'string | number | boolean',
+          },
+          endColumn: 31,
+          endLine: 3,
+          line: 3,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+    },
+    {
+      // Repeated references are deduplicated only when they resolve to the same alias.
+      code: `
+type Alias = string;
+function f(x: Alias): void;
+function f(x: Alias | number): void;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            types: 'Alias | number',
+          },
+          endColumn: 29,
+          endLine: 4,
+          line: 4,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+    },
+    {
+      // An alias and the type it denotes are distinct syntax and remain distinct.
+      code: `
+type Name = string;
+function f(x: Name): void;
+function f(x: string | Name): void;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            types: 'Name | string',
+          },
+          endColumn: 28,
+          endLine: 4,
+          line: 4,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+    },
+    {
+      // Type parameters with the same position in each overload correspond.
+      code: `
+function f<T>(x: T): void;
+function f<T>(x: T | string): void;
+      `,
+      errors: [
+        {
+          column: 15,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            types: 'T | string',
+          },
+          endColumn: 28,
+          endLine: 3,
+          line: 3,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+    },
+    {
+      // Pipes in string literals are not union separators.
+      code: `
+function f(x: 'a|b'): void;
+function f(x: 'a|b' | string): void;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            types: "'a|b' | string",
+          },
+          endColumn: 29,
+          endLine: 3,
+          line: 3,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+    },
+    {
+      // Comments and whitespace do not make structurally identical members distinct.
+      code: `
+function f(x: string /* first */ | number): void;
+function f(x: number | /* second */ string): void;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            types: 'string | number',
+          },
+          endColumn: 43,
+          endLine: 3,
+          line: 3,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+    },
+    {
+      // Intersections remain a single union member.
+      code: noFormat`
+function f(x: string & { brand: true }): void;
+function f(x: number | string & { brand: true }): void;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            types: 'string & { brand: true } | number',
+          },
+          endColumn: 48,
+          endLine: 3,
+          line: 3,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+    },
+    {
+      // Function and conditional types are parenthesized when rendered in a union.
+      code: `
+function f<T, U>(x: () => void): void;
+function f<T, U>(x: T extends U ? string : number): void;
+      `,
+      errors: [
+        {
+          column: 18,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            types: '(() => void) | (T extends U ? string : number)',
+          },
+          endColumn: 50,
+          endLine: 3,
+          line: 3,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+    },
+    {
+      // Constructor types are likewise parenthesized when rendered in a union.
+      code: `
+interface Value {}
+function f(x: new () => Value): void;
+function f(x: string): void;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            types: '(new () => Value) | string',
+          },
+          endColumn: 21,
+          endLine: 4,
+          line: 4,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+    },
+    {
+      // A larger overload group still renders only the compared pair's members.
+      code: `
+interface I {
+  f(x: string | number): void;
+  f(x: number | boolean): void;
+  f(x: symbol): string;
+}
+      `,
+      errors: [
+        {
+          column: 5,
+          data: {
+            failureStringStart:
+              'This overload and the one on line 3 can be combined into one signature',
+            types: 'string | number | boolean',
+          },
+          endColumn: 24,
+          endLine: 4,
+          line: 4,
           messageId: 'singleParameterDifference',
         },
       ],

--- a/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
+++ b/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
@@ -1468,6 +1468,22 @@ function f(x: number | /* second */ string): void;
       ],
     },
     {
+      code: `
+declare function fn(a: number): void;
+declare function fn(a: (/* before */ string /* after */)): void;
+      `,
+      errors: [
+        {
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            types: 'number | (string)',
+          },
+          messageId: 'singleParameterDifference',
+        },
+      ],
+    },
+    {
       code: noFormat`
 function f(x: string & { brand: true }): void;
 function f(x: number | string & { brand: true }): void;

--- a/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
+++ b/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
@@ -1475,26 +1475,6 @@ function f(x: number | /* second */ string): void;
       ],
     },
     {
-      code: noFormat`
-declare function fn(a: number): void;
-declare function fn(a: (/* before */ string /* after */)): void;
-      `,
-      errors: [
-        {
-          column: 21,
-          data: {
-            failureStringStart:
-              'These overloads can be combined into one signature',
-            types: 'number | (string)',
-          },
-          endColumn: 57,
-          endLine: 3,
-          line: 3,
-          messageId: 'singleParameterDifference',
-        },
-      ],
-    },
-    {
       // To avoid complex type comparisons when resolving #12504, allow duplicate union members when their source text differs.
       code: noFormat`
 function f(x: string & { brand: true }): void;

--- a/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
+++ b/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
@@ -1496,6 +1496,28 @@ declare function fn(a: (/* before */ string /* after */)): void;
       ],
     },
     {
+      // To avoid complex type comparisons when resolving #12504, allows duplicate union members when comments make their source text differ.
+      code: noFormat`
+function f(x: string & { brand: true }): void;
+function f(x: number | string & /* brand */ { brand: true }): void;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            types:
+              'string & { brand: true } | number | string & /* brand */ { brand: true }',
+          },
+          endColumn: 60,
+          endLine: 3,
+          line: 3,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+    },
+    {
       code: noFormat`
 function f(x: string & { brand: true }): void;
 function f(x: number | string & { brand: true }): void;

--- a/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
+++ b/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
@@ -1334,7 +1334,6 @@ function f(x: number | boolean): void;
       ],
     },
     {
-      // Repeated references are deduplicated only when they resolve to the same alias.
       code: `
 type Alias = string;
 function f(x: Alias): void;
@@ -1356,7 +1355,6 @@ function f(x: Alias | number): void;
       ],
     },
     {
-      // An alias and the type it denotes are distinct syntax and remain distinct.
       code: `
 type Name = string;
 function f(x: Name): void;
@@ -1378,7 +1376,6 @@ function f(x: string | Name): void;
       ],
     },
     {
-      // Type parameters with the same position in each overload correspond.
       code: `
 function f<T>(x: T): void;
 function f<T>(x: T | string): void;
@@ -1399,7 +1396,6 @@ function f<T>(x: T | string): void;
       ],
     },
     {
-      // Pipes in string literals are not union separators.
       code: `
 function f(x: 'a|b'): void;
 function f(x: 'a|b' | string): void;
@@ -1420,7 +1416,6 @@ function f(x: 'a|b' | string): void;
       ],
     },
     {
-      // Comments and whitespace do not make structurally identical members distinct.
       code: `
 function f(x: string /* first */ | number): void;
 function f(x: number | /* second */ string): void;
@@ -1441,7 +1436,6 @@ function f(x: number | /* second */ string): void;
       ],
     },
     {
-      // Intersections remain a single union member.
       code: noFormat`
 function f(x: string & { brand: true }): void;
 function f(x: number | string & { brand: true }): void;
@@ -1462,7 +1456,6 @@ function f(x: number | string & { brand: true }): void;
       ],
     },
     {
-      // Function and conditional types are parenthesized when rendered in a union.
       code: `
 function f<T, U>(x: () => void): void;
 function f<T, U>(x: T extends U ? string : number): void;
@@ -1483,7 +1476,6 @@ function f<T, U>(x: T extends U ? string : number): void;
       ],
     },
     {
-      // Constructor types are likewise parenthesized when rendered in a union.
       code: `
 interface Value {}
 function f(x: new () => Value): void;
@@ -1505,7 +1497,6 @@ function f(x: string): void;
       ],
     },
     {
-      // A larger overload group still renders only the compared pair's members.
       code: `
 interface I {
   f(x: string | number): void;
@@ -1524,6 +1515,89 @@ interface I {
           endColumn: 24,
           endLine: 4,
           line: 4,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+    },
+    {
+      code: `
+function f(x: 'a' | 'b'): void;
+function f(x: 'b' | 'c'): void;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            types: "'a' | 'b' | 'c'",
+          },
+          endColumn: 24,
+          endLine: 3,
+          line: 3,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+    },
+    {
+      code: `
+function f(x: Array<string> | boolean): void;
+function f(x: Array<number> | boolean): void;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            types: 'Array<string> | boolean | Array<number>',
+          },
+          endColumn: 38,
+          endLine: 3,
+          line: 3,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+    },
+    {
+      code: `
+function f(x: Promise | boolean): void;
+function f(x: Promise<string> | boolean): void;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            types: 'Promise | boolean | Promise<string>',
+          },
+          endColumn: 40,
+          endLine: 3,
+          line: 3,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+    },
+    {
+      code: `
+namespace Namespace {
+  export type Value = string;
+}
+function f(x: Namespace.Value): void;
+function f(x: Namespace.Value | string): void;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            types: 'Namespace.Value | string',
+          },
+          endColumn: 39,
+          endLine: 6,
+          line: 6,
           messageId: 'singleParameterDifference',
         },
       ],

--- a/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
+++ b/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
@@ -1313,7 +1313,6 @@ function f(this: string | number, a: boolean): void {}
       ],
     },
     {
-      // https://github.com/typescript-eslint/typescript-eslint/issues/12504
       code: `
 function f(x: string | number): void;
 function f(x: number | boolean): void;

--- a/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
+++ b/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
@@ -1340,11 +1340,15 @@ function f(value: string): void;
       `,
       errors: [
         {
+          column: 12,
           data: {
             failureStringStart:
               'These overloads can be combined into one signature',
             types: 'string',
           },
+          endColumn: 25,
+          endLine: 3,
+          line: 3,
           messageId: 'singleParameterDifference',
         },
       ],
@@ -1356,11 +1360,15 @@ function f(value): void;
       `,
       errors: [
         {
+          column: 12,
           data: {
             failureStringStart:
               'These overloads can be combined into one signature',
             types: 'string',
           },
+          endColumn: 17,
+          endLine: 3,
+          line: 3,
           messageId: 'singleParameterDifference',
         },
       ],
@@ -1468,17 +1476,21 @@ function f(x: number | /* second */ string): void;
       ],
     },
     {
-      code: `
+      code: noFormat`
 declare function fn(a: number): void;
 declare function fn(a: (/* before */ string /* after */)): void;
       `,
       errors: [
         {
+          column: 21,
           data: {
             failureStringStart:
               'These overloads can be combined into one signature',
             types: 'number | (string)',
           },
+          endColumn: 57,
+          endLine: 3,
+          line: 3,
           messageId: 'singleParameterDifference',
         },
       ],


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #12504
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview
### Interface
#### Unify
- Generic type parameters are declared in a separate scope for each overload. Therefore, even if both overloads declare a type parameter named `T`, comparing scope bindings alone treats them as different declarations.
- To handle this, the `Unify` result now stores both `typeParameters0` from the first signature and `typeParameters1` from the second signature.
- When generating the message, each type reference is checked against the type parameters of its corresponding signature.

#### Message
- Previously, the message template assumed exactly two distinct types and constructed the union as `type1 | type2`.
- With this change, each type can already be a union, and flattening and deduplication can result in anywhere from one to multiple union members.
- the rule now constructs the final union string as a single `types` value, and the message renders that value directly. This does not change the user-facing message.

### Implement
1. `getUnifiedTypeText`: Converts the two parameter types into union members for the diagnostic message.
2. `getUnionMembers`: Recursively flattens only `TSUnionType` nodes.
3. `typeNodesAreEqual`: Determines whether the flattened members are duplicates.
   - For regular types, compares their AST structure.
   - For type references, also compares their scope bindings.
   - For generic type parameters declared per signature, uses the provided declarations to treat type parameters at the same index as corresponding to each other.
4. `getUnifiedTypeText`: Removes duplicates and constructs the final union type string.
5. `getUnionMemberText`: Retrieves the source text for each member to be used in the final message, adding parentheses when necessary.

### Test
- test modifications due to interface changes
<!-- Description of what is changed and how the code change does that. -->

### Additional Info
- I left a question in the code comments.