### PR TITLE
fix(type-utils): match package path boundaries

### DIFF
--- a/packages/type-utils/src/typeOrValueSpecifiers/typeDeclaredInPackageDeclarationFile.ts
+++ b/packages/type-utils/src/typeOrValueSpecifiers/typeDeclaredInPackageDeclarationFile.ts
@@ -33,15 +33,19 @@ function typeDeclaredInDeclarationFile(
   declarationFiles: ts.SourceFile[],
   program: ts.Program,
 ): boolean {
-  // Handle scoped packages: if the name starts with @, remove it and replace / with __
-  const typesPackageName = packageName.replace(/^@([^/]+)\//, '$1__');
+  // Handle scoped packages: @scope/package types are published as @types/scope__package.
+  const packageNames = [
+    packageName,
+    `@types/${packageName.replace(/^@([^/]+)\//, '$1__')}`,
+  ];
 
-  const matcher = new RegExp(`${packageName}|${typesPackageName}`);
   return declarationFiles.some(declaration => {
     const packageIdName = program.sourceFileToPackageName.get(declaration.path);
     return (
       packageIdName != null &&
-      matcher.test(packageIdName) &&
+      packageNames.some(
+        name => packageIdName === name || packageIdName.startsWith(`${name}/`),
+      ) &&
       program.isSourceFileFromExternalLibrary(declaration)
     );
   });

--- a/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
+++ b/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
@@ -569,6 +569,14 @@ describe('TypeOrValueSpecifier', () => {
         { from: 'package', name: ['Node', 'Symbol'], package: 'other-package' },
       ],
       [
+        'import {BabelCodeFrameOptions} from "@babel/code-frame"; type Test = BabelCodeFrameOptions;',
+        {
+          from: 'package',
+          name: 'BabelCodeFrameOptions',
+          package: '@babel/code',
+        },
+      ],
+      [
         'interface Node {prop: string}; type Test = Node;',
         { from: 'package', name: 'Node', package: 'typescript' },
       ],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #11946
- [x] That issue was marked as accepting prs
- [x] Steps in Contributing were taken
- [x] If this PR used AI assistance, I followed the AI Contribution Policy

## Overview

Match package specifiers only at exact package or slash-delimited subpath boundaries. Preserve matching for DefinitelyTyped packages, including scoped package names, and add a regression case for partial scoped-package prefixes.

💖