### PR TITLE
fix(website): report TSConfig isolatedDeclarations errors in playground

### DIFF
--- a/packages/website/src/components/editor/LoadedEditor.tsx
+++ b/packages/website/src/components/editor/LoadedEditor.tsx
@@ -127,11 +127,13 @@ export const LoadedEditor: React.FC<LoadedEditorProps> = ({
   useEffect(() => {
     const config = createCompilerOptions(
       parseTSConfig(tsconfig).compilerOptions,
+      fileType,
     );
     monaco.languages.typescript.typescriptDefaults.setCompilerOptions(
       config as Monaco.languages.typescript.CompilerOptions,
     );
-  }, [monaco, tsconfig]);
+    webLinter.updateFileType(fileType);
+  }, [fileType, monaco, tsconfig, webLinter]);
 
   useEffect(() => {
     if (editor.getModel()?.uri.path !== tabs[activeTab].uri.path) {

--- a/packages/website/src/components/editor/useSandboxServices.ts
+++ b/packages/website/src/components/editor/useSandboxServices.ts
@@ -12,6 +12,7 @@ import type { CommonEditorProps } from './types';
 
 import { createCompilerOptions } from '../lib/createCompilerOptions';
 import { createEventsBinder } from '../lib/createEventsBinder';
+import { parseTSConfig } from '../lib/parseConfig';
 import { createFileSystem } from '../linter/bridge';
 import { createLinter } from '../linter/createLinter';
 import { createTwoslashInlayProvider } from './createProvideTwoslashInlay';
@@ -46,7 +47,10 @@ export const useSandboxServices = (
 
     sandboxSingleton(props.ts)
       .then(async ({ lintUtils, main, sandboxFactory }) => {
-        const compilerOptions = createCompilerOptions();
+        const compilerOptions = createCompilerOptions(
+          parseTSConfig(props.tsconfig).compilerOptions,
+          props.fileType,
+        );
 
         sandboxInstance = sandboxFactory.createTypeScriptSandbox(
           {
@@ -120,6 +124,7 @@ export const useSandboxServices = (
           lintUtils,
           sandboxInstance.tsvfs,
           props.onMarkersChange,
+          props.fileType,
         );
         onModelCreate.register(webLinter.registerFile);
 

--- a/packages/website/src/components/lib/createCompilerOptions.ts
+++ b/packages/website/src/components/lib/createCompilerOptions.ts
@@ -1,18 +1,28 @@
 import type * as ts from 'typescript';
 
+import type { ConfigFileType } from '../types';
+
+const javascriptFileTypes = new Set<ConfigFileType>([
+  '.cjs',
+  '.js',
+  '.jsx',
+  '.mjs',
+]);
+
 /**
  * Converts compiler options from JSON to ts.CompilerOptions
  */
 export function createCompilerOptions(
   tsConfig: Record<string, unknown> = {},
+  fileType?: ConfigFileType,
 ): ts.CompilerOptions {
   const config = window.ts.convertCompilerOptionsFromJson(
     {
       jsx: 'preserve',
       module: 'esnext',
       target: 'esnext',
+      allowJs: fileType !== undefined && javascriptFileTypes.has(fileType),
       ...tsConfig,
-      allowJs: true,
       baseUrl: undefined,
       lib: Array.isArray(tsConfig.lib) ? tsConfig.lib : undefined,
       moduleDetection: undefined,

--- a/packages/website/src/components/linter/createLinter.ts
+++ b/packages/website/src/components/linter/createLinter.ts
@@ -8,6 +8,7 @@ import type {
 import type * as ts from 'typescript';
 
 import type {
+  ConfigFileType,
   ErrorGroup,
   TabType,
 } from '../../../../website/src/components/types';
@@ -41,6 +42,7 @@ export interface CreateLinter {
   >;
   triggerFix(filename: string): Linter.FixReport | undefined;
   triggerLint(filename: string): void;
+  updateFileType(fileType?: ConfigFileType): void;
   updateParserOptions(sourceType?: SourceType): void;
   registerFile: RegisterFile;
 }
@@ -52,10 +54,12 @@ export function createLinter(
   onMarkersChange: React.Dispatch<
     React.SetStateAction<Record<TabType, ErrorGroup[]>>
   >,
+  fileType?: ConfigFileType,
 ): CreateLinter {
   const rules: CreateLinter['rules'] = new Map();
   const configs = new Map(Object.entries(webLinterModule.configs));
   let compilerOptions: ts.CompilerOptions = {};
+  let currentFileType = fileType;
   const parser = createParser(
     system,
     compilerOptions,
@@ -159,6 +163,11 @@ export function createLinter(
       sourceType ?? 'module';
   };
 
+  const updateFileType = (fileType?: ConfigFileType): void => {
+    currentFileType = fileType;
+    applyTSConfig('/tsconfig.json');
+  };
+
   const applyEslintConfig = (fileName: string): void => {
     try {
       const file = system.readFile(fileName) ?? '{}';
@@ -190,7 +199,7 @@ export function createLinter(
     try {
       const file = system.readFile(fileName) ?? '{}';
       const parsed = parseTSConfig(file).compilerOptions;
-      compilerOptions = createCompilerOptions(parsed);
+      compilerOptions = createCompilerOptions(parsed, currentFileType);
       console.log('[Editor] Updating', fileName, compilerOptions);
       parser.updateConfig(compilerOptions);
     } catch (e) {
@@ -259,6 +268,7 @@ export function createLinter(
     rules,
     triggerFix,
     triggerLint,
+    updateFileType,
     updateParserOptions,
   };
 }


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10570
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

<!-- Description of what is changed and how the code change does that. -->
### context
In conclusion, this bug is caused by `allowJS` being overridden to `true`.

I presume that setting `allowJS` to `true` was done for the sake of convenience. 
Although this differs slightly from the [issue comment](https://github.com/typescript-eslint/typescript-eslint/issues/10570#issuecomment-2566660817), I'm retaining the behavior where `allowJS` defaults based on the `fileType` in `createCompilerOptions` to maintain convenience.

### implement

<img width="512" height="461" alt="image" src="https://github.com/user-attachments/assets/e2187b8f-0d8f-44f1-b14a-f6e368d9f9f4" />

<img width="2080" height="724" alt="image" src="https://github.com/user-attachments/assets/aaf14a56-6a8e-4a07-b408-bf01c9361e73" />


1. add `fileType` in createCompilerOptions to set default `allowJS` value.
    - in `ts`, `allowJS` is false.
2. Change the spread order to allow direct configuration of `allowJS`.

