### PR TITLE
docs: fix "suite" typo in quickstart docs

### DIFF
--- a/docs/getting-started/Quickstart.mdx
+++ b/docs/getting-started/Quickstart.mdx
@@ -51,7 +51,7 @@ This code will enable our [recommended configuration](../users/Shared_Configurat
 - [`// @ts-check` enables TypeScript](https://www.typescriptlang.org/docs/handbook/intro-to-js-ts.html#ts-check) to typecheck the config file, which improves editor support and can help catch errors when authoring your ESLint config.
   It's also fine to leave this off if it causes problems with your TypeScript setup.
 - `defineConfig(...)` is an optional helper function built in to current versions of ESLint. See [the ESLint configuration docs](https://eslint.org/docs/latest/use/configure/configuration-files) for more detail.
-- `files`/`extends`: this setup is an optional feature of `defineConfig(...)` that restricts the `extends` configs to JS and TS files, and can be modified to suite your project's needs.
+- `files`/`extends`: this setup is an optional feature of `defineConfig(...)` that restricts the `extends` configs to JS and TS files, and can be modified to suit your project's needs.
   We recommend this in order to avoid issues if you enable ESLint to run on other file types such as CSS or Markdown files, but it's entirely optional.
   To enable linting for all standard JS and TS file extensions, consider using `files: ['**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}']`.
   See the [Framework FAQs](../troubleshooting/faqs/Frameworks.mdx) to use typescript-eslint on file types other than those.


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [ ] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

This PR fixes a typo in the QuickStart documentation by changing to suite to to suit.

💖