### PR TITLE
feat(eslint-plugin): [no-misused-disposable] add rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -388,6 +388,8 @@ export default defineConfig(
           'vitest/prefer-to-contain': 'error',
           'vitest/prefer-to-have-length': 'error',
           'vitest/valid-expect': 'error',
+          // TODO - handle the vi.spy() cases
+          '@typescript-eslint/no-misused-disposable': 'off',
         },
         settings: { vitest: { typecheck: true } },
       },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -109,6 +109,7 @@ export default defineConfig(
         'error',
         { ignoreVoidReturningFunctions: true },
       ],
+      '@typescript-eslint/no-misused-disposable': 'error',
       // TODO: enable it once we drop support for TS<5.0
       // https://github.com/typescript-eslint/typescript-eslint/issues/10065
       '@typescript-eslint/consistent-type-exports': [

--- a/packages/eslint-plugin/docs/rules/no-misused-disposable.mdx
+++ b/packages/eslint-plugin/docs/rules/no-misused-disposable.mdx
@@ -1,0 +1,81 @@
+---
+description: "Disallow using disposables in a way that won't be disposed."
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+> 🛑 This file is source code, not the primary documentation location! 🛑
+>
+> See **https://typescript-eslint.io/rules/no-misused-disposable** for documentation.
+
+[Explicit resource management](https://github.com/tc39/proposal-explicit-resource-management) introduces `Disposable` and `AsyncDisposable` objects, along with `using` and `await using` declarations to dispose of them automatically at the end of a scope.
+A `Disposable` (or `AsyncDisposable`) that is created but never disposed of defeats the purpose of the API: any cleanup logic in its `[Symbol.dispose]()`/`[Symbol.asyncDispose]()` method silently never runs.
+
+This rule reports disposable-producing expressions (calls, `new` expressions) whose result isn't handled in one of the following ways:
+
+- Declared with a `using` or `await using` declaration
+- `return`ed (directly, or via a variable that is later returned)
+- Passed to a function or constructor whose parameter type accepts a disposable
+- Explicitly disposed by calling `[Symbol.dispose]()`/`[Symbol.asyncDispose]()` on every code path
+
+Because handling can be conditional, this rule uses [code path analysis](https://eslint.org/docs/latest/extend/code-path-analysis) to require handling on _every_ reachable code path out of the disposable's scope, not just some of them.
+
+## Examples
+
+<Tabs>
+<TabItem value="❌ Incorrect">
+
+```ts
+declare function getDisposable(): Disposable;
+
+getDisposable();
+
+function foo() {
+  const disposable = getDisposable();
+  // `disposable` is never used again and never disposed
+}
+
+function bar() {
+  const disposable = getDisposable();
+  if (Math.random() > 0.5) {
+    disposable[Symbol.dispose]();
+  }
+  // not handled on every path
+}
+```
+
+</TabItem>
+<TabItem value="✅ Correct">
+
+```ts
+declare function getDisposable(): Disposable;
+
+using disposable = getDisposable();
+
+function foo() {
+  return getDisposable();
+}
+
+function bar() {
+  const disposable = getDisposable();
+  try {
+    // ...
+  } finally {
+    disposable[Symbol.dispose]();
+  }
+}
+
+declare function acceptsDisposable(d: Disposable): void;
+acceptsDisposable(getDisposable());
+```
+
+</TabItem>
+</Tabs>
+
+## When Not To Use It
+
+Not every `Disposable`/`AsyncDisposable` is meant to be exclusively managed with `using`/`await using`.
+Some APIs (for example, timers or handles in Node.js) implement the disposable protocol as one of several supported ways to release resources, and may be intentionally handed off to other code for lifecycle management outside of the immediately enclosing scope in ways this rule cannot always detect.
+
+If your codebase relies heavily on APIs like this, you may want to avoid this rule, or disable it for the specific lines or files involved.

--- a/packages/eslint-plugin/docs/rules/no-misused-disposable.mdx
+++ b/packages/eslint-plugin/docs/rules/no-misused-disposable.mdx
@@ -10,16 +10,15 @@ import TabItem from '@theme/TabItem';
 > See **https://typescript-eslint.io/rules/no-misused-disposable** for documentation.
 
 [Explicit resource management](https://github.com/tc39/proposal-explicit-resource-management) introduces `Disposable` and `AsyncDisposable` objects, along with `using` and `await using` declarations to dispose of them automatically at the end of a scope.
-A `Disposable` (or `AsyncDisposable`) that is created but never disposed of defeats the purpose of the API: any cleanup logic in its `[Symbol.dispose]()`/`[Symbol.asyncDispose]()` method silently never runs.
+A `Disposable` (or `AsyncDisposable`) that is created but never disposed of may be an error, since its `[Symbol.dispose]()`/`[Symbol.asyncDispose]()` method never runs.
 
-This rule reports disposable-producing expressions (calls, `new` expressions) whose result isn't handled in one of the following ways:
+This rule reports disposable-producing expressions (calls, `new` expressions) whose result isn't handled in one of the following ways, in every reachable code path:
 
-- Declared with a `using` or `await using` declaration
-- `return`ed (directly, or via a variable that is later returned)
-- Passed to a function or constructor whose parameter type accepts a disposable
-- Explicitly disposed by calling `[Symbol.dispose]()`/`[Symbol.asyncDispose]()` on every code path
-
-Because handling can be conditional, this rule uses [code path analysis](https://eslint.org/docs/latest/extend/code-path-analysis) to require handling on _every_ reachable code path out of the disposable's scope, not just some of them.
+- Assigned to a `using` or `await using` declaration
+- `return`ed, if the function signature returns a disposable
+- Passed as an argument to a function whose parameter type accepts a disposable
+- Explicitly disposed by calling `[Symbol.dispose]()`/`[Symbol.asyncDispose]()`
+- Iterated, if the disposable is an iterable (see [Iterators](#iterators))
 
 ## Examples
 
@@ -33,7 +32,7 @@ getDisposable();
 
 function foo() {
   const disposable = getDisposable();
-  // `disposable` is never used again and never disposed
+  // `disposable` is never disposed
 }
 
 function bar() {
@@ -41,7 +40,7 @@ function bar() {
   if (Math.random() > 0.5) {
     disposable[Symbol.dispose]();
   }
-  // not handled on every path
+  // not disposed on every path
 }
 ```
 
@@ -66,8 +65,89 @@ function bar() {
   }
 }
 
+function baz() {
+  const disposable = getDisposable();
+  if (Math.random() > 0.5) {
+    disposable[Symbol.dispose]();
+  } else {
+    disposable[Symbol.dispose]();
+  }
+}
+
 declare function acceptsDisposable(d: Disposable): void;
 acceptsDisposable(getDisposable());
+```
+
+</TabItem>
+</Tabs>
+
+## Iterators
+
+The built-in iterator protocol integrates with explicit resource management: [`Iterator.prototype[Symbol.dispose]()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/Symbol.dispose) calls the iterator's `return()` method, running any pending cleanup — for example, a generator's `finally` blocks.
+This means every built-in iterator object — generator objects, collection iterators such as `map.values()`, and iterator helpers — is technically a `Disposable`.
+
+Iterating such a value already ensures the iterator gets cleaned up, since iteration syntax closes the iterator when it completes or exits early.
+This rule therefore treats iteration syntax itself as a valid way of handling a disposable iterable:
+
+- `for...of` and `for await...of` loops
+- Spreading into an array, call, or `new` expression (`[...iterable]`, `fn(...iterable)`)
+- Array destructuring (`const [first] = iterable;`) — note that even partial destructuring exhausts and closes the iterator; it's not necessary to do `const [first, ...rest] = iterable;`
+- `yield*` delegation
+
+Sync iteration handles sync iterables; `for await...of` (and `yield*` in async generators) handles both sync and async iterables.
+
+An iterator that is advanced manually with `.next()`, on the other hand, is not necessarily exhausted, so its cleanup may never run.
+Declare it with `using` instead:
+
+<Tabs>
+<TabItem value="❌ Incorrect">
+
+```ts
+function* generateNumbers() {
+  try {
+    yield 1;
+    yield 2;
+    yield 3;
+  } finally {
+    console.log('Cleaning up');
+  }
+}
+
+function doSomething() {
+  const numbers = generateNumbers();
+  const res1 = numbers.next();
+  // The generator is never exhausted nor disposed,
+  // so "Cleaning up" is never logged.
+}
+```
+
+</TabItem>
+<TabItem value="✅ Correct">
+
+```ts
+function* generateNumbers() {
+  try {
+    yield 1;
+    yield 2;
+    yield 3;
+  } finally {
+    console.log('Cleaning up');
+  }
+}
+
+function doSomething() {
+  using numbers = generateNumbers();
+  const res1 = numbers.next();
+  // Before the function exits, the iterator is disposed.
+  // Logs "Cleaning up".
+}
+
+function logAll() {
+  // Iteration runs the generator to completion, which also runs its cleanup.
+  for (const value of generateNumbers()) {
+    console.log(value);
+  }
+}
 ```
 
 </TabItem>

--- a/packages/eslint-plugin/src/configs/eslintrc/all.ts
+++ b/packages/eslint-plugin/src/configs/eslintrc/all.ts
@@ -70,6 +70,7 @@ export = {
     'no-magic-numbers': 'off',
     '@typescript-eslint/no-magic-numbers': 'error',
     '@typescript-eslint/no-meaningless-void-operator': 'error',
+    '@typescript-eslint/no-misused-disposable': 'error',
     '@typescript-eslint/no-misused-new': 'error',
     '@typescript-eslint/no-misused-promises': 'error',
     '@typescript-eslint/no-misused-spread': 'error',

--- a/packages/eslint-plugin/src/configs/eslintrc/disable-type-checked.ts
+++ b/packages/eslint-plugin/src/configs/eslintrc/disable-type-checked.ts
@@ -24,6 +24,7 @@ export = {
     '@typescript-eslint/no-for-in-array': 'off',
     '@typescript-eslint/no-implied-eval': 'off',
     '@typescript-eslint/no-meaningless-void-operator': 'off',
+    '@typescript-eslint/no-misused-disposable': 'off',
     '@typescript-eslint/no-misused-promises': 'off',
     '@typescript-eslint/no-misused-spread': 'off',
     '@typescript-eslint/no-mixed-enums': 'off',

--- a/packages/eslint-plugin/src/configs/flat/all.ts
+++ b/packages/eslint-plugin/src/configs/flat/all.ts
@@ -83,6 +83,7 @@ export default (
       'no-magic-numbers': 'off',
       '@typescript-eslint/no-magic-numbers': 'error',
       '@typescript-eslint/no-meaningless-void-operator': 'error',
+      '@typescript-eslint/no-misused-disposable': 'error',
       '@typescript-eslint/no-misused-new': 'error',
       '@typescript-eslint/no-misused-promises': 'error',
       '@typescript-eslint/no-misused-spread': 'error',

--- a/packages/eslint-plugin/src/configs/flat/disable-type-checked.ts
+++ b/packages/eslint-plugin/src/configs/flat/disable-type-checked.ts
@@ -31,6 +31,7 @@ export default (
     '@typescript-eslint/no-for-in-array': 'off',
     '@typescript-eslint/no-implied-eval': 'off',
     '@typescript-eslint/no-meaningless-void-operator': 'off',
+    '@typescript-eslint/no-misused-disposable': 'off',
     '@typescript-eslint/no-misused-promises': 'off',
     '@typescript-eslint/no-misused-spread': 'off',
     '@typescript-eslint/no-mixed-enums': 'off',

--- a/packages/eslint-plugin/src/rules/index.ts
+++ b/packages/eslint-plugin/src/rules/index.ts
@@ -51,6 +51,7 @@ import noLoopFunc from './no-loop-func';
 import noLossOfPrecision from './no-loss-of-precision';
 import noMagicNumbers from './no-magic-numbers';
 import noMeaninglessVoidOperator from './no-meaningless-void-operator';
+import noMisusedDisposable from './no-misused-disposable';
 import noMisusedNew from './no-misused-new';
 import noMisusedPromises from './no-misused-promises';
 import noMisusedSpread from './no-misused-spread';
@@ -187,6 +188,7 @@ const rules = {
   'no-loss-of-precision': noLossOfPrecision,
   'no-magic-numbers': noMagicNumbers,
   'no-meaningless-void-operator': noMeaninglessVoidOperator,
+  'no-misused-disposable': noMisusedDisposable,
   'no-misused-new': noMisusedNew,
   'no-misused-promises': noMisusedPromises,
   'no-misused-spread': noMisusedSpread,

--- a/packages/eslint-plugin/src/rules/no-misused-disposable.ts
+++ b/packages/eslint-plugin/src/rules/no-misused-disposable.ts
@@ -24,6 +24,14 @@ interface FunctionInfo {
   upper: FunctionInfo | null;
 }
 
+// BIG TODO - all iterators apparently are Disposable (why??).
+// So we need to find some way to detect that and not report them all over.
+// Perhaps if a disposable is created that is also an iterator, iteration should
+// be a form a handling it?
+
+// also - vi.spy() sort of stuff triggers all over.
+// This might be big pain.
+
 export default createRule({
   name: 'no-misused-disposable',
   meta: {
@@ -84,7 +92,7 @@ export default createRule({
     }
 
     /**
-     * A segment is considered handled for `variableId` if it is unreachable,
+     * A segment is considered handled for `variableId`
      * if the variable's declaration can't reach it (the variable was never
      * live on that path, so there is nothing to require), or if it was
      * explicitly marked handled.
@@ -112,6 +120,7 @@ export default createRule({
       return undefined;
     }
 
+    // TODO - it matters what type of disposable it is.
     function typeAcceptsDisposable(type: ts.Type): boolean {
       return tsutils
         .unionConstituents(type)
@@ -149,6 +158,12 @@ export default createRule({
             return traverseUpTransparentParents(parent);
           }
           return node;
+        case AST_NODE_TYPES.TSSatisfiesExpression:
+        case AST_NODE_TYPES.TSAsExpression:
+        case AST_NODE_TYPES.TSTypeAssertion:
+          // parent.expression === node since we're in a value context
+          return traverseUpTransparentParents(parent);
+
         default:
           return node;
       }
@@ -162,8 +177,9 @@ export default createRule({
     function isEscapingCallArgument(node: TSESTree.Node): boolean {
       const { parent } = node;
       if (
-        parent?.type !== AST_NODE_TYPES.CallExpression &&
-        parent?.type !== AST_NODE_TYPES.NewExpression
+        parent == null ||
+        (parent.type !== AST_NODE_TYPES.CallExpression &&
+          parent.type !== AST_NODE_TYPES.NewExpression)
       ) {
         return false;
       }
@@ -173,8 +189,7 @@ export default createRule({
       if (argIndex === -1) {
         return false;
       }
-      const tsCallLike = services.esTreeNodeToTSNodeMap.get(parent) as
-        ts.CallExpression | ts.NewExpression;
+      const tsCallLike = services.esTreeNodeToTSNodeMap.get(parent);
       const contextualType = checker.getContextualTypeForArgumentAtIndex(
         tsCallLike,
         argIndex,
@@ -188,10 +203,8 @@ export default createRule({
      * disposable. If not, the disposable does not actually escape via this
      * return (e.g. the enclosing function's return type is `unknown`).
      */
-    function isEscapingReturnArgument(node: TSESTree.Node): boolean {
-      const tsNode = services.esTreeNodeToTSNodeMap.get(
-        node as TSESTree.Expression,
-      ) as ts.Expression;
+    function isEscapingReturnArgument(node: TSESTree.Expression): boolean {
+      const tsNode = services.esTreeNodeToTSNodeMap.get(node) as ts.Expression;
       const contextualType = checker.getContextualType(tsNode);
       if (contextualType == null) {
         return true;
@@ -207,16 +220,16 @@ export default createRule({
         return false;
       }
 
-      if (parent.type === AST_NODE_TYPES.ReturnStatement) {
-        return isEscapingReturnArgument(target);
-      }
-
       if (
         parent.type === AST_NODE_TYPES.VariableDeclarator &&
         parent.init === target &&
         (parent.parent.kind === 'using' || parent.parent.kind === 'await using')
       ) {
         return true;
+      }
+
+      if (parent.type === AST_NODE_TYPES.ReturnStatement) {
+        return isEscapingReturnArgument(target as TSESTree.Expression);
       }
 
       return isEscapingCallArgument(target);
@@ -230,18 +243,25 @@ export default createRule({
       node: TSESTree.Identifier,
       disposeKind: DisposeKind,
     ): boolean {
+      // Question - why isn't this part of isImmediatelyHandled?
       const { parent } = node;
-      if (
-        parent.type !== AST_NODE_TYPES.MemberExpression ||
-        parent.object !== node ||
-        !parent.computed ||
-        parent.parent.type !== AST_NODE_TYPES.CallExpression ||
-        parent.parent.callee !== parent
-      ) {
+      if (!(
+        parent.type === AST_NODE_TYPES.MemberExpression &&
+        parent.object === node &&
+        parent.computed &&
+        parent.parent.type === AST_NODE_TYPES.CallExpression &&
+        parent.parent.callee === parent
+      )) {
         return false;
       }
 
       const propertyType = services.getTypeAtLocation(parent.property);
+      // this should specifically be checking for the right well-known symbol.
+      // OR, syntactically checking for Symbol.dispose/Symbol.asyncDispose.
+
+      // TODO - is this whole following section just a workaround for the fact that
+      // TypeScript doesn't have a way to get the type of a symbol property access?
+
       if (!tsutils.isUniqueESSymbolType(propertyType)) {
         return false;
       }
@@ -276,6 +296,8 @@ export default createRule({
 
     function markHandled(variableId: number): void {
       for (const segment of currentFuncInfo().currentSegments) {
+        // why is the segment.reachable check necessary?
+        // No tests fail if it's removed.
         if (segment.reachable) {
           handledAtSegment.set(segmentKey(segment, variableId), true);
         }
@@ -380,6 +402,7 @@ export default createRule({
       }
 
       const type = services.getTypeAtLocation(node.right);
+      // ?
       if (getDisposeKind(type) != null) {
         // Handled by `checkProducedDisposable`, which also accounts for the
         // possibility of overwriting a previously tracked disposable.
@@ -407,8 +430,12 @@ export default createRule({
         return;
       }
 
+      // why traverseUpParents inside isImmediatelyHandled if we also traverseUp manually here?
+      // seems like that's not what immediately means?
+
       const target = traverseUpTransparentParents(node);
       const { parent } = target;
+      // TODO - what about var?
       if (
         parent?.type === AST_NODE_TYPES.VariableDeclarator &&
         parent.init === target &&
@@ -419,6 +446,7 @@ export default createRule({
         return;
       }
 
+      // what about &&= and ??= and ||= ?
       if (
         parent?.type === AST_NODE_TYPES.AssignmentExpression &&
         parent.operator === '=' &&

--- a/packages/eslint-plugin/src/rules/no-misused-disposable.ts
+++ b/packages/eslint-plugin/src/rules/no-misused-disposable.ts
@@ -30,12 +30,7 @@ interface FunctionInfo {
   upper: FunctionInfo | null;
 }
 
-// BIG TODO - all iterators apparently are Disposable (why??).
-// So we need to find some way to detect that and not report them all over.
-// Perhaps if a disposable is created that is also an iterator, iteration should
-// be a form a handling it?
-
-// also - vi.spy() sort of stuff triggers all over.
+// TODO - vi.spy() sort of stuff triggers all over.
 // This might be big pain.
 
 export default createRule({
@@ -109,6 +104,111 @@ export default createRule({
       return tsutils
         .unionConstituents(type)
         .some(part => getDisposeKind(part) != null);
+    }
+
+    function typeIsIterable(
+      type: ts.Type,
+      iteratorKind: 'asyncIterator' | 'iterator',
+    ): boolean {
+      return tsutils
+        .unionConstituents(type)
+        .some(
+          part =>
+            tsutils.getWellKnownSymbolPropertyOfType(
+              part,
+              iteratorKind,
+              checker,
+            ) != null,
+        );
+    }
+
+    function isEnclosingFunctionAsync(node: TSESTree.Node): boolean {
+      let current = node.parent;
+      while (current != null) {
+        switch (current.type) {
+          case AST_NODE_TYPES.ArrowFunctionExpression:
+          case AST_NODE_TYPES.FunctionDeclaration:
+          case AST_NODE_TYPES.FunctionExpression:
+            return current.async;
+          default:
+            current = current.parent;
+        }
+      }
+      return false;
+    }
+
+    /**
+     * Checks whether `target` sits in a syntactic position that iterates it.
+     * Iterating a disposable iterable hands its lifecycle over to the
+     * iteration protocol (which closes the iterator on completion or early
+     * exit), so it counts as handling the disposable.
+     *
+     * Sync iteration handles sync iterables (whether sync- or
+     * async-disposable). Async iteration (`for await`, delegation inside an
+     * async generator) handles both sync and async iterables. An
+     * async-only iterable is not handled by sync iteration (which would be
+     * a type error to begin with).
+     */
+    function isHandledByIteration(target: TSESTree.Node): boolean {
+      const { parent } = target;
+      if (parent == null) {
+        return false;
+      }
+
+      let isAsyncIteration: boolean;
+      switch (parent.type) {
+        case AST_NODE_TYPES.ForOfStatement:
+          if (parent.right !== target) {
+            return false;
+          }
+          isAsyncIteration = parent.await;
+          break;
+        case AST_NODE_TYPES.SpreadElement:
+          // Object spread (`{ ...value }`) copies own properties; it does
+          // not iterate.
+          if (
+            parent.parent.type !== AST_NODE_TYPES.ArrayExpression &&
+            parent.parent.type !== AST_NODE_TYPES.CallExpression &&
+            parent.parent.type !== AST_NODE_TYPES.NewExpression
+          ) {
+            return false;
+          }
+          isAsyncIteration = false;
+          break;
+        case AST_NODE_TYPES.VariableDeclarator:
+          if (
+            parent.init !== target ||
+            parent.id.type !== AST_NODE_TYPES.ArrayPattern
+          ) {
+            return false;
+          }
+          isAsyncIteration = false;
+          break;
+        case AST_NODE_TYPES.AssignmentExpression:
+          if (
+            parent.right !== target ||
+            parent.operator !== '=' ||
+            parent.left.type !== AST_NODE_TYPES.ArrayPattern
+          ) {
+            return false;
+          }
+          isAsyncIteration = false;
+          break;
+        case AST_NODE_TYPES.YieldExpression:
+          if (!parent.delegate) {
+            return false;
+          }
+          isAsyncIteration = isEnclosingFunctionAsync(parent);
+          break;
+        default:
+          return false;
+      }
+
+      const type = services.getTypeAtLocation(target);
+      if (typeIsIterable(type, 'iterator')) {
+        return true;
+      }
+      return isAsyncIteration && typeIsIterable(type, 'asyncIterator');
     }
 
     /** Skips parenthesization and control-flow-transparent wrapper expressions. */
@@ -214,6 +314,10 @@ export default createRule({
 
       if (parent.type === AST_NODE_TYPES.ReturnStatement) {
         return isEscapingReturnArgument(target as TSESTree.Expression);
+      }
+
+      if (isHandledByIteration(target)) {
+        return true;
       }
 
       return isEscapingCallArgument(target);

--- a/packages/eslint-plugin/src/rules/no-misused-disposable.ts
+++ b/packages/eslint-plugin/src/rules/no-misused-disposable.ts
@@ -1,0 +1,528 @@
+import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
+import type * as ts from 'typescript';
+
+import { AST_NODE_TYPES } from '@typescript-eslint/utils';
+import { nullThrows } from '@typescript-eslint/utils/eslint-utils';
+import * as tsutils from 'ts-api-utils';
+
+import { createRule, findVariable, getParserServices } from '../util';
+
+type DisposeKind = 'asyncDispose' | 'dispose';
+
+interface TrackedVariable {
+  /** The segments active at the point the variable was declared. */
+  declaredSegments: TSESLint.CodePathSegment[];
+  disposeKind: DisposeKind;
+  reportNode: TSESTree.Node;
+}
+
+interface FunctionInfo {
+  codePath: TSESLint.CodePath;
+  currentSegments: Set<TSESLint.CodePathSegment>;
+  /** Variables declared (and tracked) within this code path. */
+  trackedVariables: Map<number, TrackedVariable>;
+  upper: FunctionInfo | null;
+}
+
+export default createRule({
+  name: 'no-misused-disposable',
+  meta: {
+    type: 'problem',
+    docs: {
+      description: "Disallow using disposables in a way that won't be disposed",
+      requiresTypeChecking: true,
+    },
+    messages: {
+      misusedDisposable:
+        'This value creates a Disposable that is not guaranteed to be disposed. ' +
+        "It must be declared with 'using'/'await using', returned, passed to a " +
+        'function accepting a disposable, or explicitly disposed on every code path.',
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    const services = getParserServices(context);
+    const checker = services.program.getTypeChecker();
+
+    let funcInfo: FunctionInfo | null = null;
+
+    // Per-segment, per-tracked-variable "handled" state. Keyed by
+    // `${segment.id}:${variable.$id}`.
+    const handledAtSegment = new Map<string, boolean>();
+
+    function currentFuncInfo(): FunctionInfo {
+      return nullThrows(funcInfo, 'expected to be inside of a code path');
+    }
+
+    function segmentKey(
+      segment: TSESLint.CodePathSegment,
+      variableId: number,
+    ): string {
+      return `${segment.id}:${String(variableId)}`;
+    }
+
+    /** Checks whether `target` is reachable from any of `from` by following `nextSegments`. */
+    function isSegmentReachableFromAny(
+      from: TSESLint.CodePathSegment[],
+      target: TSESLint.CodePathSegment,
+    ): boolean {
+      const visited = new Set<string>();
+      const stack = [...from];
+      while (stack.length > 0) {
+        const segment = nullThrows(stack.pop(), 'stack is non-empty');
+        if (segment === target) {
+          return true;
+        }
+        if (visited.has(segment.id)) {
+          continue;
+        }
+        visited.add(segment.id);
+        stack.push(...segment.nextSegments);
+      }
+      return false;
+    }
+
+    /**
+     * A segment is considered handled for `variableId` if it is unreachable,
+     * if the variable's declaration can't reach it (the variable was never
+     * live on that path, so there is nothing to require), or if it was
+     * explicitly marked handled.
+     */
+    function isHandledAtSegment(
+      segment: TSESLint.CodePathSegment,
+      variable: TrackedVariable,
+      variableId: number,
+    ): boolean {
+      return (
+        !isSegmentReachableFromAny(variable.declaredSegments, segment) ||
+        handledAtSegment.get(segmentKey(segment, variableId)) === true
+      );
+    }
+
+    function getDisposeKind(type: ts.Type): DisposeKind | undefined {
+      if (tsutils.getWellKnownSymbolPropertyOfType(type, 'dispose', checker)) {
+        return 'dispose';
+      }
+      if (
+        tsutils.getWellKnownSymbolPropertyOfType(type, 'asyncDispose', checker)
+      ) {
+        return 'asyncDispose';
+      }
+      return undefined;
+    }
+
+    function typeAcceptsDisposable(type: ts.Type): boolean {
+      return tsutils
+        .unionConstituents(type)
+        .some(part => getDisposeKind(part) != null);
+    }
+
+    /** Skips parenthesization and control-flow-transparent wrapper expressions. */
+    function traverseUpTransparentParents(node: TSESTree.Node): TSESTree.Node {
+      const { parent } = node;
+      if (parent == null) {
+        return node;
+      }
+      switch (parent.type) {
+        case AST_NODE_TYPES.ConditionalExpression:
+          if (parent.test !== node) {
+            return traverseUpTransparentParents(parent);
+          }
+          return node;
+        case AST_NODE_TYPES.LogicalExpression:
+          // `a && b` evaluates to `b` whenever `a` is truthy, which is
+          // always the case for a (non-nullish) disposable object -- so
+          // `a`'s value is discarded and only `b` (the right side) can
+          // carry the disposable through. `a || b`, on the other hand, may
+          // evaluate to either operand depending on `a`'s runtime
+          // truthiness, so both sides are treated as transparent.
+          if (
+            parent.operator === '||' ||
+            (parent.operator === '&&' && parent.right === node)
+          ) {
+            return traverseUpTransparentParents(parent);
+          }
+          return node;
+        case AST_NODE_TYPES.SequenceExpression:
+          if (parent.expressions.at(-1) === node) {
+            return traverseUpTransparentParents(parent);
+          }
+          return node;
+        default:
+          return node;
+      }
+    }
+
+    /**
+     * Checks whether `node`, used as an argument in a call/new expression,
+     * is passed to a parameter whose contextual type accepts a disposable.
+     * If so, the disposable is considered to have escaped.
+     */
+    function isEscapingCallArgument(node: TSESTree.Node): boolean {
+      const { parent } = node;
+      if (
+        parent?.type !== AST_NODE_TYPES.CallExpression &&
+        parent?.type !== AST_NODE_TYPES.NewExpression
+      ) {
+        return false;
+      }
+      const argIndex = parent.arguments.indexOf(
+        node as TSESTree.CallExpressionArgument,
+      );
+      if (argIndex === -1) {
+        return false;
+      }
+      const tsCallLike = services.esTreeNodeToTSNodeMap.get(parent) as
+        ts.CallExpression | ts.NewExpression;
+      const contextualType = checker.getContextualTypeForArgumentAtIndex(
+        tsCallLike,
+        argIndex,
+      );
+      return typeAcceptsDisposable(contextualType);
+    }
+
+    /**
+     * Checks whether `node`, used as a `return` statement's argument, is
+     * returned to a context whose (contextual or declared) type accepts a
+     * disposable. If not, the disposable does not actually escape via this
+     * return (e.g. the enclosing function's return type is `unknown`).
+     */
+    function isEscapingReturnArgument(node: TSESTree.Node): boolean {
+      const tsNode = services.esTreeNodeToTSNodeMap.get(
+        node as TSESTree.Expression,
+      ) as ts.Expression;
+      const contextualType = checker.getContextualType(tsNode);
+      if (contextualType == null) {
+        return true;
+      }
+      return typeAcceptsDisposable(contextualType);
+    }
+
+    /** Checks whether an expression at `node` is handled at this exact location. */
+    function isImmediatelyHandled(node: TSESTree.Node): boolean {
+      const target = traverseUpTransparentParents(node);
+      const { parent } = target;
+      if (parent == null) {
+        return false;
+      }
+
+      if (parent.type === AST_NODE_TYPES.ReturnStatement) {
+        return isEscapingReturnArgument(target);
+      }
+
+      if (
+        parent.type === AST_NODE_TYPES.VariableDeclarator &&
+        parent.init === target &&
+        (parent.parent.kind === 'using' || parent.parent.kind === 'await using')
+      ) {
+        return true;
+      }
+
+      return isEscapingCallArgument(target);
+    }
+
+    /**
+     * Checks whether `node` (an Identifier reference) is the callee object
+     * of a manual disposal call, e.g. `x[Symbol.dispose]()`.
+     */
+    function isManualDisposeCall(
+      node: TSESTree.Identifier,
+      disposeKind: DisposeKind,
+    ): boolean {
+      const { parent } = node;
+      if (
+        parent.type !== AST_NODE_TYPES.MemberExpression ||
+        parent.object !== node ||
+        !parent.computed ||
+        parent.parent.type !== AST_NODE_TYPES.CallExpression ||
+        parent.parent.callee !== parent
+      ) {
+        return false;
+      }
+
+      const propertyType = services.getTypeAtLocation(parent.property);
+      if (!tsutils.isUniqueESSymbolType(propertyType)) {
+        return false;
+      }
+
+      const nodeType = services.getTypeAtLocation(node);
+      const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+      // Optional chaining (e.g. `foo?.[Symbol.dispose]()`) adds `| undefined`
+      // to the member access's resolved type, so compare against the
+      // non-nullable type to still recognize the dispose call.
+      const actualType = checker.getNonNullableType(
+        services.getTypeAtLocation(parent),
+      );
+      return tsutils.unionConstituents(nodeType).some(part => {
+        const expectedSymbol = tsutils.getWellKnownSymbolPropertyOfType(
+          part,
+          disposeKind,
+          checker,
+        );
+        if (expectedSymbol == null) {
+          return false;
+        }
+
+        // Both `parent.property` and `expectedSymbol` are keyed off of the
+        // same well-known symbol iff their resolved (unique) types match.
+        const expectedType = checker.getTypeOfSymbolAtLocation(
+          expectedSymbol,
+          tsNode,
+        );
+        return actualType === expectedType;
+      });
+    }
+
+    function markHandled(variableId: number): void {
+      for (const segment of currentFuncInfo().currentSegments) {
+        if (segment.reachable) {
+          handledAtSegment.set(segmentKey(segment, variableId), true);
+        }
+      }
+    }
+
+    /**
+     * Checks a reference to a tracked variable, marking it handled on the
+     * current code path segments if this reference constitutes handling.
+     */
+    function checkTrackedVariableReference(node: TSESTree.Identifier): void {
+      const scope = context.sourceCode.getScope(node);
+      const variable = findVariable(scope, node);
+      if (variable == null) {
+        return;
+      }
+
+      const info = currentFuncInfo().trackedVariables.get(variable.$id);
+      if (info == null) {
+        return;
+      }
+
+      if (
+        isImmediatelyHandled(node) ||
+        isManualDisposeCall(node, info.disposeKind)
+      ) {
+        markHandled(variable.$id);
+      }
+    }
+
+    /**
+     * If `variableId`'s currently tracked disposable (if any) is still live
+     * (unhandled) on the current segments, it's about to be overwritten and
+     * lost -- report it immediately, since its fate can't depend on
+     * anything that happens after this point.
+     */
+    function reportIfOverwritingLiveTrackedVariable(variableId: number): void {
+      const info = currentFuncInfo();
+      const existing = info.trackedVariables.get(variableId);
+      if (existing == null) {
+        return;
+      }
+
+      const stillLive = [...info.currentSegments].some(
+        segment => !isHandledAtSegment(segment, existing, variableId),
+      );
+      if (stillLive) {
+        context.report({
+          node: existing.reportNode,
+          messageId: 'misusedDisposable',
+        });
+      }
+    }
+
+    /**
+     * Registers `id` as holding a not-yet-handled disposable as of the
+     * current segments, reporting first if this overwrites a previous live
+     * tracked disposable. If there's no conflicting overwrite, the new
+     * declaration point is merged into any existing tracked entry so that
+     * disposals/escapes reachable from either registration are honored.
+     */
+    function registerTrackedVariable(
+      id: TSESTree.Identifier,
+      disposeKind: DisposeKind,
+    ): void {
+      const scope = context.sourceCode.getScope(id);
+      const variable = findVariable(scope, id);
+      if (variable == null) {
+        return;
+      }
+
+      reportIfOverwritingLiveTrackedVariable(variable.$id);
+
+      const info = currentFuncInfo();
+      const existing = info.trackedVariables.get(variable.$id);
+      if (existing != null) {
+        existing.declaredSegments.push(...info.currentSegments);
+        existing.reportNode = id;
+        return;
+      }
+
+      info.trackedVariables.set(variable.$id, {
+        declaredSegments: [...info.currentSegments],
+        disposeKind,
+        reportNode: id,
+      });
+    }
+
+    /**
+     * Checks an assignment `id = <non-disposable value>`, reporting if `id`
+     * currently holds a live (unhandled) tracked disposable: that value is
+     * about to be overwritten and lost.
+     */
+    function checkAssignmentExpression(
+      node: TSESTree.AssignmentExpression,
+    ): void {
+      if (
+        node.operator !== '=' ||
+        node.left.type !== AST_NODE_TYPES.Identifier
+      ) {
+        return;
+      }
+
+      const type = services.getTypeAtLocation(node.right);
+      if (getDisposeKind(type) != null) {
+        // Handled by `checkProducedDisposable`, which also accounts for the
+        // possibility of overwriting a previously tracked disposable.
+        return;
+      }
+
+      const scope = context.sourceCode.getScope(node.left);
+      const variable = findVariable(scope, node.left);
+      if (variable == null) {
+        return;
+      }
+
+      reportIfOverwritingLiveTrackedVariable(variable.$id);
+      currentFuncInfo().trackedVariables.delete(variable.$id);
+    }
+
+    function checkProducedDisposable(node: TSESTree.Expression): void {
+      const type = services.getTypeAtLocation(node);
+      const disposeKind = getDisposeKind(type);
+      if (disposeKind == null) {
+        return;
+      }
+
+      if (isImmediatelyHandled(node)) {
+        return;
+      }
+
+      const target = traverseUpTransparentParents(node);
+      const { parent } = target;
+      if (
+        parent?.type === AST_NODE_TYPES.VariableDeclarator &&
+        parent.init === target &&
+        (parent.parent.kind === 'const' || parent.parent.kind === 'let') &&
+        parent.id.type === AST_NODE_TYPES.Identifier
+      ) {
+        registerTrackedVariable(parent.id, disposeKind);
+        return;
+      }
+
+      if (
+        parent?.type === AST_NODE_TYPES.AssignmentExpression &&
+        parent.operator === '=' &&
+        parent.right === target &&
+        parent.left.type === AST_NODE_TYPES.Identifier
+      ) {
+        registerTrackedVariable(parent.left, disposeKind);
+        return;
+      }
+
+      context.report({
+        node,
+        messageId: 'misusedDisposable',
+      });
+    }
+
+    /** Updates a single segment's "handled" state from its `prevSegments`. */
+    function updateHandledFromPrevSegments(
+      segment: TSESLint.CodePathSegment,
+      trackedVariables: Map<number, TrackedVariable>,
+    ): void {
+      for (const [variableId, variable] of trackedVariables) {
+        const handled =
+          segment.prevSegments.length > 0 &&
+          segment.prevSegments.every(prev =>
+            isHandledAtSegment(prev, variable, variableId),
+          );
+        if (handled) {
+          handledAtSegment.set(segmentKey(segment, variableId), true);
+        }
+      }
+    }
+
+    const codePathListeners: Partial<{
+      onCodePathEnd: (codePath: TSESLint.CodePath) => void;
+      onCodePathSegmentEnd: (segment: TSESLint.CodePathSegment) => void;
+      onCodePathSegmentLoop: (
+        fromSegment: TSESLint.CodePathSegment,
+        toSegment: TSESLint.CodePathSegment,
+      ) => void;
+      onCodePathSegmentStart: (segment: TSESLint.CodePathSegment) => void;
+      onCodePathStart: (codePath: TSESLint.CodePath) => void;
+      onUnreachableCodePathSegmentEnd: (
+        segment: TSESLint.CodePathSegment,
+      ) => void;
+      onUnreachableCodePathSegmentStart: (
+        segment: TSESLint.CodePathSegment,
+      ) => void;
+    }> = {
+      onCodePathEnd(codePath) {
+        const info = currentFuncInfo();
+        for (const [variableId, tracked] of info.trackedVariables) {
+          const allFinalSegmentsHandled = codePath.finalSegments.every(
+            segment => isHandledAtSegment(segment, tracked, variableId),
+          );
+          if (!allFinalSegmentsHandled) {
+            context.report({
+              node: tracked.reportNode,
+              messageId: 'misusedDisposable',
+            });
+          }
+        }
+        funcInfo = info.upper;
+      },
+      onCodePathSegmentEnd(segment) {
+        currentFuncInfo().currentSegments.delete(segment);
+      },
+      onCodePathSegmentLoop(fromSegment, toSegment) {
+        const info = currentFuncInfo();
+        info.codePath.traverseSegments(
+          { first: toSegment, last: fromSegment },
+          segment => {
+            updateHandledFromPrevSegments(segment, info.trackedVariables);
+          },
+        );
+      },
+      onCodePathSegmentStart(segment) {
+        const info = currentFuncInfo();
+        info.currentSegments.add(segment);
+        updateHandledFromPrevSegments(segment, info.trackedVariables);
+      },
+      onCodePathStart(codePath) {
+        funcInfo = {
+          codePath,
+          currentSegments: new Set(),
+          trackedVariables: new Map(),
+          upper: funcInfo,
+        };
+      },
+      onUnreachableCodePathSegmentEnd(segment) {
+        currentFuncInfo().currentSegments.delete(segment);
+      },
+      onUnreachableCodePathSegmentStart(segment) {
+        currentFuncInfo().currentSegments.add(segment);
+      },
+    };
+
+    return {
+      ...(codePathListeners as TSESLint.RuleListener),
+
+      'AssignmentExpression:exit': checkAssignmentExpression,
+      CallExpression: checkProducedDisposable,
+      'Identifier:exit': checkTrackedVariableReference,
+      NewExpression: checkProducedDisposable,
+    };
+  },
+});

--- a/packages/eslint-plugin/src/rules/no-misused-disposable.ts
+++ b/packages/eslint-plugin/src/rules/no-misused-disposable.ts
@@ -1,4 +1,5 @@
 import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
+import type { CodePathListener } from '@typescript-eslint/utils/ts-eslint';
 import type * as ts from 'typescript';
 
 import { AST_NODE_TYPES } from '@typescript-eslint/utils';
@@ -13,11 +14,16 @@ interface TrackedVariable {
   /** The segments active at the point the variable was declared. */
   declaredSegments: TSESLint.CodePathSegment[];
   disposeKind: DisposeKind;
+  /**
+   * Segments in which the variable was handled (disposed or escaped).
+   * Since a segment is a straight-line run of code, every execution that
+   * passes through such a segment handles the value.
+   */
+  handledSegmentIds: Set<string>;
   reportNode: TSESTree.Node;
 }
 
 interface FunctionInfo {
-  codePath: TSESLint.CodePath;
   currentSegments: Set<TSESLint.CodePathSegment>;
   /** Variables declared (and tracked) within this code path. */
   trackedVariables: Map<number, TrackedVariable>;
@@ -55,57 +61,35 @@ export default createRule({
 
     let funcInfo: FunctionInfo | null = null;
 
-    // Per-segment, per-tracked-variable "handled" state. Keyed by
-    // `${segment.id}:${variable.$id}`.
-    const handledAtSegment = new Map<string, boolean>();
-
     function currentFuncInfo(): FunctionInfo {
       return nullThrows(funcInfo, 'expected to be inside of a code path');
     }
 
-    function segmentKey(
-      segment: TSESLint.CodePathSegment,
-      variableId: number,
-    ): string {
-      return `${segment.id}:${String(variableId)}`;
-    }
-
-    /** Checks whether `target` is reachable from any of `from` by following `nextSegments`. */
-    function isSegmentReachableFromAny(
-      from: TSESLint.CodePathSegment[],
-      target: TSESLint.CodePathSegment,
-    ): boolean {
-      const visited = new Set<string>();
-      const stack = [...from];
+    /**
+     * Computes the set of segments that some execution path can reach with
+     * the tracked disposable still unhandled: forward reachability from the
+     * declaration site(s), stopped at any segment where the value was
+     * handled. Loops need no special treatment -- a cycle just stops
+     * expanding once its segments are visited.
+     */
+    function computeUnhandledSegmentIds(tracked: TrackedVariable): Set<string> {
+      const unhandled = new Set<string>();
+      const stack = tracked.declaredSegments.filter(
+        segment => !tracked.handledSegmentIds.has(segment.id),
+      );
       while (stack.length > 0) {
         const segment = nullThrows(stack.pop(), 'stack is non-empty');
-        if (segment === target) {
-          return true;
-        }
-        if (visited.has(segment.id)) {
+        if (unhandled.has(segment.id)) {
           continue;
         }
-        visited.add(segment.id);
-        stack.push(...segment.nextSegments);
+        unhandled.add(segment.id);
+        for (const next of segment.nextSegments) {
+          if (!tracked.handledSegmentIds.has(next.id)) {
+            stack.push(next);
+          }
+        }
       }
-      return false;
-    }
-
-    /**
-     * A segment is considered handled for `variableId`
-     * if the variable's declaration can't reach it (the variable was never
-     * live on that path, so there is nothing to require), or if it was
-     * explicitly marked handled.
-     */
-    function isHandledAtSegment(
-      segment: TSESLint.CodePathSegment,
-      variable: TrackedVariable,
-      variableId: number,
-    ): boolean {
-      return (
-        !isSegmentReachableFromAny(variable.declaredSegments, segment) ||
-        handledAtSegment.get(segmentKey(segment, variableId)) === true
-      );
+      return unhandled;
     }
 
     function getDisposeKind(type: ts.Type): DisposeKind | undefined {
@@ -294,12 +278,12 @@ export default createRule({
       });
     }
 
-    function markHandled(variableId: number): void {
+    function markHandled(tracked: TrackedVariable): void {
       for (const segment of currentFuncInfo().currentSegments) {
         // why is the segment.reachable check necessary?
         // No tests fail if it's removed.
         if (segment.reachable) {
-          handledAtSegment.set(segmentKey(segment, variableId), true);
+          tracked.handledSegmentIds.add(segment.id);
         }
       }
     }
@@ -324,15 +308,15 @@ export default createRule({
         isImmediatelyHandled(node) ||
         isManualDisposeCall(node, info.disposeKind)
       ) {
-        markHandled(variable.$id);
+        markHandled(info);
       }
     }
 
     /**
-     * If `variableId`'s currently tracked disposable (if any) is still live
-     * (unhandled) on the current segments, it's about to be overwritten and
-     * lost -- report it immediately, since its fate can't depend on
-     * anything that happens after this point.
+     * If `variableId`'s currently tracked disposable (if any) may still be
+     * live (unhandled) on some path reaching the current segments, it's
+     * about to be overwritten and lost -- report it immediately, since its
+     * fate can't depend on anything that happens after this point.
      */
     function reportIfOverwritingLiveTrackedVariable(variableId: number): void {
       const info = currentFuncInfo();
@@ -341,8 +325,9 @@ export default createRule({
         return;
       }
 
-      const stillLive = [...info.currentSegments].some(
-        segment => !isHandledAtSegment(segment, existing, variableId),
+      const unhandledSegmentIds = computeUnhandledSegmentIds(existing);
+      const stillLive = [...info.currentSegments].some(segment =>
+        unhandledSegmentIds.has(segment.id),
       );
       if (stillLive) {
         context.report({
@@ -375,6 +360,11 @@ export default createRule({
       const existing = info.trackedVariables.get(variable.$id);
       if (existing != null) {
         existing.declaredSegments.push(...info.currentSegments);
+        // The newly assigned value is not handled as of this point, even if
+        // the previous value was already handled within these segments.
+        for (const segment of info.currentSegments) {
+          existing.handledSegmentIds.delete(segment.id);
+        }
         existing.reportNode = id;
         return;
       }
@@ -382,6 +372,7 @@ export default createRule({
       info.trackedVariables.set(variable.$id, {
         declaredSegments: [...info.currentSegments],
         disposeKind,
+        handledSegmentIds: new Set(),
         reportNode: id,
       });
     }
@@ -463,46 +454,15 @@ export default createRule({
       });
     }
 
-    /** Updates a single segment's "handled" state from its `prevSegments`. */
-    function updateHandledFromPrevSegments(
-      segment: TSESLint.CodePathSegment,
-      trackedVariables: Map<number, TrackedVariable>,
-    ): void {
-      for (const [variableId, variable] of trackedVariables) {
-        const handled =
-          segment.prevSegments.length > 0 &&
-          segment.prevSegments.every(prev =>
-            isHandledAtSegment(prev, variable, variableId),
-          );
-        if (handled) {
-          handledAtSegment.set(segmentKey(segment, variableId), true);
-        }
-      }
-    }
-
-    const codePathListeners: Partial<{
-      onCodePathEnd: (codePath: TSESLint.CodePath) => void;
-      onCodePathSegmentEnd: (segment: TSESLint.CodePathSegment) => void;
-      onCodePathSegmentLoop: (
-        fromSegment: TSESLint.CodePathSegment,
-        toSegment: TSESLint.CodePathSegment,
-      ) => void;
-      onCodePathSegmentStart: (segment: TSESLint.CodePathSegment) => void;
-      onCodePathStart: (codePath: TSESLint.CodePath) => void;
-      onUnreachableCodePathSegmentEnd: (
-        segment: TSESLint.CodePathSegment,
-      ) => void;
-      onUnreachableCodePathSegmentStart: (
-        segment: TSESLint.CodePathSegment,
-      ) => void;
-    }> = {
+    const codePathListeners: CodePathListener = {
       onCodePathEnd(codePath) {
         const info = currentFuncInfo();
-        for (const [variableId, tracked] of info.trackedVariables) {
-          const allFinalSegmentsHandled = codePath.finalSegments.every(
-            segment => isHandledAtSegment(segment, tracked, variableId),
+        for (const tracked of info.trackedVariables.values()) {
+          const unhandledSegmentIds = computeUnhandledSegmentIds(tracked);
+          const someFinalSegmentUnhandled = codePath.finalSegments.some(
+            segment => unhandledSegmentIds.has(segment.id),
           );
-          if (!allFinalSegmentsHandled) {
+          if (someFinalSegmentUnhandled) {
             context.report({
               node: tracked.reportNode,
               messageId: 'misusedDisposable',
@@ -514,26 +474,14 @@ export default createRule({
       onCodePathSegmentEnd(segment) {
         currentFuncInfo().currentSegments.delete(segment);
       },
-      onCodePathSegmentLoop(fromSegment, toSegment) {
-        const info = currentFuncInfo();
-        info.codePath.traverseSegments(
-          { first: toSegment, last: fromSegment },
-          segment => {
-            updateHandledFromPrevSegments(segment, info.trackedVariables);
-          },
-        );
-      },
       onCodePathSegmentStart(segment) {
-        const info = currentFuncInfo();
-        info.currentSegments.add(segment);
-        updateHandledFromPrevSegments(segment, info.trackedVariables);
+        currentFuncInfo().currentSegments.add(segment);
       },
-      onCodePathStart(codePath) {
+      onCodePathStart() {
         funcInfo = {
-          codePath,
           currentSegments: new Set(),
           trackedVariables: new Map(),
-          upper: funcInfo,
+          upper: funcInfo, // previous funcInfo
         };
       },
       onUnreachableCodePathSegmentEnd(segment) {

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-misused-disposable.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-misused-disposable.shot
@@ -8,7 +8,7 @@ getDisposable();
 function foo() {
   const disposable = getDisposable();
         ~~~~~~~~~~ This value creates a Disposable that is not guaranteed to be disposed. It must be declared with 'using'/'await using', returned, passed to a function accepting a disposable, or explicitly disposed on every code path.
-  // `disposable` is never used again and never disposed
+  // `disposable` is never disposed
 }
 
 function bar() {
@@ -17,7 +17,7 @@ function bar() {
   if (Math.random() > 0.5) {
     disposable[Symbol.dispose]();
   }
-  // not handled on every path
+  // not disposed on every path
 }
 
 Correct
@@ -39,5 +39,60 @@ function bar() {
   }
 }
 
+function baz() {
+  const disposable = getDisposable();
+  if (Math.random() > 0.5) {
+    disposable[Symbol.dispose]();
+  } else {
+    disposable[Symbol.dispose]();
+  }
+}
+
 declare function acceptsDisposable(d: Disposable): void;
 acceptsDisposable(getDisposable());
+
+Incorrect
+
+function* generateNumbers() {
+  try {
+    yield 1;
+    yield 2;
+    yield 3;
+  } finally {
+    console.log('Cleaning up');
+  }
+}
+
+function doSomething() {
+  const numbers = generateNumbers();
+        ~~~~~~~ This value creates a Disposable that is not guaranteed to be disposed. It must be declared with 'using'/'await using', returned, passed to a function accepting a disposable, or explicitly disposed on every code path.
+  const res1 = numbers.next();
+  // The generator is never exhausted nor disposed,
+  // so "Cleaning up" is never logged.
+}
+
+Correct
+
+function* generateNumbers() {
+  try {
+    yield 1;
+    yield 2;
+    yield 3;
+  } finally {
+    console.log('Cleaning up');
+  }
+}
+
+function doSomething() {
+  using numbers = generateNumbers();
+  const res1 = numbers.next();
+  // Before the function exits, the iterator is disposed.
+  // Logs "Cleaning up".
+}
+
+function logAll() {
+  // Iteration runs the generator to completion, which also runs its cleanup.
+  for (const value of generateNumbers()) {
+    console.log(value);
+  }
+}

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-misused-disposable.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-misused-disposable.shot
@@ -1,0 +1,43 @@
+Incorrect
+
+declare function getDisposable(): Disposable;
+
+getDisposable();
+~~~~~~~~~~~~~~~ This value creates a Disposable that is not guaranteed to be disposed. It must be declared with 'using'/'await using', returned, passed to a function accepting a disposable, or explicitly disposed on every code path.
+
+function foo() {
+  const disposable = getDisposable();
+        ~~~~~~~~~~ This value creates a Disposable that is not guaranteed to be disposed. It must be declared with 'using'/'await using', returned, passed to a function accepting a disposable, or explicitly disposed on every code path.
+  // `disposable` is never used again and never disposed
+}
+
+function bar() {
+  const disposable = getDisposable();
+        ~~~~~~~~~~ This value creates a Disposable that is not guaranteed to be disposed. It must be declared with 'using'/'await using', returned, passed to a function accepting a disposable, or explicitly disposed on every code path.
+  if (Math.random() > 0.5) {
+    disposable[Symbol.dispose]();
+  }
+  // not handled on every path
+}
+
+Correct
+
+declare function getDisposable(): Disposable;
+
+using disposable = getDisposable();
+
+function foo() {
+  return getDisposable();
+}
+
+function bar() {
+  const disposable = getDisposable();
+  try {
+    // ...
+  } finally {
+    disposable[Symbol.dispose]();
+  }
+}
+
+declare function acceptsDisposable(d: Disposable): void;
+acceptsDisposable(getDisposable());

--- a/packages/eslint-plugin/tests/rules/no-misused-disposable.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-misused-disposable.test.ts
@@ -1,0 +1,497 @@
+import rule from '../../src/rules/no-misused-disposable';
+import { createRuleTesterWithTypes } from '../RuleTester';
+
+const ruleTester = createRuleTesterWithTypes();
+
+ruleTester.run('no-misused-disposable', rule, {
+  valid: [
+    `
+declare function makeDisposable(): Disposable;
+using foo = makeDisposable();
+    `,
+    `
+declare function makeAsyncDisposable(): AsyncDisposable;
+async function test() {
+  await using foo = makeAsyncDisposable();
+}
+    `,
+    `
+declare function makeDisposable(): Disposable;
+new (class {
+  constructor() {
+    using foo = makeDisposable();
+  }
+})();
+    `,
+    `
+declare function makeDisposable(): Disposable;
+function foo() {
+  return makeDisposable();
+}
+    `,
+    `
+declare function makeDisposable(): Disposable;
+function foo() {
+  const x = makeDisposable();
+  return x;
+}
+    `,
+    // passed as an argument to a function accepting a disposable
+    `
+declare function makeDisposable(): Disposable;
+declare function acceptsDisposable(d: Disposable): void;
+acceptsDisposable(makeDisposable());
+    `,
+    `
+declare function makeDisposable(): Disposable;
+declare function acceptsDisposable(d: Disposable): void;
+function foo() {
+  const x = makeDisposable();
+  acceptsDisposable(x);
+}
+    `,
+    `
+declare function makeDisposable(): Disposable;
+declare function doSomething(): void;
+
+function foo() {
+  const x = makeDisposable();
+  try {
+    doSomething();
+  } finally {
+    x[Symbol.dispose]();
+  }
+}
+    `,
+    `
+declare function makeAsyncDisposable(): AsyncDisposable;
+declare function doSomething(): void;
+
+async function foo() {
+  const x = makeAsyncDisposable();
+  try {
+    doSomething();
+  } finally {
+    await x[Symbol.asyncDispose]();
+  }
+}
+    `,
+    `
+declare function makeDisposable(): Disposable;
+function foo() {
+  const x = makeDisposable();
+  if (Math.random() > 0.5) {
+    return x;
+  }
+  return x;
+}
+    `,
+    `
+declare function makeDisposable(): Disposable;
+
+function foo() {
+  const x = makeDisposable();
+  if (Math.random() > 0.5) {
+    x[Symbol.dispose]();
+    return;
+  }
+  return x;
+}
+    `,
+    `
+declare function makeThing(): { a: string };
+declare function acceptsDisposable(d: Disposable): void;
+acceptsDisposable(makeThing());
+    `,
+    `
+declare function makeDisposable(): Disposable;
+declare const cond: boolean;
+
+using foo = cond ? makeDisposable() : makeDisposable();
+    `,
+    `
+declare function f(): void;
+declare function makeDisposable(): Disposable;
+using foo = (f(), makeDisposable());
+    `,
+    `
+declare function makeDisposable(): Disposable;
+declare const cond: boolean;
+using foo = cond && makeDisposable();
+    `,
+    `
+declare function makeDisposable(): Disposable;
+declare const cond: boolean;
+using foo = cond || makeDisposable();
+    `,
+    `
+declare function makeDisposable(): Disposable | undefined;
+declare const cond: boolean;
+using foo = makeDisposable() || cond;
+    `,
+    `
+declare function makeDisposable(): Disposable;
+declare const cond: boolean;
+using foo = makeDisposable() || cond;
+    `,
+    `
+declare function makeDisposable(): Disposable | undefined;
+declare const cond: boolean;
+using foo = makeDisposable() || makeDisposable();
+    `,
+    `
+declare function makeDisposable(): Disposable;
+const foo = () => {
+  return makeDisposable();
+};
+    `,
+    `
+declare function makeDisposable(): Disposable;
+class Foo {
+  method() {
+    return makeDisposable();
+  }
+}
+    `,
+    `
+declare function makeDisposable(): Disposable;
+function foo(items: number[]) {
+  for (const item of items) {
+    const x = makeDisposable();
+    x[Symbol.dispose]();
+  }
+}
+    `,
+    `
+declare function makeDisposable(): Disposable;
+function foo(x: number) {
+  switch (x) {
+    case 1: {
+      const d1 = makeDisposable();
+      d1[Symbol.dispose]();
+      break;
+    }
+    default: {
+      const d2 = makeDisposable();
+      return d2;
+    }
+  }
+}
+    `,
+    `
+declare function makeDisposable(): Disposable;
+declare const cond: true | undefined;
+const foo = cond && makeDisposable();
+foo?.[Symbol.dispose]();
+    `,
+    `
+declare function makeDisposable(): Disposable;
+let foo = makeDisposable();
+foo[Symbol.dispose]();
+    `,
+    `
+declare function makeDisposable(): Disposable;
+function outer() {
+  const x = makeDisposable();
+  function inner() {
+    return x;
+  }
+  return x;
+}
+    `,
+
+    `
+declare function makeDisposable(): Disposable;
+function foo(items: number[]) {
+  for (const item of items) {
+    const x = makeDisposable();
+    if (item > 0) {
+      x[Symbol.dispose]();
+    } else {
+      return x;
+    }
+  }
+}
+    `,
+    `
+declare function makeDisposable(): Disposable;
+let foo;
+if (Math.random() > 0.5) {
+  foo = makeDisposable();
+} else {
+  foo = makeDisposable();
+}
+foo[Symbol.dispose]();
+    `,
+    `
+declare function makeDisposable(): Disposable;
+let foo;
+if (Math.random() > 0.5) {
+  foo = makeDisposable();
+} else {
+  foo = makeDisposable();
+}
+using bar = foo;
+    `,
+    `
+declare function makeDisposable(): Disposable;
+const foo = makeDisposable();
+using bar = foo;
+    `,
+  ],
+  invalid: [
+    {
+      code: `
+declare function makeDisposable(): Disposable;
+makeDisposable();
+      `,
+      errors: [{ messageId: 'misusedDisposable' }],
+    },
+    {
+      code: `
+declare function makeDisposable(): Disposable;
+const foo = makeDisposable();
+      `,
+      errors: [{ messageId: 'misusedDisposable' }],
+    },
+    {
+      code: `
+declare function makeDisposable(): Disposable;
+let foo = makeDisposable();
+      `,
+      errors: [{ messageId: 'misusedDisposable' }],
+    },
+    {
+      code: `
+interface MyDisposable extends Disposable {
+  prop: string;
+}
+declare function makeDisposable(): MyDisposable;
+makeDisposable().prop;
+      `,
+      errors: [{ messageId: 'misusedDisposable' }],
+    },
+    {
+      code: `
+declare function makeDisposable(): Disposable;
+declare function acceptsAnything(v: unknown): void;
+acceptsAnything(makeDisposable());
+      `,
+      errors: [{ messageId: 'misusedDisposable' }],
+    },
+    {
+      code: `
+declare function makeDisposable(): Disposable;
+function foo() {
+  const x = makeDisposable();
+  if (Math.random() > 0.5) {
+    return x;
+  }
+}
+      `,
+      errors: [{ messageId: 'misusedDisposable' }],
+    },
+    {
+      code: `
+declare function makeDisposable(): Disposable;
+function foo() {
+  const x = makeDisposable();
+  if (Math.random() > 0.5) {
+    x[Symbol.dispose]();
+  }
+}
+      `,
+      errors: [{ messageId: 'misusedDisposable' }],
+    },
+    {
+      code: `
+declare function makeDisposable(): Disposable;
+function outer() {
+  const x = makeDisposable();
+  function inner() {
+    return x;
+  }
+}
+      `,
+      errors: [{ messageId: 'misusedDisposable' }],
+    },
+    {
+      code: `
+interface MyDisposable extends Disposable {
+  prop: string;
+}
+declare function makeDisposable(): MyDisposable;
+function foo() {
+  const x = makeDisposable();
+  console.log(x.prop);
+}
+      `,
+      errors: [{ messageId: 'misusedDisposable' }],
+    },
+    {
+      code: `
+declare class MyDisposable implements Disposable {
+  [Symbol.dispose](): void;
+}
+new MyDisposable();
+      `,
+      errors: [{ messageId: 'misusedDisposable' }],
+    },
+    {
+      code: `
+declare function makeDisposable(): Disposable;
+function foo(items: number[]) {
+  for (const item of items) {
+    const x = makeDisposable();
+    if (item > 0) {
+      continue;
+    }
+    x[Symbol.dispose]();
+  }
+}
+      `,
+      errors: [{ messageId: 'misusedDisposable' }],
+    },
+    {
+      code: `
+declare function makeDisposable(): Disposable;
+function foo(x: number) {
+  switch (x) {
+    case 1: {
+      const d1 = makeDisposable();
+      break;
+    }
+    default: {
+      const d2 = makeDisposable();
+      return d2;
+    }
+  }
+}
+      `,
+      errors: [{ messageId: 'misusedDisposable' }],
+    },
+    {
+      code: `
+declare function makeDisposable(): Disposable;
+function foo(items: number[]) {
+  for (const item of items) {
+    const x = makeDisposable();
+    if (item > 0) {
+      x[Symbol.dispose]();
+    }
+  }
+}
+      `,
+      errors: [{ messageId: 'misusedDisposable' }],
+    },
+    {
+      code: `
+declare function makeDisposable(): Disposable;
+function foo(items: number[]) {
+  for (const item of items) {
+    const x = makeDisposable();
+  }
+}
+      `,
+      errors: [{ messageId: 'misusedDisposable' }],
+    },
+    {
+      code: `
+declare function makeDisposable(): Disposable;
+function foo(items: number[]) {
+  for (const item of items) {
+    makeDisposable();
+  }
+}
+      `,
+      errors: [{ messageId: 'misusedDisposable' }],
+    },
+    {
+      code: `
+declare function f(): void;
+declare function makeDisposable(): Disposable;
+using foo = (makeDisposable(), f());
+      `,
+      errors: [{ messageId: 'misusedDisposable' }],
+    },
+    {
+      code: `
+declare function makeDisposable(): Disposable;
+declare const cond: boolean;
+using foo = makeDisposable() && cond;
+      `,
+      errors: [{ messageId: 'misusedDisposable' }],
+    },
+    {
+      code: `
+declare function makeDisposable(): Disposable;
+class Foo {
+  method(): unknown {
+    return makeDisposable();
+  }
+}
+      `,
+      errors: [{ messageId: 'misusedDisposable' }],
+    },
+    {
+      code: `
+declare function makeDisposable(): Disposable;
+let foo = makeDisposable();
+foo = makeDisposable();
+foo[Symbol.dispose]();
+      `,
+      errors: [{ messageId: 'misusedDisposable' }],
+    },
+    {
+      code: `
+declare function makeDisposable(): Disposable;
+let foo;
+if (Math.random() > 0.5) {
+  foo = makeDisposable();
+} else {
+  foo = makeDisposable();
+}
+if (Math.random() > 0.5) {
+  foo = 42;
+}
+
+using bar = foo;
+      `,
+      errors: [{ messageId: 'misusedDisposable' }],
+    },
+    {
+      code: `
+declare function makeDisposable(): Disposable;
+let foo;
+if (Math.random() > 0.5) {
+  foo = makeDisposable();
+} else {
+  foo = makeDisposable();
+}
+if (Math.random() > 0.5) {
+  foo = makeDisposable();
+}
+
+using bar = foo;
+      `,
+      errors: [{ messageId: 'misusedDisposable' }],
+    },
+    {
+      code: `
+declare function makeDisposable(): Disposable;
+let foo;
+if (Math.random() > 0.5) {
+  foo = makeDisposable();
+} else {
+  foo = makeDisposable();
+}
+if (Math.random() > 0.5) {
+  throw new Error('oops');
+}
+
+using bar = foo;
+      `,
+      errors: [{ messageId: 'misusedDisposable' }],
+    },
+  ],
+});

--- a/packages/eslint-plugin/tests/rules/no-misused-disposable.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-misused-disposable.test.ts
@@ -56,10 +56,61 @@ declare function doSomething(): void;
 
 function foo() {
   const x = makeDisposable();
+  doSomething();
+  x[Symbol.dispose]();
+}
+    `,
+    // regression test for control flow bug when a loop follows the disposal
+    `
+declare function makeDisposable(): Disposable;
+declare function doSomething(): void;
+
+function foo() {
+  const x = makeDisposable();
+  doSomething();
+  x[Symbol.dispose]();
+
+  for (const item of [1, 2, 3]) {
+  }
+}
+    `,
+    `
+declare function makeDisposable(): Disposable;
+declare function doSomething(): void;
+
+function foo() {
+  const x = makeDisposable();
   try {
     doSomething();
   } finally {
     x[Symbol.dispose]();
+  }
+}
+    `,
+    `
+declare function makeDisposable(): Disposable;
+declare function doSomething(): void;
+
+function foo() {
+  const x = makeDisposable();
+  try {
+    doSomething();
+  } finally {
+    x?.[Symbol.dispose]?.();
+  }
+}
+    `,
+    `
+declare function makeDisposable(): Disposable;
+declare function doSomething(): void;
+const symbolDisposeAlias = Symbol.dispose;
+
+function foo() {
+  const x = makeDisposable();
+  try {
+    doSomething();
+  } finally {
+    x[symbolDisposeAlias]();
   }
 }
     `,
@@ -236,6 +287,50 @@ using bar = foo;
     `
 declare function makeDisposable(): Disposable;
 const foo = makeDisposable();
+using bar = foo;
+    `,
+    `
+declare function makeDisposable(): Disposable;
+
+using d = makeDisposable() satisfies {};
+    `,
+    `
+declare function makeDisposable(): Disposable;
+
+using d = makeDisposable() as {};
+    `,
+    // member accesses aren't considered to have "produced" a disposable,
+    // just accessed it
+    `
+declare const o: { d: Disposable };
+console.log(o.d);
+    `,
+    `
+declare function makeDisposable(): Disposable;
+let foo;
+if (Math.random() > 0.5) {
+  foo = makeDisposable();
+} else {
+  foo = makeDisposable();
+}
+if (Math.random() > 0.5) {
+  foo ||= 42;
+}
+
+using bar = foo;
+    `,
+    `
+declare function makeDisposable(): Disposable;
+let foo;
+if (Math.random() > 0.5) {
+  foo = makeDisposable();
+} else {
+  foo = makeDisposable();
+}
+if (Math.random() > 0.5) {
+  foo ??= 42;
+}
+
 using bar = foo;
     `,
   ],
@@ -469,6 +564,23 @@ if (Math.random() > 0.5) {
   foo = makeDisposable();
 }
 if (Math.random() > 0.5) {
+  foo &&= 42;
+}
+
+using bar = foo;
+      `,
+      errors: [{ messageId: 'misusedDisposable' }],
+    },
+    {
+      code: `
+declare function makeDisposable(): Disposable;
+let foo;
+if (Math.random() > 0.5) {
+  foo = makeDisposable();
+} else {
+  foo = makeDisposable();
+}
+if (Math.random() > 0.5) {
   foo = makeDisposable();
 }
 
@@ -490,6 +602,31 @@ if (Math.random() > 0.5) {
 }
 
 using bar = foo;
+      `,
+      errors: [{ messageId: 'misusedDisposable' }],
+    },
+    {
+      code: `
+declare function makeDisposable(): Disposable;
+declare function acceptsAsyncDisposable(d: AsyncDisposable): void;
+
+acceptsAsyncDisposable(makeDisposable());
+      `,
+      errors: [{ messageId: 'misusedDisposable' }],
+    },
+    {
+      code: `
+declare function makeDisposable(): Disposable;
+
+makeDisposable() satisfies {};
+      `,
+      errors: [{ messageId: 'misusedDisposable' }],
+    },
+    {
+      code: `
+declare function makeDisposable(): Disposable;
+
+makeDisposable() as {};
       `,
       errors: [{ messageId: 'misusedDisposable' }],
     },

--- a/packages/eslint-plugin/tests/rules/no-misused-disposable.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-misused-disposable.test.ts
@@ -333,6 +333,161 @@ if (Math.random() > 0.5) {
 
 using bar = foo;
     `,
+    // iteration handles disposable iterables: for...of
+    `
+interface IterableDisposable extends Disposable, Iterable<number> {}
+declare function makeIterableDisposable(): IterableDisposable;
+for (const x of makeIterableDisposable()) {
+  console.log(x);
+}
+    `,
+    `
+interface IterableDisposable extends Disposable, Iterable<number> {}
+declare function makeIterableDisposable(): IterableDisposable;
+const it = makeIterableDisposable();
+for (const x of it) {
+  console.log(x);
+}
+    `,
+    // for await...of handles sync-disposable async-iterables
+    `
+interface AsyncIterableDisposable extends Disposable, AsyncIterable<number> {}
+declare function makeAsyncIterableDisposable(): AsyncIterableDisposable;
+async function f() {
+  for await (const x of makeAsyncIterableDisposable()) {
+    console.log(x);
+  }
+}
+    `,
+    // for await...of also handles sync iterables
+    `
+interface IterableDisposable extends Disposable, Iterable<number> {}
+declare function makeIterableDisposable(): IterableDisposable;
+async function f() {
+  const it = makeIterableDisposable();
+  for await (const x of it) {
+    console.log(x);
+  }
+}
+    `,
+    // array spread
+    `
+interface IterableDisposable extends Disposable, Iterable<number> {}
+declare function makeIterableDisposable(): IterableDisposable;
+const arr = [...makeIterableDisposable()];
+    `,
+    `
+interface IterableDisposable extends Disposable, Iterable<number> {}
+declare function makeIterableDisposable(): IterableDisposable;
+const it = makeIterableDisposable();
+const arr = [...it];
+    `,
+    // array destructuring
+    `
+interface IterableDisposable extends Disposable, Iterable<number> {}
+declare function makeIterableDisposable(): IterableDisposable;
+const [...nums] = makeIterableDisposable();
+    `,
+    `
+interface IterableDisposable extends Disposable, Iterable<number> {}
+declare function makeIterableDisposable(): IterableDisposable;
+const it = makeIterableDisposable();
+const [first] = it;
+    `,
+    // partial (even empty) destructuring closes the iterator via
+    // IteratorClose, the same way an early \`break\` out of \`for...of\` does
+    `
+interface IterableDisposable extends Disposable, Iterable<number> {}
+declare function makeIterableDisposable(): IterableDisposable;
+const [] = makeIterableDisposable();
+    `,
+    // array destructuring assignment
+    `
+interface IterableDisposable extends Disposable, Iterable<number> {}
+declare function makeIterableDisposable(): IterableDisposable;
+const it = makeIterableDisposable();
+let first;
+[first] = it;
+    `,
+    // call and new argument spread
+    `
+interface IterableDisposable extends Disposable, Iterable<number> {}
+declare function makeIterableDisposable(): IterableDisposable;
+declare function sum(...nums: number[]): number;
+sum(...makeIterableDisposable());
+    `,
+    `
+interface IterableDisposable extends Disposable, Iterable<number> {}
+declare function makeIterableDisposable(): IterableDisposable;
+declare function sum(...nums: number[]): number;
+const it = makeIterableDisposable();
+sum(...it);
+    `,
+    `
+interface IterableDisposable extends Disposable, Iterable<number> {}
+declare function makeIterableDisposable(): IterableDisposable;
+class Holder {
+  constructor(...nums: number[]) {}
+}
+new Holder(...makeIterableDisposable());
+    `,
+    // yield* delegation
+    `
+interface IterableDisposable extends Disposable, Iterable<number> {}
+declare function makeIterableDisposable(): IterableDisposable;
+function* gen() {
+  yield* makeIterableDisposable();
+}
+    `,
+    `
+interface AsyncIterableDisposable extends Disposable, AsyncIterable<number> {}
+declare function makeAsyncIterableDisposable(): AsyncIterableDisposable;
+async function* gen() {
+  yield* makeAsyncIterableDisposable();
+}
+    `,
+    // async-disposable sync-iterables are handled by sync iteration too
+    `
+interface IterableAsyncDisposable extends AsyncDisposable, Iterable<number> {}
+declare function makeIterableAsyncDisposable(): IterableAsyncDisposable;
+for (const x of makeIterableAsyncDisposable()) {
+  console.log(x);
+}
+    `,
+    // async-disposable async-iterables are handled by async iteration
+    `
+interface AsyncIterableAsyncDisposable
+  extends AsyncDisposable, AsyncIterable<number> {}
+declare function makeAsyncIterableAsyncDisposable(): AsyncIterableAsyncDisposable;
+async function f() {
+  for await (const x of makeAsyncIterableAsyncDisposable()) {
+    console.log(x);
+  }
+}
+    `,
+    // a manually-advanced generator, correctly managed with \`using\`, from
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/Symbol.dispose
+    `
+function* generateNumbers() {
+  try {
+    yield 1;
+    yield 2;
+    yield 3;
+  } finally {
+    console.log('Cleaning up');
+  }
+}
+
+function doSomething() {
+  using numbers = generateNumbers();
+  const res1 = numbers.next();
+  // Not iterating the rest of the numbers
+  // Before the function exits, the iterator is disposed
+  // Logs "Cleaning up"
+}
+
+doSomething();
+    `,
   ],
   invalid: [
     {
@@ -627,6 +782,57 @@ makeDisposable() satisfies {};
 declare function makeDisposable(): Disposable;
 
 makeDisposable() as {};
+      `,
+      errors: [{ messageId: 'misusedDisposable' }],
+    },
+    // object spread copies properties; it does not iterate
+    {
+      code: `
+interface IterableDisposable extends Disposable, Iterable<number> {}
+declare function makeIterableDisposable(): IterableDisposable;
+const obj = { ...makeIterableDisposable() };
+      `,
+      errors: [{ messageId: 'misusedDisposable' }],
+    },
+    // sync iteration does not handle an async-only iterable
+    {
+      code: `
+interface AsyncIterableDisposable extends Disposable, AsyncIterable<number> {}
+declare function makeAsyncIterableDisposable(): AsyncIterableDisposable;
+const arr = [...makeAsyncIterableDisposable()];
+      `,
+      errors: [{ messageId: 'misusedDisposable' }],
+    },
+    // a disposable iterable that is never iterated is still misused
+    {
+      code: `
+interface IterableDisposable extends Disposable, Iterable<number> {}
+declare function makeIterableDisposable(): IterableDisposable;
+const it = makeIterableDisposable();
+      `,
+      errors: [{ messageId: 'misusedDisposable' }],
+    },
+    // manually advancing a generator with .next() is not iteration syntax;
+    // without \`using\`, the generator's cleanup never runs. This is the
+    // mistake the MDN Iterator[Symbol.dispose] example exists to prevent.
+    {
+      code: `
+function* generateNumbers() {
+  try {
+    yield 1;
+    yield 2;
+    yield 3;
+  } finally {
+    console.log('Cleaning up');
+  }
+}
+
+function doSomething() {
+  const numbers = generateNumbers();
+  const res1 = numbers.next();
+}
+
+doSomething();
       `,
       errors: [{ messageId: 'misusedDisposable' }],
     },

--- a/packages/eslint-plugin/tests/schema-snapshots/no-misused-disposable.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-misused-disposable.shot
@@ -1,0 +1,10 @@
+
+# SCHEMA:
+
+[]
+
+
+# TYPES:
+
+/** No options declared */
+type Options = [];

--- a/packages/utils/src/ts-eslint/Rule.ts
+++ b/packages/utils/src/ts-eslint/Rule.ts
@@ -738,6 +738,58 @@ export interface RuleListenerExtension {
   */
 }
 
+/**
+ * These methods exist on the {@link RuleListener} object in ESLint, but are intentionally omitted from the RuleListener
+ * type because they cause unresolvable compiler errors: https://github.com/typescript-eslint/typescript-eslint/issues/6993
+ *
+ * Consider merging the objects like so to satisfy the type system:
+ *
+ * ```ts
+ * export default createRule({
+ *   // ...
+ *   create(context) {
+ *     const codePathListener: CodePathListener = {
+ *       onCodePathStart(codePath, node) {
+ *         // ...
+ *       },
+ *       onCodePathEnd(codePath, node) {
+ *         // ...
+ *       },
+ *     };
+ *
+ *     return {
+ *       ...(codePathListener as TSESLint.RuleListener),
+ *
+ *       ExpressionStatement(node) {
+ *         // ...
+ *       },
+ *       // other selectors...
+ *     };
+ *   },
+ * });
+ * ```
+ */
+export interface CodePathListener {
+  onCodePathStart?: (codePath: CodePath, node: TSESTree.Node) => void;
+  onCodePathEnd?: (codePath: CodePath, node: TSESTree.Node) => void;
+  onCodePathSegmentEnd?: (
+    segment: CodePathSegment,
+    node: TSESTree.Node,
+  ) => void;
+  onCodePathSegmentStart?: (
+    segment: CodePathSegment,
+    node: TSESTree.Node,
+  ) => void;
+  onUnreachableCodePathSegmentEnd?: (
+    segment: CodePathSegment,
+    node: TSESTree.Node,
+  ) => void;
+  onUnreachableCodePathSegmentStart?: (
+    segment: CodePathSegment,
+    node: TSESTree.Node,
+  ) => void;
+}
+
 export type RuleListener = RuleListenerBaseSelectors &
   RuleListenerCatchAllBaseCase &
   RuleListenerExitSelectors;

--- a/packages/utils/src/ts-eslint/Rule.ts
+++ b/packages/utils/src/ts-eslint/Rule.ts
@@ -393,6 +393,22 @@ export interface RuleContext<
   report(descriptor: ReportDescriptor<MessageIds>): void;
 }
 
+export interface CodePathSegmentTraversalController {
+  skip(): void;
+  break(): void;
+}
+
+export type CodePathSegmentTraversalCallback = (
+  this: CodePath,
+  segment: CodePathSegment,
+  controller: CodePathSegmentTraversalController,
+) => void;
+
+export interface CodePathTraversalOptions {
+  first?: CodePathSegment | undefined;
+  last?: CodePathSegment | undefined;
+}
+
 /**
  * Part of the code path analysis feature of ESLint:
  * https://eslint.org/docs/latest/extend/code-path-analysis
@@ -432,6 +448,15 @@ export interface CodePath {
 
   /** The code path of the upper function/global scope. */
   upper: CodePath | null;
+
+  traverseSegments(
+    options: CodePathTraversalOptions,
+    callback: (
+      this: CodePath,
+      segment: CodePathSegment,
+      controller: CodePathSegmentTraversalCallback,
+    ) => void,
+  ): void;
 }
 
 /**

--- a/packages/utils/src/ts-eslint/Rule.ts
+++ b/packages/utils/src/ts-eslint/Rule.ts
@@ -451,11 +451,7 @@ export interface CodePath {
 
   traverseSegments(
     options: CodePathTraversalOptions,
-    callback: (
-      this: CodePath,
-      segment: CodePathSegment,
-      controller: CodePathSegmentTraversalCallback,
-    ) => void,
+    callback: CodePathSegmentTraversalCallback,
   ): void;
 }
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #8255 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [ ] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)
   - *_This PR currently contains a lot of AI slop! This is intentional. It's in prototype stage for now, for reviewers to comment on viability and limitations of the rule, not intended for final review yet. I did handwrite quite a few of the test cases, especially as I found various mistakes in the implementation. I also had the AI generate a good chunk of test cases._*

## Overview

I hacked away at this with Claude to see if such a rule is practical. I would encourage checking the branch out and playing with the rule to see what you think, especially regarding unresolved lint reports.

If the rule seems viable, and we finish speccing it out, I'll go in and deslopify the PR.

At a high level, this rule implements the ideas discussed in #8255.
- `using disposable = makeDisposable();` marks the disposable as used.
- `makeDisposable()[Symbol.dispose]();` marks the disposable as used.
- `return makeDisposable()` (in a disposable-returning function) marks the disposable as used
- `acceptsDisposable(makeDisposable())` marks the disposable as used

and one of these must occur in every reachable code path.

- `makeDisposable().property` does _not_ handle a disposable.
- `foo.disposableProperty` does _not_ "produce" a disposable. Only function/constructor calls "produce" a new disposable that needs to be handled.
- Things like `makeDisposable1() || makeDisposable2()` and similar operators are correctly handled, I think. In the `||` case, the overall node produces a disposable that must be handled, no matter which branch it's from, _because disposables are always truthy_. Similarly, `makeDisposable() && whatever` is _never valid_, because if a disposable is produced from `makeDisposable()`, it is immediately floating/unhandled, because it would always be truthy, and would be discarded by the `&&`.
- I made `makeDisposable() satisfies WhateverType;` be considered unhandled (unless of course the overall expression is handled), since the `satisfies` expression just transparently passes the value through without changing the type.
- I made `makeDisposable() as WhateverType;` the same as `satisfies` for now, but I think that's probably incorrect. `foo() as SomeDisposable` should probably "produce" a disposable, and `makeDisposable() as NotADisposable` should probably "handle" the disposable (due to asserting it never was a disposable).

Some big findings:
1. [All built-in iterators are Disposable nowadays](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/Symbol.dispose) (this was a surprise to me). Therefore, iteration is a valid way of handling iterable disposables.
   - `Array.from(iterable)` isn't implemented yet, but all the bult-in syntaxes, i.e. `for...of`, `const [foo] = iterable`, `yield* iterable`, etc. are handled.
   - The disposable iterators situation _also applies to iterator helpers_. So, something like 
      ```ts
      [1, 2, 3].values().map(value => value + 1).find(value => value === 2);
      ```
      causes many lint reports for now. This is something we'll have to find a way to handle. 
1. Some node.js types do not play well with this rule.
   - `setTimeout()` being disposable is a prime example
   - But also _each line_ of 
      ```ts
       const child = childProcess.spawn(command, args, {
         ...options,
         shell: process.platform === 'win32',
         stdio: 'inherit',
       });

       child.on('error', e => reject(e));
       child.on('exit', () => resolve());
       child.on('close', () => resolve());
       ``` 
       causes a report, since each line returns a disposable.
      
1. We have _lots_ of lint reports in the test code, since lots of the vitest spy/mock objects are disposable. I haven't dug deeply into whether we reasonably could/should refactor the tests to use disposable style, or whether they should be considered problematic false positives. 

1. To address some of the above issues, I wonder whether we should use a heuristic, along the lines of: `disposable.methodReturnsDisposable()` should _not_ be considered a new disposable needing to be handled for the sake of this rule. As long as _either_ `disposable` or `disposable.methodReturnsDisposable()` is handled, both are considered handled. (This would address the `child.on()` calls, and most of the iterator helpers).
1. We probably need to hardcode iterator helpers terminal methods, i.e. `.find()`, `.reduce()`, etc.