### PR TITLE
chore: [ci] dedupe `integration-tests` jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,10 @@ jobs:
             // `eslint-plugin` runs in its own sharded job; gate it with a boolean.
             const isPluginAffected = affected.includes('eslint-plugin');
 
-            const affectedUnitTests = affected.filter((pkg) => pkg !== 'eslint-plugin');
+            // Packages that have their own tests CI task.
+            const EXCLUDED_PACKAGES = ['eslint-plugin', 'integration-tests'];
+
+            const affectedUnitTests = affected.filter((pkg) => !EXCLUDED_PACKAGES.includes(pkg));
             const affectedProjectService = projectServicePackages.filter((pkg) => affected.includes(pkg));
 
             core.setOutput('is_plugin_affected', isPluginAffected);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
             // `eslint-plugin` runs in its own sharded job; gate it with a boolean.
             const isPluginAffected = affected.includes('eslint-plugin');
 
-            // Packages that have their own tests CI task.
+            // Packages that have their own tests CI job.
             const EXCLUDED_PACKAGES = ['eslint-plugin', 'integration-tests'];
 
             const affectedUnitTests = affected.filter((pkg) => !EXCLUDED_PACKAGES.includes(pkg));


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [X] Addresses an existing open issue: Related #11204
- [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [X] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

I had some failing jobs in #12679, and noticed that we're running the integration tests 3 times!

https://github.com/typescript-eslint/typescript-eslint/actions/runs/31376607771/attempts/1?pr=12679
<img width="303" height="185" alt="image" src="https://github.com/user-attachments/assets/7ea9115c-f326-4378-9836-af44e831c98c" />


That's probably my fault, caused by the `affected-for-tests` logic from #11994