### PR TITLE
feat(utils): support ESLint rule meta.languages

### DIFF
--- a/packages/utils/src/ts-eslint/Rule.ts
+++ b/packages/utils/src/ts-eslint/Rule.ts
@@ -136,6 +136,15 @@ export interface RuleMetaData<
   type: 'layout' | 'problem' | 'suggestion';
 
   /**
+   * Languages supported by this rule in the format `"plugin/language"`.
+   * Use `"*"` for any language or `"plugin/*"` for any language from a specific plugin.
+   *
+   * @example
+   * ['js/js', 'markdown/gfm', 'json/jsonc', 'css/css']
+   */
+  languages?: string[] | undefined;
+
+  /**
    * Specifies default options for the rule. If present, any user-provided options in their config will be merged on top of them recursively.
    * This merging will be applied directly to `context.options`.
    * If you want backwards-compatible support for earlier ESLint version, consider using the top-level `defaultOptions` instead.

--- a/packages/utils/tests/eslint-utils/RuleCreator.test.ts
+++ b/packages/utils/tests/eslint-utils/RuleCreator.test.ts
@@ -21,6 +21,7 @@ describe(ESLintUtils.RuleCreator, () => {
           description: 'some description',
           recommended: 'yes',
         },
+        languages: ['js/js'],
         messages: {
           foo: 'some message',
         },
@@ -35,6 +36,7 @@ describe(ESLintUtils.RuleCreator, () => {
         recommended: 'yes',
         url: 'test/test',
       },
+      languages: ['js/js'],
       messages: {
         foo: 'some message',
       },


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #~12662~
- [x] That issue was marked as accepting prs
- [x] Steps in Contributing were taken
- [x] If this PR used AI assistance, I followed the AI Contribution Policy

## Overview

ESLint supports language-aware rules through `meta.languages`, but
`@typescript-eslint/utils` did not expose the property in `RuleMetaData`.
This change adds the optional `languages` field with the same
`plugin/language` format used by ESLint, including wildcard forms, and adds a
`RuleCreator` regression assertion to ensure the metadata is preserved.

## Validation

- `utils:typecheck`
- focused `RuleCreator` test
- full `utils:test` — 9 files, 57 tests passed
- changed-file ESLint
- Prettier
- `git diff --check`

The full `nx lint utils` target was not completed because Nx remained in daemon
wait; direct ESLint on the changed files passed.
