### PR TITLE
test(ast-spec): include `typescript-estree` in coverage

### DIFF
--- a/packages/ast-spec/vitest.config.mts
+++ b/packages/ast-spec/vitest.config.mts
@@ -5,7 +5,22 @@ import { vitestBaseConfig } from '../../vitest.config.base.mjs';
 import packageJson from './package.json' with { type: 'json' };
 
 const vitestConfig = mergeConfig(
-  vitestBaseConfig,
+  mergeConfig(vitestBaseConfig, {
+    test: {
+      coverage: {
+        // `ast-spec` tests are transitively testing the `typescript-estree`
+        // package, so we include `typescript-estree` in the coverage report.
+        //
+        // Including `dist` because the tests are running against the compiled
+        // output. Vitest will then use the sourcemaps to map the coverage back
+        // to the source files.
+        allowExternal: true,
+        include: [
+          path.join(import.meta.dirname, '../typescript-estree/dist/**/*.js'),
+        ],
+      },
+    },
+  }),
 
   defineProject({
     root: import.meta.dirname,

--- a/packages/ast-spec/vitest.config.mts
+++ b/packages/ast-spec/vitest.config.mts
@@ -10,10 +10,6 @@ const vitestConfig = mergeConfig(
       coverage: {
         // `ast-spec` tests are transitively testing the `typescript-estree`
         // package, so we include `typescript-estree` in the coverage report.
-        //
-        // Including `dist` because the tests are running against the compiled
-        // output. Vitest will then use the sourcemaps to map the coverage back
-        // to the source files.
         allowExternal: true,
         include: [
           path.join(import.meta.dirname, '../typescript-estree/dist/**/*.js'),

--- a/packages/typescript-estree/package.json
+++ b/packages/typescript-estree/package.json
@@ -4,7 +4,8 @@
   "description": "A parser that converts TypeScript source code into an ESTree compatible form",
   "files": [
     "dist",
-    "!**/*.tsbuildinfo"
+    "!**/*.tsbuildinfo",
+    "!**/*.js.map"
   ],
   "type": "commonjs",
   "exports": {

--- a/packages/typescript-estree/tsconfig.build.json
+++ b/packages/typescript-estree/tsconfig.build.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../tsconfig.build.json",
-  "compilerOptions": {},
+  "compilerOptions": {
+    "sourceMap": true
+  },
   "references": [
     {
       "path": "../project-service/tsconfig.build.json"


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [X] Addresses an existing open issue: fixes #6701 
- [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [X] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

So, changing the Codecov config as suggested in #6701 -> https://github.com/typescript-eslint/typescript-eslint/pull/6240#discussion_r1142216814 doesn't really help here. It doesn't affect the coverage collection but only the visual grouping of it in the UI (unless we want this?).

To collect `typescript-estree` coverage when running `ast-spec` tests, we need to tell Vitest manually to include it. You'd think it should work out of the box, but turns out [it's not the case when you test against the compiled files](https://github.com/vitest-dev/vitest/issues/5218)

The solution in the above issue was to use an alias, but I didn't go this path because it means testing against the source code rather than the compiled output. I went with `sourceMap` instead (related - #12677).
I excluded it from the final `.tgz` for now, but we'll need to decide whether we want that or not, so we can do the same in #12677