### PR TITLE
fix(eslint-plugin): [unified-signatures] report identical signatures

### DIFF
--- a/packages/eslint-plugin/src/rules/unified-signatures.ts
+++ b/packages/eslint-plugin/src/rules/unified-signatures.ts
@@ -21,6 +21,11 @@ type Unify =
       kind: 'single-parameter-difference';
       p0: TSESTree.Parameter;
       p1: TSESTree.Parameter;
+    }
+  | {
+      kind: 'all-parameters-are-same';
+      signature0: SignatureDefinition;
+      signature1: SignatureDefinition;
     };
 
 /**
@@ -42,6 +47,7 @@ type ContainingNode =
 
 type SignatureDefinition =
   | TSESTree.FunctionExpression
+  | TSESTree.FunctionDeclaration
   | TSESTree.TSCallSignatureDeclaration
   | TSESTree.TSConstructSignatureDeclaration
   | TSESTree.TSDeclareFunction
@@ -54,7 +60,8 @@ type MethodDefinition =
 export type MessageIds =
   | 'omittingRestParameter'
   | 'omittingSingleParameter'
-  | 'singleParameterDifference';
+  | 'singleParameterDifference'
+  | 'allParametersAreSame';
 
 export type Options = [
   {
@@ -79,6 +86,7 @@ export default createRule<Options, MessageIds>({
         '{{failureStringStart}} with an optional parameter.',
       singleParameterDifference:
         '{{failureStringStart}} taking `{{type1}} | {{type2}}`.',
+      allParametersAreSame: '{{failureStringStart}} with identical parameters.',
     },
     schema: [
       {
@@ -170,7 +178,28 @@ export default createRule<Options, MessageIds>({
                 failureStringStart: failureStringStart(lineOfOtherOverload),
               },
             });
+
+            break;
           }
+
+          case 'all-parameters-are-same': {
+            const { signature0, signature1 } = unify;
+            const lineOfOtherOverload = only2
+              ? undefined
+              : signature0.loc.start.line;
+
+            context.report({
+              node: signature1,
+              messageId: 'allParametersAreSame',
+              data: {
+                failureStringStart: failureStringStart(lineOfOtherOverload),
+              },
+            });
+            break;
+          }
+
+          default:
+            unify satisfies never;
         }
       }
     }
@@ -209,7 +238,7 @@ export default createRule<Options, MessageIds>({
       }
 
       return a.params.length === b.params.length
-        ? signaturesDifferBySingleParameter(a.params, b.params)
+        ? signaturesHaveSameAmountOfParameters(a, b)
         : signaturesDifferByOptionalOrRestParameter(a, b);
     }
 
@@ -256,13 +285,16 @@ export default createRule<Options, MessageIds>({
       );
     }
 
-    /** Detect `a(x: number, y: number, z: number)` and `a(x: number, y: string, z: number)`. */
-    function signaturesDifferBySingleParameter(
-      types1: readonly TSESTree.Parameter[],
-      types2: readonly TSESTree.Parameter[],
+    /**
+     * Detect no difference, i.e. `a(x: number, y: string)` and `a(x: number, y: string)`,
+     * or one param difference, i.e. `a(x: number, y: number, z: number)` and `a(x: number, y: string, z: number)`.
+     * */
+    function signaturesHaveSameAmountOfParameters(
+      signature0: SignatureDefinition,
+      signature1: SignatureDefinition,
     ): Unify | undefined {
-      const firstParam1 = types1[0];
-      const firstParam2 = types2[0];
+      const firstParam1 = signature0.params[0];
+      const firstParam2 = signature1.params[0];
 
       // exempt signatures with `this: void` from the rule
       if (isThisVoidParam(firstParam1) || isThisVoidParam(firstParam2)) {
@@ -270,27 +302,31 @@ export default createRule<Options, MessageIds>({
       }
 
       const index = getIndexOfFirstDifference(
-        types1,
-        types2,
+        signature0.params,
+        signature1.params,
         parametersAreEqual,
       );
       if (index == null) {
-        return undefined;
+        return {
+          kind: 'all-parameters-are-same',
+          signature0,
+          signature1,
+        };
       }
 
       // If remaining arrays are equal, the signatures differ by just one parameter type
       if (
         !arraysAreEqual(
-          types1.slice(index + 1),
-          types2.slice(index + 1),
+          signature0.params.slice(index + 1),
+          signature1.params.slice(index + 1),
           parametersAreEqual,
         )
       ) {
         return undefined;
       }
 
-      const a = types1[index];
-      const b = types2[index];
+      const a = signature0.params[index];
+      const b = signature1.params[index];
       // Can unify `a?: string` and `b?: number`. Can't unify `...args: string[]` and `...args: number[]`.
       // See https://github.com/Microsoft/TypeScript/issues/5077
       return parametersHaveEqualSigils(a, b) &&

--- a/packages/eslint-plugin/src/rules/unified-signatures.ts
+++ b/packages/eslint-plugin/src/rules/unified-signatures.ts
@@ -18,14 +18,14 @@ type Unify =
       otherSignature: SignatureDefinition;
     }
   | {
-      kind: 'single-parameter-difference';
-      p0: TSESTree.Parameter;
-      p1: TSESTree.Parameter;
-    }
-  | {
       kind: 'all-parameters-are-same';
       signature0: SignatureDefinition;
       signature1: SignatureDefinition;
+    }
+  | {
+      kind: 'single-parameter-difference';
+      p0: TSESTree.Parameter;
+      p1: TSESTree.Parameter;
     };
 
 /**
@@ -46,7 +46,6 @@ type ContainingNode =
   TSESTree.ExportDefaultDeclaration | TSESTree.ExportNamedDeclaration;
 
 type SignatureDefinition =
-  | TSESTree.FunctionExpression
   | TSESTree.FunctionDeclaration
   | TSESTree.TSCallSignatureDeclaration
   | TSESTree.TSConstructSignatureDeclaration
@@ -58,10 +57,10 @@ type MethodDefinition =
   TSESTree.MethodDefinition | TSESTree.TSAbstractMethodDefinition;
 
 export type MessageIds =
+  | 'allParametersAreSame'
   | 'omittingRestParameter'
   | 'omittingSingleParameter'
-  | 'singleParameterDifference'
-  | 'allParametersAreSame';
+  | 'singleParameterDifference';
 
 export type Options = [
   {
@@ -81,12 +80,12 @@ export default createRule<Options, MessageIds>({
       recommended: 'strict',
     },
     messages: {
+      allParametersAreSame: '{{failureStringStart}} with identical parameters.',
       omittingRestParameter: '{{failureStringStart}} with a rest parameter.',
       omittingSingleParameter:
         '{{failureStringStart}} with an optional parameter.',
       singleParameterDifference:
         '{{failureStringStart}} taking `{{type1}} | {{type2}}`.',
-      allParametersAreSame: '{{failureStringStart}} with identical parameters.',
     },
     schema: [
       {
@@ -288,7 +287,7 @@ export default createRule<Options, MessageIds>({
     /**
      * Detect no difference, i.e. `a(x: number, y: string)` and `a(x: number, y: string)`,
      * or one param difference, i.e. `a(x: number, y: number, z: number)` and `a(x: number, y: string, z: number)`.
-     * */
+     */
     function signaturesHaveSameAmountOfParameters(
       signature0: SignatureDefinition,
       signature1: SignatureDefinition,

--- a/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
+++ b/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
@@ -474,7 +474,7 @@ function f(a: number): void {}
 class A {
   f(a: number): void;
   f(a: number): void;
-  f(a: number): void { }
+  f(a: number): void {}
 }
       `,
       errors: [

--- a/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
+++ b/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
@@ -412,6 +412,87 @@ function f(this: void | {}, a: boolean): void {}
   invalid: [
     {
       code: `
+declare function f(a: number): void;
+declare function f(a: number): void;
+      `,
+      errors: [
+        {
+          column: 1,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+          },
+          endColumn: 37,
+          endLine: 3,
+          line: 3,
+          messageId: 'allParametersAreSame',
+        },
+      ],
+    },
+    {
+      code: `
+declare function f(a: number): void;
+declare function f(a: number): void;
+declare function f(a: string): string;
+      `,
+      errors: [
+        {
+          column: 1,
+          data: {
+            failureStringStart:
+              'This overload and the one on line 2 can be combined into one signature',
+          },
+          endColumn: 37,
+          endLine: 3,
+          line: 3,
+          messageId: 'allParametersAreSame',
+        },
+      ],
+    },
+    {
+      code: `
+function f(a: number): void;
+function f(a: number): void;
+function f(a: number): void {}
+      `,
+      errors: [
+        {
+          column: 1,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+          },
+          endColumn: 29,
+          endLine: 3,
+          line: 3,
+          messageId: 'allParametersAreSame',
+        },
+      ],
+    },
+    {
+      code: `
+class A {
+  f(a: number): void;
+  f(a: number): void;
+  f(a: number): void { }
+}
+      `,
+      errors: [
+        {
+          column: 4,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+          },
+          endColumn: 22,
+          endLine: 4,
+          line: 4,
+          messageId: 'allParametersAreSame',
+        },
+      ],
+    },
+    {
+      code: `
 function f(a: number): void;
 function f(b: string): void;
 function f(a: number | string): void {}


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [X] Addresses an existing open issue: fixes #12670
- [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [X] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

I didn't take into account this case (overload + implementation are the same):

```TS
function fn(a: string): void;
function fn(a: string): void {}
```

It's complicating things, and I'm not sure it's worth the effort
Anyway, I think it should have its own PR