### PR TITLE
fix(type-utils): respect package path boundaries

### DIFF
--- a/packages/type-utils/src/typeOrValueSpecifiers/typeDeclaredInPackageDeclarationFile.ts
+++ b/packages/type-utils/src/typeOrValueSpecifiers/typeDeclaredInPackageDeclarationFile.ts
@@ -1,5 +1,26 @@
 import * as ts from 'typescript';
 
+function packageNameMatches(
+  configuredPackageName: string,
+  declaredPackageName: string,
+): boolean {
+  const typesPackageName = declaredPackageName.startsWith('@types/')
+    ? declaredPackageName.slice('@types/'.length)
+    : undefined;
+  const scopeSeparatorIndex = typesPackageName?.indexOf('__') ?? -1;
+  const normalizedDeclaredPackageName =
+    typesPackageName == null
+      ? declaredPackageName
+      : scopeSeparatorIndex === -1
+        ? typesPackageName
+        : `@${typesPackageName.slice(0, scopeSeparatorIndex)}/${typesPackageName.slice(scopeSeparatorIndex + 2)}`;
+
+  return (
+    normalizedDeclaredPackageName === configuredPackageName ||
+    normalizedDeclaredPackageName.startsWith(`${configuredPackageName}/`)
+  );
+}
+
 function findParentModuleDeclaration(
   node: ts.Node,
 ): ts.ModuleDeclaration | undefined {
@@ -22,10 +43,11 @@ function typeDeclaredInDeclareModule(
   packageName: string,
   declarations: ts.Node[],
 ): boolean {
-  return declarations.some(
-    declaration =>
-      findParentModuleDeclaration(declaration)?.name.text === packageName,
-  );
+  return declarations.some(declaration => {
+    const moduleName = findParentModuleDeclaration(declaration)?.name.text;
+
+    return moduleName != null && packageNameMatches(packageName, moduleName);
+  });
 }
 
 function typeDeclaredInDeclarationFile(
@@ -33,15 +55,11 @@ function typeDeclaredInDeclarationFile(
   declarationFiles: ts.SourceFile[],
   program: ts.Program,
 ): boolean {
-  // Handle scoped packages: if the name starts with @, remove it and replace / with __
-  const typesPackageName = packageName.replace(/^@([^/]+)\//, '$1__');
-
-  const matcher = new RegExp(`${packageName}|${typesPackageName}`);
   return declarationFiles.some(declaration => {
     const packageIdName = program.sourceFileToPackageName.get(declaration.path);
     return (
       packageIdName != null &&
-      matcher.test(packageIdName) &&
+      packageNameMatches(packageName, packageIdName) &&
       program.isSourceFileFromExternalLibrary(declaration)
     );
   });

--- a/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
+++ b/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
@@ -431,6 +431,14 @@ describe('TypeOrValueSpecifier', () => {
           package: 'assert',
         },
       ],
+      [
+        'import {BabelCodeFrameOptions} from "@babel/code-frame"; type Test = BabelCodeFrameOptions;',
+        {
+          from: 'package',
+          name: 'BabelCodeFrameOptions',
+          package: '@babel',
+        },
+      ],
     ] as const satisfies [string, TypeOrValueSpecifier][])(
       'matches a matching package specifier: %s\n\t%s',
       ([code, typeOrValueSpecifier], { expect }) => {
@@ -575,6 +583,18 @@ describe('TypeOrValueSpecifier', () => {
       [
         'import type {Node as TsNode} from "typescript"; type Test = TsNode;',
         { from: 'package', name: 'TsNode', package: 'typescript' },
+      ],
+      [
+        'import type {Node} from "typescript"; type Test = Node;',
+        { from: 'package', name: 'Node', package: 'type' },
+      ],
+      [
+        'import {BabelCodeFrameOptions} from "@babel/code-frame"; type Test = BabelCodeFrameOptions;',
+        {
+          from: 'package',
+          name: 'BabelCodeFrameOptions',
+          package: '@babel/code',
+        },
       ],
     ] as const satisfies [string, TypeOrValueSpecifier][])(
       "doesn't match a mismatched package specifier: %s\n\t%s",


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #11946
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

Package specifiers were matched with an unescaped substring regular expression, so names such as `type` matched `typescript` and `@angular/com` matched `@angular/common`. This change normalizes DefinitelyTyped package IDs back to their source package names, then requires either an exact match or a complete `/`-delimited path prefix.

The same boundary semantics are applied to ambient module declarations. Regression cases cover valid scope-prefix matching and invalid partial matches for both scoped and unscoped packages.

## Verification

- `pnpm --filter @typescript-eslint/type-utils build`
- `pnpm exec vitest run packages/type-utils/tests/TypeOrValueSpecifier.test.ts --pool=threads --testTimeout=30000` (161 passed)
- `pnpm --filter @typescript-eslint/type-utils lint`
- `pnpm run pre-commit`

💖
