### PR TITLE
feat(eslint-plugin): add rule [no-misleading-return-type]

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-misleading-return-type.mdx
+++ b/packages/eslint-plugin/docs/rules/no-misleading-return-type.mdx
@@ -1,0 +1,127 @@
+---
+description: 'Disallow return type annotations that include types the function never returns.'
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+> 🛑 This file is source code, not the primary documentation location! 🛑
+>
+> See **https://typescript-eslint.io/rules/no-misleading-return-type** for documentation.
+
+An explicit return type annotation that is wider than what the function actually returns misleads callers into handling cases that can never happen.
+This commonly happens after refactoring: a code path is removed, but the return type annotation keeps the now-impossible union constituent.
+
+```ts
+function random(param: string): string | null {
+  return 'has param';
+}
+
+const rand = random('value');
+
+if (rand === null) {
+  // This branch is unreachable, but neither the type checker
+  // nor the linter can tell you that.
+  throw new Error('...');
+}
+```
+
+This rule reports analyzable union constituents in return type annotations that the function implementation can never return.
+Primitive annotations such as `string`, `number`, and `boolean` intentionally remain abstractions over their literal values; the rule does not require them to be rewritten as literal unions.
+
+## Examples
+
+<Tabs>
+<TabItem value="❌ Incorrect">
+
+```ts
+function getName(): string | null {
+  return 'Bea';
+}
+
+function getStatus(done: boolean): 'idle' | 'loading' | 'errored' {
+  if (done) {
+    return 'idle';
+  }
+  return 'loading';
+}
+
+async function fetchCount(): Promise<number | null> {
+  return 42;
+}
+
+function createValues(): Array<string | null> {
+  return ['ready'];
+}
+```
+
+</TabItem>
+<TabItem value="✅ Correct">
+
+```ts
+function getName(): string {
+  return 'Bea';
+}
+
+function getStatus(done: boolean): 'idle' | 'loading' {
+  if (done) {
+    return 'idle';
+  }
+  return 'loading';
+}
+
+async function fetchCount(): Promise<number> {
+  return 42;
+}
+
+function getMessage(done: boolean): string {
+  return done ? 'complete' : 'pending';
+}
+
+function firstItem(items: string[]): string | undefined {
+  // Indexed access may produce undefined. TypeScript models that possibility
+  // explicitly when `noUncheckedIndexedAccess` is enabled.
+  return items[0];
+}
+```
+
+</TabItem>
+</Tabs>
+
+## Fixing Reports
+
+To keep the implementation checked against a contract without widening what callers see, prefer `satisfies` on the returned value over a return type annotation:
+
+```ts
+type Status = 'idle' | 'loading' | 'errored';
+
+function getStatus(done: boolean) {
+  return (done ? 'idle' : 'loading') satisfies Status;
+}
+```
+
+The return value is still validated against `Status`, but callers see the narrower inferred type `'idle' | 'loading'`.
+If your project requires annotations through [`explicit-function-return-type`](./explicit-function-return-type.mdx), narrow the annotation to what the function returns instead.
+
+## Limitations
+
+To avoid false positives, this rule intentionally does not check:
+
+- `undefined` and `void` union constituents when either [`strictNullChecks`](https://www.typescriptlang.org/tsconfig/#strictNullChecks) or [`noUncheckedIndexedAccess`](https://www.typescriptlang.org/tsconfig/#noUncheckedIndexedAccess) is disabled. With both options enabled, the rule checks them like other constituents. If either option is disabled, unchecked index access can produce `undefined` at runtime even when the type checker exposes only the element type.
+- Overload implementation signatures: they must be wide enough to cover every overload.
+- Return annotations that mirror an inherited or contextual contract, and class members in decorator-affected classes: their implementation body does not define the whole caller-visible contract.
+- A whole enum named by one type reference: TypeScript widens a returned enum member to that enum. Explicit unions of enum members can still be checked.
+- Generic conditional, mapped, index, or indexed-access types that remain unresolved before type parameters are instantiated.
+- Flow narrowing of property and element reads beyond their declared access type: getters, aliases, and function calls can invalidate that narrowing in ways TypeScript's control-flow analysis does not model.
+- Generator return and input channels (`TReturn` and `TNext`): callers can supply values through `generator.return(value)` and `generator.next(value)`, so those channels are not determined solely by the implementation body. The yielded-value channel is checked for synchronous and asynchronous iterables, including resolvable `yield*` delegation.
+- Expressions whose runtime possibilities cannot be recovered safely, such as unresolved narrowing assertions, escaped Promise resolvers, direct `eval`, or analysis that exceeds the rule's bounded work limits.
+
+## When Not To Use It
+
+If your codebase intentionally annotates wider return types to reserve room for future implementations of public APIs, this rule will report those annotations.
+You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific cases instead of disabling this rule entirely.
+
+## Related To
+
+- [`explicit-function-return-type`](./explicit-function-return-type.mdx)
+- [`no-redundant-type-constituents`](./no-redundant-type-constituents.mdx)

--- a/packages/eslint-plugin/src/configs/eslintrc/all.ts
+++ b/packages/eslint-plugin/src/configs/eslintrc/all.ts
@@ -70,6 +70,7 @@ export = {
     'no-magic-numbers': 'off',
     '@typescript-eslint/no-magic-numbers': 'error',
     '@typescript-eslint/no-meaningless-void-operator': 'error',
+    '@typescript-eslint/no-misleading-return-type': 'error',
     '@typescript-eslint/no-misused-new': 'error',
     '@typescript-eslint/no-misused-promises': 'error',
     '@typescript-eslint/no-misused-spread': 'error',

--- a/packages/eslint-plugin/src/configs/eslintrc/disable-type-checked.ts
+++ b/packages/eslint-plugin/src/configs/eslintrc/disable-type-checked.ts
@@ -24,6 +24,7 @@ export = {
     '@typescript-eslint/no-for-in-array': 'off',
     '@typescript-eslint/no-implied-eval': 'off',
     '@typescript-eslint/no-meaningless-void-operator': 'off',
+    '@typescript-eslint/no-misleading-return-type': 'off',
     '@typescript-eslint/no-misused-promises': 'off',
     '@typescript-eslint/no-misused-spread': 'off',
     '@typescript-eslint/no-mixed-enums': 'off',

--- a/packages/eslint-plugin/src/configs/flat/all.ts
+++ b/packages/eslint-plugin/src/configs/flat/all.ts
@@ -83,6 +83,7 @@ export default (
       'no-magic-numbers': 'off',
       '@typescript-eslint/no-magic-numbers': 'error',
       '@typescript-eslint/no-meaningless-void-operator': 'error',
+      '@typescript-eslint/no-misleading-return-type': 'error',
       '@typescript-eslint/no-misused-new': 'error',
       '@typescript-eslint/no-misused-promises': 'error',
       '@typescript-eslint/no-misused-spread': 'error',

--- a/packages/eslint-plugin/src/configs/flat/disable-type-checked.ts
+++ b/packages/eslint-plugin/src/configs/flat/disable-type-checked.ts
@@ -31,6 +31,7 @@ export default (
     '@typescript-eslint/no-for-in-array': 'off',
     '@typescript-eslint/no-implied-eval': 'off',
     '@typescript-eslint/no-meaningless-void-operator': 'off',
+    '@typescript-eslint/no-misleading-return-type': 'off',
     '@typescript-eslint/no-misused-promises': 'off',
     '@typescript-eslint/no-misused-spread': 'off',
     '@typescript-eslint/no-mixed-enums': 'off',

--- a/packages/eslint-plugin/src/rules/index.ts
+++ b/packages/eslint-plugin/src/rules/index.ts
@@ -51,6 +51,7 @@ import noLoopFunc from './no-loop-func';
 import noLossOfPrecision from './no-loss-of-precision';
 import noMagicNumbers from './no-magic-numbers';
 import noMeaninglessVoidOperator from './no-meaningless-void-operator';
+import noMisleadingReturnType from './no-misleading-return-type';
 import noMisusedNew from './no-misused-new';
 import noMisusedPromises from './no-misused-promises';
 import noMisusedSpread from './no-misused-spread';
@@ -187,6 +188,7 @@ const rules = {
   'no-loss-of-precision': noLossOfPrecision,
   'no-magic-numbers': noMagicNumbers,
   'no-meaningless-void-operator': noMeaninglessVoidOperator,
+  'no-misleading-return-type': noMisleadingReturnType,
   'no-misused-new': noMisusedNew,
   'no-misused-promises': noMisusedPromises,
   'no-misused-spread': noMisusedSpread,

--- a/packages/eslint-plugin/src/rules/no-misleading-return-type-utils/analysis-state.ts
+++ b/packages/eslint-plugin/src/rules/no-misleading-return-type-utils/analysis-state.ts
@@ -1,0 +1,309 @@
+import * as tsutils from 'ts-api-utils';
+import * as ts from 'typescript';
+
+import type {
+  Observation,
+  ResolvedObservation,
+  RuleDependencies,
+} from './shared';
+
+import {
+  isRuntimeFunctionLike,
+  MAX_ANALYSIS_SYNTAX_DEPTH,
+  MAX_ANALYSIS_WORK,
+  isDeferredType,
+  isUncertain,
+} from './shared';
+
+export interface AnalysisState {
+  analyzableUndefinedType: ts.Type | undefined;
+  analysisBudgetExceeded: Error;
+  assignabilityComparisonFailed: Error;
+  checker: RuleDependencies['checker'];
+  consumeAnalysisWork: () => void;
+  exceedsAnalysisSyntaxDepth: (root: ts.Node) => boolean;
+  expandObservations: (observations: readonly Observation[]) => Observation[];
+  expandResolvedObservations: (
+    observations: readonly Observation[],
+  ) => ResolvedObservation[];
+  getAnalysisObjectId: (value: object) => number;
+  getAnalysisStateKey: (
+    anchor: ts.Node,
+    observations: readonly Observation[],
+  ) => string;
+  isDeferredType: (type: ts.Type) => boolean;
+  isExemptVoidLike: (type: ts.Type) => boolean;
+  isNeverLike: (type: ts.Type) => boolean;
+  isStackOverflowError: (error: unknown) => boolean;
+  isTypeAssignableTo: (source: ts.Type, target: ts.Type) => boolean;
+  isUncertain: (type: ts.Type) => boolean;
+  program: RuleDependencies['program'];
+  resetAnalysisWork: () => void;
+  resolveObservation: (observation: Observation) => ResolvedObservation;
+  services: RuleDependencies['services'];
+}
+
+export function createAnalysisState(
+  dependencies: RuleDependencies,
+): AnalysisState {
+  const { checker, program } = dependencies;
+  const compilerOptions = program.getCompilerOptions();
+  const canAnalyzeVoidLikeConstituents =
+    tsutils.isStrictCompilerOptionEnabled(
+      compilerOptions,
+      'strictNullChecks',
+    ) &&
+    tsutils.isCompilerOptionEnabled(
+      compilerOptions,
+      'noUncheckedIndexedAccess',
+    );
+  const analyzableUndefinedType = canAnalyzeVoidLikeConstituents
+    ? checker.getUndefinedType()
+    : undefined;
+  const assignabilityBySource = new WeakMap<
+    ts.Type,
+    WeakMap<ts.Type, boolean>
+  >();
+  const analysisObjectIds = new WeakMap<object, number>();
+  let analysisWorkCount = 0;
+  let nextAnalysisObjectId = 0;
+  const analysisBudgetExceeded = new Error('Type analysis budget exceeded');
+  const assignabilityComparisonFailed = new Error(
+    'TypeScript assignability comparison failed',
+  );
+
+  /**
+   * `never` itself, or an intersection that reduces to it.
+   */
+  function isNeverLike(type: ts.Type): boolean {
+    return (
+      tsutils.isTypeFlagSet(type, ts.TypeFlags.Never) ||
+      (type.isIntersection() &&
+        isTypeAssignableTo(type, checker.getNeverType()))
+    );
+  }
+
+  /**
+   * `undefined`/`void` constituents are exempt unless the program models
+   * unchecked index access (`strictNullChecks` + `noUncheckedIndexedAccess`).
+   */
+  function isExemptVoidLike(type: ts.Type): boolean {
+    return (
+      !canAnalyzeVoidLikeConstituents &&
+      tsutils.isTypeFlagSet(type, ts.TypeFlags.Undefined | ts.TypeFlags.Void)
+    );
+  }
+
+  /**
+   * Measures body nesting iteratively; deeply nested syntax risks stack
+   * overflows inside recursive analysis and the checker itself.
+   */
+  function exceedsAnalysisSyntaxDepth(root: ts.Node): boolean {
+    const pending: { depth: number; node: ts.Node }[] = [
+      { depth: 0, node: root },
+    ];
+    for (
+      let current = pending.pop();
+      current != null;
+      current = pending.pop()
+    ) {
+      if (current.depth > MAX_ANALYSIS_SYNTAX_DEPTH) {
+        return true;
+      }
+      ts.forEachChild(current.node, child => {
+        if (isRuntimeFunctionLike(child)) {
+          return;
+        }
+        pending.push({ depth: current.depth + 1, node: child });
+      });
+    }
+    return false;
+  }
+
+  /**
+   * Only call-stack RangeErrors count; other RangeErrors must propagate.
+   */
+  function isStackOverflowError(error: unknown): boolean {
+    return (
+      error instanceof RangeError &&
+      error.message.toLowerCase().includes('call stack')
+    );
+  }
+
+  /**
+   * Charges one unit against the per-function budget and aborts the whole
+   * function's analysis once it is exhausted.
+   */
+  function consumeAnalysisWork(): void {
+    analysisWorkCount += 1;
+    if (analysisWorkCount > MAX_ANALYSIS_WORK) {
+      throw analysisBudgetExceeded;
+    }
+  }
+
+  /**
+   * Budgeted, memoized assignability; converts checker overflows on
+   * pathological types into an abort of the current function.
+   */
+  function isTypeAssignableTo(source: ts.Type, target: ts.Type): boolean {
+    const cachedByTarget = assignabilityBySource.get(source);
+    const cached = cachedByTarget?.get(target);
+    if (cached != null) {
+      return cached;
+    }
+    consumeAnalysisWork();
+    try {
+      const result = checker.isTypeAssignableTo(source, target);
+      const byTarget = cachedByTarget ?? new WeakMap<ts.Type, boolean>();
+      byTarget.set(target, result);
+      if (cachedByTarget == null) {
+        assignabilityBySource.set(source, byTarget);
+      }
+      return result;
+    } catch {
+      // TypeScript can overflow on mutually recursive template-literal
+      // types: https://github.com/microsoft/TypeScript/issues/62933
+      throw assignabilityComparisonFailed;
+    }
+  }
+
+  /**
+   * Stable per-object ids used to build memoization keys.
+   */
+  function getAnalysisObjectId(value: object): number {
+    const existing = analysisObjectIds.get(value);
+    if (existing != null) {
+      return existing;
+    }
+    const id = nextAnalysisObjectId;
+    nextAnalysisObjectId += 1;
+    analysisObjectIds.set(value, id);
+    return id;
+  }
+
+  /**
+   * Order-insensitive key for one (anchor, observations) analysis state.
+   */
+  function getAnalysisStateKey(
+    anchor: ts.Node,
+    observations: readonly Observation[],
+  ): string {
+    const observationKeys = observations
+      .map(
+        observation =>
+          `${getAnalysisObjectId(observation.node)}:${
+            observation.type == null
+              ? 'deferred'
+              : getAnalysisObjectId(observation.type)
+          }`,
+      )
+      .sort();
+    return `${getAnalysisObjectId(anchor)}|${[...new Set(observationKeys)].join(',')}`;
+  }
+
+  /**
+   * Fills in a deferred observation's type from its node.
+   */
+  function resolveObservation(observation: Observation): ResolvedObservation {
+    return observation.type == null
+      ? {
+          node: observation.node,
+          type: checker.getTypeAtLocation(observation.node),
+        }
+      : (observation as ResolvedObservation);
+  }
+
+  /**
+   * Flattens union observations and widens deferred types and type
+   * parameters to their base constraints (an upper bound can retain extra
+   * possibilities but never proves one absent).
+   */
+  function expandObservations(
+    observations: readonly Observation[],
+  ): Observation[] {
+    function expand(
+      observation: Observation,
+      seen: Set<ts.Type>,
+    ): Observation[] {
+      const { type } = observation;
+      if (type == null) {
+        return [observation];
+      }
+      if (isNeverLike(type)) {
+        return [];
+      }
+      if (seen.has(type)) {
+        return [];
+      }
+
+      seen.add(type);
+      if (type.isUnion()) {
+        return type.types.flatMap(member =>
+          expand({ node: observation.node, type: member }, seen),
+        );
+      }
+      if (isDeferredType(type)) {
+        const constraint = checker.getBaseConstraintOfType(type);
+        if (
+          constraint != null &&
+          constraint !== type &&
+          !isUncertain(constraint)
+        ) {
+          // A deferred type's base constraint is an upper bound for every
+          // instantiation. Expanding that bound may retain extra
+          // possibilities, but it cannot incorrectly prove one absent.
+          return expand({ node: observation.node, type: constraint }, seen);
+        }
+      }
+      if (tsutils.isTypeParameter(type)) {
+        const constraint = checker.getBaseConstraintOfType(type);
+        return constraint == null ||
+          constraint === type ||
+          isUncertain(constraint)
+          ? [observation]
+          : [
+              observation,
+              ...expand({ node: observation.node, type: constraint }, seen),
+            ];
+      }
+      return [observation];
+    }
+
+    return observations.flatMap(observation => expand(observation, new Set()));
+  }
+
+  function expandResolvedObservations(
+    observations: readonly Observation[],
+  ): ResolvedObservation[] {
+    return expandObservations(observations.map(resolveObservation)).map(
+      resolveObservation,
+    );
+  }
+
+  function resetAnalysisWork(): void {
+    analysisWorkCount = 0;
+  }
+
+  return {
+    analysisBudgetExceeded,
+    analyzableUndefinedType,
+    assignabilityComparisonFailed,
+    checker,
+    consumeAnalysisWork,
+    exceedsAnalysisSyntaxDepth,
+    expandObservations,
+    expandResolvedObservations,
+    getAnalysisObjectId,
+    getAnalysisStateKey,
+    isDeferredType,
+    isExemptVoidLike,
+    isNeverLike,
+    isStackOverflowError,
+    isTypeAssignableTo,
+    isUncertain,
+    program,
+    resetAnalysisWork,
+    resolveObservation,
+    services: dependencies.services,
+  };
+}

--- a/packages/eslint-plugin/src/rules/no-misleading-return-type-utils/analyzer.ts
+++ b/packages/eslint-plugin/src/rules/no-misleading-return-type-utils/analyzer.ts
@@ -1,0 +1,386 @@
+import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
+
+import { AST_NODE_TYPES } from '@typescript-eslint/utils';
+import * as ts from 'typescript';
+
+import type {
+  FunctionNode,
+  Observation,
+  RuleContext,
+  RuleDependencies,
+} from './shared';
+
+import { isBuiltinSymbolLike } from '../../util';
+import { createAnalysisState } from './analysis-state';
+import { createCallableProjections } from './callable-projections';
+import { createContractAnalysis } from './contracts';
+import { createControlFlowAnalysis } from './control-flow';
+import { createExpressionAnalysis } from './expression-observations';
+import { createExpressionUtilities } from './expression-utils';
+import { createPropertyProjections } from './property-projections';
+import {
+  GENERATOR_NAMES,
+  isRuntimeFunctionLike,
+  isRuntimeFunctionLikeWithBody,
+  truncateTypeString,
+  TYPE_STRING_MAX_LENGTH,
+} from './shared';
+import { createTypeAnalysis } from './type-analysis';
+
+export function createNoMisleadingReturnTypeAnalyzer(
+  context: RuleContext,
+  services: RuleDependencies['services'],
+): TSESLint.RuleListener {
+  const program = services.program;
+  const checker = program.getTypeChecker();
+  const dependencies = { checker, context, program, services };
+  const state = createAnalysisState(dependencies);
+  const expressionUtilities = createExpressionUtilities(state);
+  const controlFlow = createControlFlowAnalysis(
+    dependencies,
+    expressionUtilities,
+  );
+  const expressions = createExpressionAnalysis(
+    state,
+    controlFlow,
+    expressionUtilities,
+  );
+  const callables = createCallableProjections(state, expressions);
+  const properties = createPropertyProjections(
+    state,
+    controlFlow,
+    expressions,
+    callables,
+  );
+  const typeAnalysis = createTypeAnalysis(
+    state,
+    expressions,
+    properties,
+    callables,
+  );
+  const contracts = createContractAnalysis(state, properties);
+
+  const {
+    analysisBudgetExceeded,
+    assignabilityComparisonFailed,
+    exceedsAnalysisSyntaxDepth,
+    isStackOverflowError,
+    isUncertain,
+    resetAnalysisWork,
+    resolveObservation,
+  } = state;
+  const {
+    blockCanCompleteNormally,
+    blockCannotCompleteNormally,
+    containsDirectEval,
+    isAfterNeverCompletion,
+    isTSNodeInStaticallyUnreachableBranch,
+    onCodePathEnd,
+    onCodePathSegmentEnd,
+    onCodePathSegmentStart,
+    onCodePathStart,
+    reachableYields,
+    recordBlockExit,
+    recordCallExit,
+    recordReturn,
+    recordYield,
+  } = controlFlow;
+  const {
+    collectBuiltinPromiseSettlementCalls,
+    collectReturns,
+    getBuiltinPromiseExecutor,
+    getExpressionObservations,
+  } = expressions;
+  const { projectIterableElement, projectYieldedValues } = callables;
+  const {
+    analyzeResolvedType,
+    analyzeTypeNode,
+    collectUnobservedUnionMembers,
+    resetTypeAnalysis,
+  } = typeAnalysis;
+  const {
+    isAffectedByDecorators,
+    isOverloadImplementation,
+    mirrorsBaseContract,
+    mirrorsContextualContract,
+  } = contracts;
+
+  /**
+   * Collects the values each reachable `yield` produces, resolving
+   * `yield*` delegation to its element type.
+   */
+  function collectGeneratorObservations(
+    body: ts.Block,
+    isAsync: boolean,
+  ): Observation[] {
+    const yields: Observation[] = [];
+
+    function visit(node: ts.Node): void {
+      if (isRuntimeFunctionLike(node)) {
+        return;
+      }
+      if (ts.isYieldExpression(node)) {
+        if (
+          !reachableYields.has(node) ||
+          isTSNodeInStaticallyUnreachableBranch(node) ||
+          isAfterNeverCompletion(node, body.parent)
+        ) {
+          return;
+        }
+        if (node.expression == null) {
+          yields.push({ node, type: checker.getUndefinedType() });
+        } else if (node.asteriskToken != null) {
+          yields.push(
+            ...projectIterableElement(
+              getExpressionObservations(node.expression),
+              isAsync,
+            ),
+          );
+        } else {
+          yields.push(
+            ...projectYieldedValues(
+              getExpressionObservations(node.expression),
+              isAsync,
+            ),
+          );
+        }
+        ts.forEachChild(node, visit);
+        return;
+      }
+      ts.forEachChild(node, visit);
+    }
+
+    visit(body);
+    return yields;
+  }
+
+  /**
+   * Checks only the yielded-value channel: callers can inject `TReturn`
+   * and `TNext` values through `generator.return()` / `generator.next()`.
+   */
+  function analyzeGenerator(
+    node: FunctionNode,
+    tsFunctionNode: ts.FunctionLikeDeclaration,
+    body: ts.Block,
+    returnTypeNode: TSESTree.TSTypeAnnotation,
+    annotatedType: ts.Type,
+  ): void {
+    if (!isBuiltinSymbolLike(program, annotatedType, GENERATOR_NAMES)) {
+      return;
+    }
+
+    const observations = collectGeneratorObservations(body, node.async);
+    const unused: ts.Type[] = [];
+    const expectedYields = projectIterableElement(
+      [{ node: tsFunctionNode, type: annotatedType }],
+      node.async,
+    );
+    if (observations.length === 0) {
+      for (const yielded of expectedYields) {
+        collectUnobservedUnionMembers(resolveObservation(yielded).type, unused);
+      }
+      report(returnTypeNode, annotatedType, unused);
+      return;
+    }
+    for (const yielded of expectedYields) {
+      const expectedYield = resolveObservation(yielded);
+      analyzeResolvedType(
+        expectedYield.type,
+        tsFunctionNode,
+        observations,
+        unused,
+        undefined,
+      );
+    }
+    report(returnTypeNode, annotatedType, unused);
+  }
+
+  /**
+   * Renders unused constituents deduplicated, with `true`+`false`
+   * collapsed back to `boolean` and the list length capped.
+   */
+  function report(
+    returnTypeNode: TSESTree.TSTypeAnnotation,
+    annotatedType: ts.Type,
+    unusedTypes: readonly ts.Type[],
+  ): void {
+    const trueType = checker.getTrueType();
+    const falseType = checker.getFalseType();
+    const hasUnusedBoolean =
+      unusedTypes.includes(trueType) && unusedTypes.includes(falseType);
+    let emittedBoolean = false;
+    const unused = new Set<string>();
+    const separatorLength = ' | '.length;
+    let renderedLength = 0;
+    for (const type of unusedTypes) {
+      let rendered: string;
+      if (hasUnusedBoolean && (type === trueType || type === falseType)) {
+        if (emittedBoolean) {
+          continue;
+        }
+        emittedBoolean = true;
+        rendered = checker.typeToString(checker.getBooleanType());
+      } else {
+        rendered = checker.typeToString(type);
+      }
+      if (unused.has(rendered)) {
+        continue;
+      }
+      unused.add(rendered);
+      renderedLength +=
+        rendered.length + (unused.size === 1 ? 0 : separatorLength);
+      if (renderedLength >= TYPE_STRING_MAX_LENGTH) {
+        break;
+      }
+    }
+    if (unused.size === 0) {
+      return;
+    }
+
+    context.report({
+      data: {
+        annotated: truncateTypeString(checker.typeToString(annotatedType)),
+        unused: truncateTypeString([...unused].join(' | ')),
+      },
+      messageId: 'misleadingReturnType',
+      node: returnTypeNode,
+    });
+  }
+
+  /**
+   * The per-function pipeline: bail conditions, contract mirroring, then
+   * observation collection and constituent analysis.
+   */
+  function checkFunctionWithTypes(node: FunctionNode): void {
+    const returnTypeNode = node.returnType;
+    if (returnTypeNode == null) {
+      return;
+    }
+
+    const tsFunctionNode = services.esTreeNodeToTSNodeMap.get(node);
+    if (
+      !isRuntimeFunctionLikeWithBody(tsFunctionNode) ||
+      exceedsAnalysisSyntaxDepth(tsFunctionNode) ||
+      isOverloadImplementation(tsFunctionNode) ||
+      isAffectedByDecorators(tsFunctionNode) ||
+      containsDirectEval(tsFunctionNode)
+    ) {
+      return;
+    }
+
+    const tsReturnTypeNode = services.esTreeNodeToTSNodeMap.get(
+      returnTypeNode.typeAnnotation,
+    );
+    if (!ts.isTypeNode(tsReturnTypeNode)) {
+      return;
+    }
+
+    const annotatedType = checker.getTypeFromTypeNode(tsReturnTypeNode);
+    if (
+      isUncertain(annotatedType) ||
+      mirrorsBaseContract(node, annotatedType) ||
+      mirrorsContextualContract(tsFunctionNode, annotatedType)
+    ) {
+      return;
+    }
+
+    if (node.generator) {
+      if (ts.isBlock(tsFunctionNode.body)) {
+        analyzeGenerator(
+          node,
+          tsFunctionNode,
+          tsFunctionNode.body,
+          returnTypeNode,
+          annotatedType,
+        );
+      }
+      return;
+    }
+
+    let observations: Observation[];
+    if (
+      node.type === AST_NODE_TYPES.ArrowFunctionExpression &&
+      node.expression
+    ) {
+      const expression = services.esTreeNodeToTSNodeMap.get(node.body);
+      if (!ts.isExpression(expression)) {
+        return;
+      }
+      observations = getExpressionObservations(expression);
+    } else {
+      const body = tsFunctionNode.body;
+      if (!ts.isBlock(body)) {
+        return;
+      }
+      observations = collectReturns(body);
+      // The code path observation alone cannot see type-level completion
+      // (a trailing `never`-returning call still ends the function), so the
+      // implicit `undefined` needs both sources to agree.
+      if (
+        blockCanCompleteNormally.get(body) === true &&
+        !blockCannotCompleteNormally(body)
+      ) {
+        observations.push({ node: body, type: checker.getUndefinedType() });
+      }
+    }
+
+    if (observations.length === 0) {
+      return;
+    }
+
+    const unused: ts.Type[] = [];
+    analyzeTypeNode(tsReturnTypeNode, observations, unused);
+    report(returnTypeNode, annotatedType, unused);
+  }
+
+  /**
+   * Entry point that converts analysis aborts (budget, checker overflow)
+   * into silence for this function only.
+   */
+  function checkFunction(node: FunctionNode): void {
+    resetAnalysisWork();
+    resetTypeAnalysis();
+    try {
+      checkFunctionWithTypes(node);
+    } catch (error) {
+      if (
+        error !== analysisBudgetExceeded &&
+        error !== assignabilityComparisonFailed &&
+        !isStackOverflowError(error)
+      ) {
+        throw error;
+      }
+    }
+  }
+
+  return {
+    'ArrowFunctionExpression:exit': checkFunction,
+    'BlockStatement:exit'(node): void {
+      recordBlockExit(services.esTreeNodeToTSNodeMap.get(node));
+    },
+    'CallExpression:exit'(node): void {
+      recordCallExit(services.esTreeNodeToTSNodeMap.get(node));
+    },
+    'FunctionDeclaration:exit': checkFunction,
+    'FunctionExpression:exit': checkFunction,
+    NewExpression(node): void {
+      const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+      const promiseExecutor = getBuiltinPromiseExecutor(tsNode);
+      if (promiseExecutor != null) {
+        collectBuiltinPromiseSettlementCalls(promiseExecutor);
+      }
+    },
+    onCodePathEnd,
+    onCodePathSegmentEnd,
+    onCodePathSegmentStart,
+    onCodePathStart,
+    onUnreachableCodePathSegmentEnd: onCodePathSegmentEnd,
+    onUnreachableCodePathSegmentStart: onCodePathSegmentStart,
+    ReturnStatement(node): void {
+      recordReturn(services.esTreeNodeToTSNodeMap.get(node));
+    },
+    YieldExpression(node): void {
+      recordYield(services.esTreeNodeToTSNodeMap.get(node));
+    },
+  };
+}

--- a/packages/eslint-plugin/src/rules/no-misleading-return-type-utils/callable-projections.ts
+++ b/packages/eslint-plugin/src/rules/no-misleading-return-type-utils/callable-projections.ts
@@ -1,0 +1,826 @@
+import * as tsutils from 'ts-api-utils';
+import * as ts from 'typescript';
+
+import type { AnalysisState } from './analysis-state';
+import type { ExpressionAnalysis } from './expression-observations';
+import type { Observation, SignatureParameterDomain } from './shared';
+
+import { isBuiltinSymbolLike } from '../../util';
+
+export interface CallableProjections {
+  projectArrayElement: (observations: readonly Observation[]) => Observation[];
+  projectIterableElement: (
+    observations: readonly Observation[],
+    isAsync: boolean,
+  ) => Observation[];
+  projectMapEntry: (
+    observations: readonly Observation[],
+    index: number,
+  ) => Observation[];
+  projectMethodParameter: (
+    observations: readonly Observation[],
+    methodName: string,
+    parameterIndex: number,
+  ) => Observation[];
+  projectMethodReturn: (
+    observations: readonly Observation[],
+    methodName: string,
+  ) => Observation[];
+  projectSignatureReturn: (
+    observations: readonly Observation[],
+    kind: ts.SignatureKind,
+    expectedSignature?: ts.Signature,
+  ) => Observation[];
+  projectTupleElement: (
+    observations: readonly Observation[],
+    index: number,
+    rest: boolean,
+  ) => Observation[];
+  projectYieldedValues: (
+    observations: readonly Observation[],
+    isAsync: boolean,
+  ) => Observation[];
+}
+
+export function createCallableProjections(
+  state: AnalysisState,
+  expressions: ExpressionAnalysis,
+): CallableProjections {
+  const {
+    checker,
+    expandObservations,
+    expandResolvedObservations,
+    isDeferredType,
+    isNeverLike,
+    isTypeAssignableTo,
+    isUncertain,
+    program,
+    resolveObservation,
+  } = state;
+  const { getExpressionObservations, projectAwaited } = expressions;
+
+  /**
+   * A tuple slot type, unwrapping variadic slots to their element type.
+   */
+  function getTupleElementType(
+    tuple: ts.TupleTypeReference,
+    index: number,
+    type: ts.Type,
+  ): ts.Type | undefined {
+    const flags = tuple.target.elementFlags.at(index);
+    return flags != null && (flags & ts.ElementFlags.Variadic) !== 0
+      ? checker.getIndexTypeOfType(type, ts.IndexKind.Number)
+      : type;
+  }
+
+  /**
+   * Element values of arrays and tuples, from literal syntax when
+   * available, otherwise from the numeric index type.
+   */
+  function projectArrayElement(
+    observations: readonly Observation[],
+  ): Observation[] {
+    return expandObservations(observations).flatMap(observation => {
+      if (ts.isArrayLiteralExpression(observation.node)) {
+        return observation.node.elements.flatMap(element => {
+          if (ts.isOmittedExpression(element)) {
+            return [{ node: element, type: checker.getUndefinedType() }];
+          }
+          return ts.isSpreadElement(element)
+            ? projectIterableElement(
+                getExpressionObservations(element.expression),
+                false,
+              )
+            : getExpressionObservations(element);
+        });
+      }
+
+      const resolved = resolveObservation(observation);
+      if (isUncertain(resolved.type)) {
+        return [resolved];
+      }
+
+      const resolvedType = resolved.type;
+      if (checker.isTupleType(resolvedType)) {
+        return checker.getTypeArguments(resolvedType).flatMap((type, index) => {
+          const element = getTupleElementType(resolvedType, index, type);
+          return element == null ||
+            tsutils.isTypeFlagSet(element, ts.TypeFlags.Never)
+            ? []
+            : [{ node: observation.node, type: element }];
+        });
+      }
+
+      const element = checker.getIndexTypeOfType(
+        resolved.type,
+        ts.IndexKind.Number,
+      );
+      return element == null ||
+        tsutils.isTypeFlagSet(element, ts.TypeFlags.Never)
+        ? []
+        : [{ node: observation.node, type: element }];
+    });
+  }
+
+  /**
+   * Values a fixed tuple position (or its rest region) can hold.
+   */
+  function projectTupleElement(
+    observations: readonly Observation[],
+    index: number,
+    rest: boolean,
+  ): Observation[] {
+    return expandObservations(observations).flatMap(observation => {
+      if (ts.isArrayLiteralExpression(observation.node)) {
+        if (rest) {
+          return observation.node.elements.slice(index).flatMap(element => {
+            if (ts.isOmittedExpression(element)) {
+              return [{ node: element, type: checker.getUndefinedType() }];
+            }
+            return ts.isSpreadElement(element)
+              ? projectIterableElement(
+                  getExpressionObservations(element.expression),
+                  false,
+                )
+              : getExpressionObservations(element);
+          });
+        }
+
+        if (
+          !observation.node.elements
+            .slice(0, index + 1)
+            .some(ts.isSpreadElement)
+        ) {
+          const element = observation.node.elements.at(index);
+          return element == null || ts.isOmittedExpression(element)
+            ? [
+                {
+                  node: element ?? observation.node,
+                  type: checker.getUndefinedType(),
+                },
+              ]
+            : getExpressionObservations(element);
+        }
+        // A preceding spread makes the source element at this tuple index
+        // data-dependent, so use the checker's instantiated tuple type.
+      }
+
+      const resolved = resolveObservation(observation);
+      if (isUncertain(resolved.type)) {
+        return [resolved];
+      }
+
+      if (checker.isTupleType(resolved.type)) {
+        const tuple = resolved.type;
+        const typeArguments = checker.getTypeArguments(tuple);
+        const selected = rest
+          ? typeArguments.slice(index)
+          : [typeArguments.at(index)];
+        return selected.flatMap((type, offset) => {
+          if (type == null) {
+            return [];
+          }
+          const element = getTupleElementType(tuple, index + offset, type);
+          return element == null ||
+            tsutils.isTypeFlagSet(element, ts.TypeFlags.Never)
+            ? []
+            : [{ node: observation.node, type: element }];
+        });
+      }
+
+      const type = checker.getIndexTypeOfType(
+        resolved.type,
+        ts.IndexKind.Number,
+      );
+      return type == null || tsutils.isTypeFlagSet(type, ts.TypeFlags.Never)
+        ? []
+        : [{ node: observation.node, type }];
+    });
+  }
+
+  /**
+   * Return-type observations of every call signature on the observed
+   * callables.
+   */
+  function projectSignatureReturn(
+    observations: readonly Observation[],
+    kind: ts.SignatureKind,
+    expectedSignature?: ts.Signature,
+  ): Observation[] {
+    return expandResolvedObservations(observations).flatMap(observation => {
+      if (isUncertain(observation.type)) {
+        return [observation];
+      }
+
+      const signatures = checker.getSignaturesOfType(observation.type, kind);
+      const corresponding =
+        expectedSignature == null
+          ? signatures
+          : signatures.filter(signature =>
+              signaturesCanCorrespond(expectedSignature, signature),
+            );
+      return (corresponding.length > 0 ? corresponding : signatures).map(
+        signature => ({
+          node: observation.node,
+          type: checker.getReturnTypeOfSignature(signature),
+        }),
+      );
+    });
+  }
+
+  /**
+   * Parameter declarations when every parameter has one; parameter-domain
+   * analysis needs their syntax.
+   */
+  function getSignatureParameterDeclarations(
+    signature: ts.Signature,
+  ): readonly ts.ParameterDeclaration[] | undefined {
+    const declarations = signature.parameters.map(
+      parameter => parameter.valueDeclaration,
+    );
+    return declarations.every(
+      (declaration): declaration is ts.ParameterDeclaration =>
+        declaration != null && ts.isParameter(declaration),
+    )
+      ? declarations
+      : undefined;
+  }
+
+  /**
+   * The tuple constraint behind a rest parameter type, following
+   * deferred types and type parameters.
+   */
+  function getTupleParameterConstraint(
+    type: ts.Type,
+    seen = new Set<ts.Type>(),
+  ): ts.TupleTypeReference | undefined {
+    if (checker.isTupleType(type)) {
+      return type;
+    }
+    if (seen.has(type)) {
+      return undefined;
+    }
+    seen.add(type);
+    if (!tsutils.isTypeParameter(type) && !isDeferredType(type)) {
+      return undefined;
+    }
+    const constraint = checker.getBaseConstraintOfType(type);
+    return constraint == null || constraint === type
+      ? undefined
+      : getTupleParameterConstraint(constraint, seen);
+  }
+
+  /**
+   * A signature's argument positions as prefix / rest / required suffix,
+   * or nothing when slot assignment would be ambiguous.
+   */
+  function getSignatureParameterDomain(
+    signature: ts.Signature,
+    declarations: readonly ts.ParameterDeclaration[],
+  ): SignatureParameterDomain | undefined {
+    const prefix: SignatureParameterDomain['prefix'] = [];
+    let rest: ts.Type | undefined;
+    const suffix: SignatureParameterDomain['suffix'] = [];
+
+    for (const [index, declaration] of declarations.entries()) {
+      const parameterType = checker.getTypeOfSymbolAtLocation(
+        signature.parameters[index],
+        declaration,
+      );
+      if (declaration.dotDotDotToken == null) {
+        prefix.push({
+          required:
+            declaration.questionToken == null &&
+            declaration.initializer == null,
+          type: parameterType,
+        });
+        continue;
+      }
+
+      const tupleType = getTupleParameterConstraint(parameterType);
+      if (tupleType != null) {
+        const elements = checker.getTypeArguments(tupleType);
+        let sawRestElement = false;
+        for (const [elementIndex, element] of elements.entries()) {
+          const flags = tupleType.target.elementFlags[elementIndex];
+          if (
+            (flags & (ts.ElementFlags.Rest | ts.ElementFlags.Variadic)) !==
+            0
+          ) {
+            if (rest != null) {
+              return undefined;
+            }
+            rest =
+              (flags & ts.ElementFlags.Variadic) !== 0
+                ? checker.getIndexTypeOfType(element, ts.IndexKind.Number)
+                : element;
+            if (rest == null) {
+              return undefined;
+            }
+            sawRestElement = true;
+          } else {
+            (sawRestElement ? suffix : prefix).push({
+              required: (flags & ts.ElementFlags.Required) !== 0,
+              type: element,
+            });
+          }
+        }
+        continue;
+      }
+
+      if (rest != null) {
+        return undefined;
+      }
+      rest = checker.getIndexTypeOfType(parameterType, ts.IndexKind.Number);
+      if (rest == null) {
+        return undefined;
+      }
+    }
+
+    // Mapping a required suffix from the right is unambiguous when every
+    // fixed slot around it is required. If TypeScript ever exposes a tuple
+    // with optional slots around a variadic middle, retain all overloads
+    // rather than guessing which argument occupies which slot.
+    if (
+      suffix.length > 0 &&
+      [...prefix, ...suffix].some(parameter => !parameter.required)
+    ) {
+      return undefined;
+    }
+    return { prefix, rest, suffix };
+  }
+
+  /**
+   * The fewest arguments the domain accepts.
+   */
+  function getMinimumArgumentCount(domain: SignatureParameterDomain): number {
+    if (domain.suffix.length > 0) {
+      return domain.prefix.length + domain.suffix.length;
+    }
+    let minimum = 0;
+    for (const [index, parameter] of domain.prefix.entries()) {
+      if (parameter.required) {
+        minimum = index + 1;
+      }
+    }
+    return minimum;
+  }
+
+  /**
+   * The type an argument at a given index is checked against.
+   */
+  function getParameterTypeAt(
+    domain: SignatureParameterDomain,
+    index: number,
+    argumentCount: number,
+  ): ts.Type | undefined {
+    if (index < domain.prefix.length) {
+      return domain.prefix[index].type;
+    }
+    const suffixStart = argumentCount - domain.suffix.length;
+    if (index >= suffixStart) {
+      return domain.suffix[index - suffixStart]?.type;
+    }
+    return domain.rest;
+  }
+
+  /**
+   * Replaces a type parameter or deferred type with its constraint so the
+   * overlap comparison sees a concrete upper bound.
+   */
+  function getComparableParameterType(type: ts.Type): ts.Type {
+    if (tsutils.isTypeParameter(type) || isDeferredType(type)) {
+      const constraint = checker.getBaseConstraintOfType(type);
+      if (constraint != null && !isUncertain(constraint)) {
+        return constraint;
+      }
+    }
+    return type;
+  }
+
+  /**
+   * The primitive-domain summary used to check cheaply that domains cannot overlap.
+   */
+  function getPrimitiveDomain(
+    type: ts.Type,
+  ):
+    | 'bigint'
+    | 'boolean'
+    | 'null'
+    | 'number'
+    | 'object'
+    | 'string'
+    | 'symbol'
+    | 'undefined'
+    | undefined {
+    if (tsutils.isTypeFlagSet(type, ts.TypeFlags.StringLike)) {
+      return 'string';
+    }
+    if (tsutils.isTypeFlagSet(type, ts.TypeFlags.NumberLike)) {
+      return 'number';
+    }
+    if (tsutils.isTypeFlagSet(type, ts.TypeFlags.BigIntLike)) {
+      return 'bigint';
+    }
+    if (tsutils.isTypeFlagSet(type, ts.TypeFlags.BooleanLike)) {
+      return 'boolean';
+    }
+    if (tsutils.isTypeFlagSet(type, ts.TypeFlags.ESSymbolLike)) {
+      return 'symbol';
+    }
+    if (tsutils.isTypeFlagSet(type, ts.TypeFlags.Null)) {
+      return 'null';
+    }
+    if (
+      tsutils.isTypeFlagSet(type, ts.TypeFlags.Undefined | ts.TypeFlags.Void)
+    ) {
+      return 'undefined';
+    }
+    if (
+      type.isIntersection() ||
+      tsutils.isTypeFlagSet(
+        type,
+        ts.TypeFlags.Object | ts.TypeFlags.NonPrimitive,
+      )
+    ) {
+      return 'object';
+    }
+    return undefined;
+  }
+
+  /**
+   * Conservative overlap test between two parameter types; uncertainty
+   * counts as overlap.
+   */
+  function parameterTypesMayOverlap(a: ts.Type, b: ts.Type): boolean {
+    a = getComparableParameterType(a);
+    b = getComparableParameterType(b);
+    if (
+      isUncertain(a) ||
+      isUncertain(b) ||
+      tsutils.isTypeParameter(a) ||
+      tsutils.isTypeParameter(b) ||
+      isDeferredType(a) ||
+      isDeferredType(b)
+    ) {
+      return true;
+    }
+    if (a.isUnion()) {
+      return a.types.some(member => parameterTypesMayOverlap(member, b));
+    }
+    if (b.isUnion()) {
+      return b.types.some(member => parameterTypesMayOverlap(a, member));
+    }
+    if (isNeverLike(a) || isNeverLike(b)) {
+      return false;
+    }
+    if (isTypeAssignableTo(a, b) || isTypeAssignableTo(b, a)) {
+      return true;
+    }
+
+    const aDomain = getPrimitiveDomain(a);
+    const bDomain = getPrimitiveDomain(b);
+    if (aDomain == null || bDomain == null || aDomain === bDomain) {
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Whether two signatures can describe the same call, so their return
+   * positions are comparable.
+   */
+  function signaturesCanCorrespond(
+    expected: ts.Signature,
+    source: ts.Signature,
+  ): boolean {
+    const expectedParameters = getSignatureParameterDeclarations(expected);
+    const sourceParameters = getSignatureParameterDeclarations(source);
+    if (expectedParameters == null || sourceParameters == null) {
+      return true;
+    }
+    const expectedDomain = getSignatureParameterDomain(
+      expected,
+      expectedParameters,
+    );
+    const sourceDomain = getSignatureParameterDomain(source, sourceParameters);
+    if (expectedDomain == null || sourceDomain == null) {
+      return true;
+    }
+
+    const expectedMaximum =
+      expectedDomain.rest == null
+        ? expectedDomain.prefix.length + expectedDomain.suffix.length
+        : Infinity;
+    const sourceMaximum =
+      sourceDomain.rest == null
+        ? sourceDomain.prefix.length + sourceDomain.suffix.length
+        : Infinity;
+    const minimumCommonArgumentCount = Math.max(
+      getMinimumArgumentCount(expectedDomain),
+      getMinimumArgumentCount(sourceDomain),
+    );
+    const maximumCommonArgumentCount = Math.min(expectedMaximum, sourceMaximum);
+    if (minimumCommonArgumentCount > maximumCommonArgumentCount) {
+      return false;
+    }
+
+    const fixedFootprint = Math.max(
+      expectedDomain.prefix.length + expectedDomain.suffix.length,
+      sourceDomain.prefix.length + sourceDomain.suffix.length,
+    );
+    const lastArgumentCount = Number.isFinite(maximumCommonArgumentCount)
+      ? maximumCommonArgumentCount
+      : Math.max(minimumCommonArgumentCount, fixedFootprint) + 1;
+
+    for (
+      let argumentCount = minimumCommonArgumentCount;
+      argumentCount <= lastArgumentCount;
+      argumentCount += 1
+    ) {
+      let overlaps = true;
+      for (let index = 0; index < argumentCount; index += 1) {
+        const expectedType = getParameterTypeAt(
+          expectedDomain,
+          index,
+          argumentCount,
+        );
+        const sourceType = getParameterTypeAt(
+          sourceDomain,
+          index,
+          argumentCount,
+        );
+        if (
+          expectedType == null ||
+          sourceType == null ||
+          !parameterTypesMayOverlap(expectedType, sourceType)
+        ) {
+          overlaps = false;
+          break;
+        }
+      }
+      if (overlaps) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Resolves each observation's `methodName` call signatures and projects
+   * them through `projectSignature`; opaque observations pass through.
+   */
+  function flatMapMethodSignatures(
+    observations: readonly Observation[],
+    methodName: string,
+    projectSignature: (signature: ts.Signature, node: ts.Node) => Observation[],
+  ): Observation[] {
+    return expandResolvedObservations(observations).flatMap(observation => {
+      if (isUncertain(observation.type)) {
+        return [observation];
+      }
+
+      const method = checker.getPropertyOfType(observation.type, methodName);
+      if (method == null) {
+        return [];
+      }
+
+      const methodType = checker.getTypeOfSymbolAtLocation(
+        method,
+        observation.node,
+      );
+      return checker
+        .getSignaturesOfType(methodType, ts.SignatureKind.Call)
+        .flatMap(signature => projectSignature(signature, observation.node));
+    });
+  }
+
+  function projectMethodReturn(
+    observations: readonly Observation[],
+    methodName: string,
+  ): Observation[] {
+    return flatMapMethodSignatures(
+      observations,
+      methodName,
+      (signature, node) => [
+        { node, type: checker.getReturnTypeOfSignature(signature) },
+      ],
+    );
+  }
+
+  function projectMethodParameter(
+    observations: readonly Observation[],
+    methodName: string,
+    parameterIndex: number,
+  ): Observation[] {
+    return flatMapMethodSignatures(
+      observations,
+      methodName,
+      (signature, node) => {
+        const parameter = signature.getParameters().at(parameterIndex);
+        return parameter == null
+          ? []
+          : [
+              {
+                node,
+                type: checker.getTypeOfSymbolAtLocation(parameter, node),
+              },
+            ];
+      },
+    );
+  }
+
+  /**
+   * Yield values read from an iterator's `next` result shape.
+   */
+  function getIteratorResultValues(
+    iterator: Observation,
+    isAsync: boolean,
+  ): Observation[] {
+    const resolved = resolveObservation(iterator);
+    const next = checker.getPropertyOfType(resolved.type, 'next');
+    if (next == null) {
+      return [];
+    }
+
+    const nextType = checker.getTypeOfSymbolAtLocation(next, iterator.node);
+    return checker
+      .getSignaturesOfType(nextType, ts.SignatureKind.Call)
+      .flatMap(signature => {
+        const rawResult = checker.getReturnTypeOfSignature(signature);
+        const result = isAsync ? checker.getAwaitedType(rawResult) : rawResult;
+        if (result == null) {
+          return [];
+        }
+
+        return tsutils.unionConstituents(result).flatMap(resultPart => {
+          const done = checker.getPropertyOfType(resultPart, 'done');
+          if (done != null) {
+            const doneType = checker.getTypeOfSymbolAtLocation(
+              done,
+              iterator.node,
+            );
+            if (
+              !isTypeAssignableTo(checker.getFalseType(), doneType) &&
+              !isTypeAssignableTo(checker.getUndefinedType(), doneType)
+            ) {
+              return [];
+            }
+          }
+
+          const value = checker.getPropertyOfType(resultPart, 'value');
+          return value == null
+            ? []
+            : [
+                {
+                  node: iterator.node,
+                  type: checker.getTypeOfSymbolAtLocation(value, iterator.node),
+                },
+              ];
+        });
+      });
+  }
+
+  /**
+   * Async generators await each yielded value; sync ones emit it as-is.
+   */
+  function projectYieldedValues(
+    observations: readonly Observation[],
+    isAsync: boolean,
+  ): Observation[] {
+    if (!isAsync) {
+      return [...observations];
+    }
+    return projectAwaited(observations);
+  }
+
+  /**
+   * Element observations from iterable arguments of built-in collection
+   * constructors.
+   */
+  function projectBuiltinConstructorIterable(
+    observation: Observation,
+    constructorName: string | string[],
+  ): Observation[] | undefined {
+    if (
+      !ts.isNewExpression(observation.node) ||
+      observation.node.typeArguments != null ||
+      !isBuiltinSymbolLike(
+        program,
+        checker.getTypeAtLocation(observation.node.expression),
+        constructorName,
+      )
+    ) {
+      return undefined;
+    }
+
+    const source = observation.node.arguments?.at(0);
+    return source == null
+      ? []
+      : projectIterableElement(getExpressionObservations(source), false);
+  }
+
+  /**
+   * Element values of sync or async iterables, from iterator signatures
+   * or literal syntax.
+   */
+  function projectIterableElement(
+    observations: readonly Observation[],
+    isAsync: boolean,
+  ): Observation[] {
+    return expandResolvedObservations(observations).flatMap(observation => {
+      if (isUncertain(observation.type)) {
+        return [observation];
+      }
+
+      if (!isAsync) {
+        const constructed = projectBuiltinConstructorIterable(observation, [
+          'MapConstructor',
+          'SetConstructor',
+          'WeakMapConstructor',
+          'WeakSetConstructor',
+        ]);
+        if (constructed != null) {
+          return constructed;
+        }
+      }
+
+      if (
+        checker.isArrayType(observation.type) ||
+        checker.isTupleType(observation.type)
+      ) {
+        return projectYieldedValues(
+          projectArrayElement([observation]),
+          isAsync,
+        );
+      }
+
+      const iteratorProperty =
+        (isAsync &&
+          tsutils.getWellKnownSymbolPropertyOfType(
+            observation.type,
+            'asyncIterator',
+            checker,
+          )) ||
+        tsutils.getWellKnownSymbolPropertyOfType(
+          observation.type,
+          'iterator',
+          checker,
+        );
+      if (iteratorProperty == null) {
+        return projectYieldedValues(
+          getIteratorResultValues(observation, isAsync),
+          isAsync,
+        );
+      }
+
+      const iteratorMethod = checker.getTypeOfSymbolAtLocation(
+        iteratorProperty,
+        observation.node,
+      );
+      return projectYieldedValues(
+        checker
+          .getSignaturesOfType(iteratorMethod, ts.SignatureKind.Call)
+          .flatMap(signature => {
+            const iteratorType = checker.getReturnTypeOfSignature(signature);
+            return getIteratorResultValues(
+              { node: observation.node, type: iteratorType },
+              isAsync,
+            );
+          }),
+        isAsync,
+      );
+    });
+  }
+
+  /**
+   * Key or value observations of map-like entries.
+   */
+  function projectMapEntry(
+    observations: readonly Observation[],
+    index: number,
+  ): Observation[] {
+    const entries = projectIterableElement(observations, false);
+    if (entries.length > 0) {
+      return projectTupleElement(entries, index, false);
+    }
+
+    // WeakMap is not iterable, but its public `get` signature exposes both
+    // generic positions. The same fallback also keeps derived map-like
+    // interfaces analyzable when they intentionally hide iteration.
+    return index === 0
+      ? projectMethodParameter(observations, 'get', 0)
+      : projectMethodReturn(observations, 'get');
+  }
+
+  return {
+    projectArrayElement,
+    projectIterableElement,
+    projectMapEntry,
+    projectMethodParameter,
+    projectMethodReturn,
+    projectSignatureReturn,
+    projectTupleElement,
+    projectYieldedValues,
+  };
+}

--- a/packages/eslint-plugin/src/rules/no-misleading-return-type-utils/contracts.ts
+++ b/packages/eslint-plugin/src/rules/no-misleading-return-type-utils/contracts.ts
@@ -1,0 +1,260 @@
+import { AST_NODE_TYPES } from '@typescript-eslint/utils';
+import * as tsutils from 'ts-api-utils';
+import * as ts from 'typescript';
+
+import type { AnalysisState } from './analysis-state';
+import type { PropertyProjections } from './property-projections';
+import type { FunctionNode } from './shared';
+
+import { getBaseTypesOfClassMember } from '../../util';
+import { hasAnyDecorators } from './shared';
+
+export interface ContractAnalysis {
+  isAffectedByDecorators: (functionNode: ts.FunctionLikeDeclaration) => boolean;
+  isOverloadImplementation: (tsFunctionNode: ts.Node) => boolean;
+  mirrorsBaseContract: (node: FunctionNode, annotatedType: ts.Type) => boolean;
+  mirrorsContextualContract: (
+    tsFunctionNode: ts.Node,
+    annotatedType: ts.Type,
+  ) => boolean;
+}
+
+export function createContractAnalysis(
+  state: AnalysisState,
+  properties: PropertyProjections,
+): ContractAnalysis {
+  const { checker, isTypeAssignableTo, services } = state;
+  const { getPropertyName } = properties;
+  const decoratedClasses = new WeakMap<
+    ts.ClassDeclaration | ts.ClassExpression,
+    boolean
+  >();
+
+  /**
+   * Implementation signatures must be wide enough for every overload, so
+   * they are never treated as misleading.
+   */
+  function isOverloadImplementation(tsFunctionNode: ts.Node): boolean {
+    return (
+      tsutils.isSignatureDeclaration(tsFunctionNode) &&
+      checker.isImplementationOfOverload(tsFunctionNode) === true
+    );
+  }
+
+  /**
+   * Call signatures across every union constituent: contract properties are
+   * often written as `'literal' | ((...) => T)`, where the callable branch
+   * still carries the return contract.
+   */
+  function getCallSignaturesOfConstituents(
+    type: ts.Type,
+  ): readonly ts.Signature[] {
+    return tsutils
+      .unionConstituents(type)
+      .flatMap(member =>
+        checker.getSignaturesOfType(member, ts.SignatureKind.Call),
+      );
+  }
+
+  function isMutuallyAssignable(a: ts.Type, b: ts.Type): boolean {
+    return isTypeAssignableTo(a, b) && isTypeAssignableTo(b, a);
+  }
+
+  /**
+   * An annotation mutually assignable with an inherited member type
+   * documents the base contract, not this implementation.
+   */
+  function mirrorsBaseContract(
+    node: FunctionNode,
+    annotatedType: ts.Type,
+  ): boolean {
+    const member =
+      node.parent.type === AST_NODE_TYPES.MethodDefinition ||
+      (node.parent.type === AST_NODE_TYPES.PropertyDefinition &&
+        node.parent.value === node)
+        ? node.parent
+        : undefined;
+    if (member == null) {
+      return false;
+    }
+
+    for (const { baseMemberType } of getBaseTypesOfClassMember(
+      services,
+      member,
+    )) {
+      const signatures = getCallSignaturesOfConstituents(baseMemberType);
+      if (
+        signatures.length > 0
+          ? signatures.some(signature =>
+              isMutuallyAssignable(
+                annotatedType,
+                checker.getReturnTypeOfSignature(signature),
+              ),
+            )
+          : isMutuallyAssignable(annotatedType, baseMemberType)
+      ) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Return types the surrounding context declares for this function
+   * (callback parameters, contextually typed object members).
+   */
+  function getContextualReturnTypes(tsFunctionNode: ts.Node): ts.Type[] {
+    if (
+      ts.isArrowFunction(tsFunctionNode) ||
+      ts.isFunctionExpression(tsFunctionNode)
+    ) {
+      const contextual = checker.getContextualType(tsFunctionNode);
+      return contextual == null
+        ? []
+        : getCallSignaturesOfConstituents(contextual).map(signature =>
+            checker.getReturnTypeOfSignature(signature),
+          );
+    }
+
+    if (
+      (ts.isMethodDeclaration(tsFunctionNode) ||
+        ts.isGetAccessorDeclaration(tsFunctionNode)) &&
+      ts.isObjectLiteralExpression(tsFunctionNode.parent)
+    ) {
+      const contextualObject = checker.getContextualType(tsFunctionNode.parent);
+      const propertyName = getPropertyName(tsFunctionNode.name);
+      if (contextualObject == null || propertyName == null) {
+        return [];
+      }
+      const property = checker.getPropertyOfType(
+        contextualObject,
+        propertyName,
+      );
+      if (property == null) {
+        return [];
+      }
+      const propertyType = checker.getTypeOfSymbolAtLocation(
+        property,
+        tsFunctionNode,
+      );
+      if (ts.isGetAccessorDeclaration(tsFunctionNode)) {
+        return [propertyType];
+      }
+      return getCallSignaturesOfConstituents(propertyType).map(signature =>
+        checker.getReturnTypeOfSignature(signature),
+      );
+    }
+
+    return [];
+  }
+
+  /**
+   * An annotation matching a contextual return contract restates what the
+   * receiving API requires.
+   */
+  function mirrorsContextualContract(
+    tsFunctionNode: ts.Node,
+    annotatedType: ts.Type,
+  ): boolean {
+    return getContextualReturnTypes(tsFunctionNode).some(contextualType =>
+      isMutuallyAssignable(annotatedType, contextualType),
+    );
+  }
+
+  /**
+   * Any legacy decorator receives the prototype and may patch sibling
+   * members imperatively, so one decorated member taints the class.
+   */
+  function classHasDecorators(
+    classNode: ts.ClassDeclaration | ts.ClassExpression,
+  ): boolean {
+    const cached = decoratedClasses.get(classNode);
+    if (cached != null) {
+      return cached;
+    }
+    const result =
+      hasAnyDecorators(classNode) ||
+      classNode.members.some(member => {
+        if (hasAnyDecorators(member)) {
+          return true;
+        }
+        return (
+          (ts.isConstructorDeclaration(member) ||
+            ts.isMethodDeclaration(member) ||
+            ts.isGetAccessorDeclaration(member) ||
+            ts.isSetAccessorDeclaration(member)) &&
+          member.parameters.some(hasAnyDecorators)
+        );
+      });
+    decoratedClasses.set(classNode, result);
+    return result;
+  }
+
+  /**
+   * The property declaration a function initializes, if it directly
+   * initializes one.
+   */
+  function getPropertyFunctionInitializer(
+    functionNode: ts.ArrowFunction | ts.FunctionExpression,
+  ): ts.PropertyDeclaration | undefined {
+    let child: ts.Node = functionNode;
+    const property = ts.findAncestor(functionNode, ancestor => {
+      if (
+        ts.isSourceFile(ancestor) ||
+        ts.isClassDeclaration(ancestor) ||
+        ts.isClassExpression(ancestor) ||
+        ts.isMethodDeclaration(ancestor) ||
+        ts.isGetAccessorDeclaration(ancestor) ||
+        ts.isSetAccessorDeclaration(ancestor)
+      ) {
+        return 'quit';
+      }
+      const isInitializer =
+        ts.isPropertyDeclaration(ancestor) && ancestor.initializer === child;
+      child = ancestor;
+      return isInitializer;
+    });
+    return property != null && ts.isPropertyDeclaration(property)
+      ? property
+      : undefined;
+  }
+
+  /**
+   * Decorators can replace runtime implementations, making body analysis
+   * unsound for the affected members.
+   */
+  function isAffectedByDecorators(
+    functionNode: ts.FunctionLikeDeclaration,
+  ): boolean {
+    if (hasAnyDecorators(functionNode)) {
+      return true;
+    }
+
+    const member =
+      ts.isArrowFunction(functionNode) || ts.isFunctionExpression(functionNode)
+        ? getPropertyFunctionInitializer(functionNode)
+        : ts.isMethodDeclaration(functionNode) ||
+            ts.isGetAccessorDeclaration(functionNode) ||
+            ts.isSetAccessorDeclaration(functionNode)
+          ? functionNode
+          : undefined;
+    if (member == null) {
+      return false;
+    }
+    if (member !== functionNode && hasAnyDecorators(member)) {
+      return true;
+    }
+    return (
+      (ts.isClassDeclaration(member.parent) ||
+        ts.isClassExpression(member.parent)) &&
+      classHasDecorators(member.parent)
+    );
+  }
+
+  return {
+    isAffectedByDecorators,
+    isOverloadImplementation,
+    mirrorsBaseContract,
+    mirrorsContextualContract,
+  };
+}

--- a/packages/eslint-plugin/src/rules/no-misleading-return-type-utils/control-flow.ts
+++ b/packages/eslint-plugin/src/rules/no-misleading-return-type-utils/control-flow.ts
@@ -1,0 +1,1089 @@
+import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
+
+import { AST_NODE_TYPES } from '@typescript-eslint/utils';
+import * as tsutils from 'ts-api-utils';
+import * as ts from 'typescript';
+
+import type { ExpressionUtilities } from './expression-utils';
+import type {
+  FunctionLikeDeclarationWithBody,
+  RuleDependencies,
+} from './shared';
+
+import { getStaticValue, isPossiblyFalsy, isPossiblyTruthy } from '../../util';
+import {
+  isRuntimeFunctionLike,
+  isUncertain,
+  STATIC_SWITCH_NO_ENTRY,
+  STATIC_SWITCH_UNKNOWN,
+} from './shared';
+
+export interface ControlFlowAnalysis {
+  blockCanCompleteNormally: WeakMap<ts.Block, boolean>;
+  blockCannotCompleteNormally: (block: ts.Block) => boolean;
+  callCodePathSegments: WeakMap<
+    ts.CallExpression,
+    readonly TSESLint.CodePathSegment[]
+  >;
+  callExecutionOrder: WeakMap<ts.CallExpression, number>;
+  containsDirectEval: (
+    functionNode: FunctionLikeDeclarationWithBody,
+  ) => boolean;
+  expressionNeverCompletes: (expression: ts.Expression) => boolean;
+  getTSStaticTruthiness: (expression: ts.Expression) => boolean | undefined;
+  getTSStaticValue: (
+    expression: ts.Expression,
+  ) => { value: unknown } | undefined;
+  isAfterNeverCompletion: (
+    completion: ts.Node,
+    functionNode: ts.Node,
+  ) => boolean;
+  isOverriddenByFinally: (
+    completion: ts.Node,
+    functionNode: ts.Node,
+  ) => boolean;
+  isTSNodeInStaticallyUnreachableBranch: (node: ts.Node) => boolean;
+  onCodePathEnd: () => void;
+  onCodePathSegmentEnd: (segment: TSESLint.CodePathSegment) => void;
+  onCodePathSegmentStart: (segment: TSESLint.CodePathSegment) => void;
+  onCodePathStart: () => void;
+  promiseSettlementCalls: WeakSet<ts.CallExpression>;
+  reachableCalls: WeakSet<ts.CallExpression>;
+  reachableReturns: WeakSet<ts.ReturnStatement>;
+  reachableYields: WeakSet<ts.YieldExpression>;
+  recordBlockExit: (block: ts.Block) => void;
+  recordCallExit: (call: ts.CallExpression) => void;
+  recordReturn: (statement: ts.ReturnStatement) => void;
+  recordYield: (expression: ts.YieldExpression) => void;
+  unwrapRuntimeExpression: (expression: ts.Expression) => ts.Expression;
+}
+
+export function createControlFlowAnalysis(
+  { checker, context, services }: RuleDependencies,
+  expressionUtilities: ExpressionUtilities,
+): ControlFlowAnalysis {
+  const { unwrapImmutableAlias, unwrapTransparentExpression } =
+    expressionUtilities;
+  const codePathSegmentStack: Set<TSESLint.CodePathSegment>[] = [];
+  let currentCodePathSegments = new Set<TSESLint.CodePathSegment>();
+  const reachableReturns = new WeakSet<ts.ReturnStatement>();
+  const reachableYields = new WeakSet<ts.YieldExpression>();
+  const reachableCalls = new WeakSet<ts.CallExpression>();
+  const promiseSettlementCalls = new WeakSet<ts.CallExpression>();
+  const callCodePathSegments = new WeakMap<
+    ts.CallExpression,
+    readonly TSESLint.CodePathSegment[]
+  >();
+  const callExecutionOrder = new WeakMap<ts.CallExpression, number>();
+  let nextCallExecutionOrder = 0;
+  const blockCanCompleteNormally = new WeakMap<ts.Block, boolean>();
+  const blockCannotCompleteNormallyCache = new WeakMap<ts.Block, boolean>();
+  const statementCannotCompleteNormallyCache = new WeakMap<
+    ts.Statement,
+    boolean
+  >();
+  const staticSwitchEntries = new WeakMap<TSESTree.SwitchStatement, number>();
+  const staticallyUnreachableSwitchCases = new WeakMap<
+    TSESTree.SwitchStatement,
+    ReadonlySet<TSESTree.SwitchCase>
+  >();
+  const statementsAfterNeverCompletion = new WeakMap<
+    ts.Block | ts.CaseClause | ts.DefaultClause,
+    WeakSet<ts.Statement>
+  >();
+  const staticTruthiness = new WeakMap<TSESTree.Expression, boolean | null>();
+  const directEvalByFunction = new WeakMap<
+    ts.FunctionLikeDeclaration,
+    boolean
+  >();
+
+  function isCurrentCodePathReachable(): boolean {
+    for (const segment of currentCodePathSegments) {
+      if (segment.reachable) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // A type whose every constituent is truthy (or falsy) decides a branch
+  // just as reliably as a static value: the checker's flow type at the test
+  // site is exactly what TypeScript itself narrows with.
+  function getTypeLevelTruthiness(
+    expression: ts.Expression,
+  ): boolean | undefined {
+    const type = checker.getTypeAtLocation(expression);
+    if (isUncertain(type)) {
+      return undefined;
+    }
+    if (!isPossiblyFalsy(type)) {
+      return true;
+    }
+    if (!isPossiblyTruthy(type)) {
+      return false;
+    }
+    return undefined;
+  }
+
+  /**
+   * Static-value truthiness first, then type-level truthiness; both
+   * outcomes (including "unknown") are cached per node.
+   */
+  function getStaticTruthiness(node: TSESTree.Expression): boolean | undefined {
+    if (staticTruthiness.has(node)) {
+      return staticTruthiness.get(node) ?? undefined;
+    }
+    const result = getESTreeStaticValue(node);
+    let value = result == null ? undefined : Boolean(result.value);
+    if (value == null) {
+      const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+      if (ts.isExpression(tsNode)) {
+        value = getTypeLevelTruthiness(tsNode);
+      }
+    }
+    staticTruthiness.set(node, value ?? null);
+    return value;
+  }
+
+  function isStaticSwitchValue(
+    value: unknown,
+  ): value is bigint | boolean | number | string | null | undefined {
+    return (
+      value == null ||
+      typeof value === 'bigint' ||
+      typeof value === 'boolean' ||
+      typeof value === 'number' ||
+      typeof value === 'string'
+    );
+  }
+
+  /**
+   * The case index a statically-known discriminant enters, or the
+   * NO_ENTRY / UNKNOWN sentinels.
+   */
+  function getStaticSwitchEntry(node: TSESTree.SwitchStatement): number {
+    const cached = staticSwitchEntries.get(node);
+    if (cached != null) {
+      return cached;
+    }
+
+    const discriminant = getESTreeStaticValue(node.discriminant);
+    if (discriminant == null || !isStaticSwitchValue(discriminant.value)) {
+      staticSwitchEntries.set(node, STATIC_SWITCH_UNKNOWN);
+      return STATIC_SWITCH_UNKNOWN;
+    }
+
+    let defaultIndex = STATIC_SWITCH_NO_ENTRY;
+    for (const [index, switchCase] of node.cases.entries()) {
+      if (switchCase.test == null) {
+        defaultIndex = index;
+        continue;
+      }
+      const caseValue = getESTreeStaticValue(switchCase.test);
+      if (caseValue == null || !isStaticSwitchValue(caseValue.value)) {
+        staticSwitchEntries.set(node, STATIC_SWITCH_UNKNOWN);
+        return STATIC_SWITCH_UNKNOWN;
+      }
+      if (caseValue.value === discriminant.value) {
+        staticSwitchEntries.set(node, index);
+        return index;
+      }
+    }
+    staticSwitchEntries.set(node, defaultIndex);
+    return defaultIndex;
+  }
+
+  /**
+   * Cases before the static entry, or sealed off by an earlier case that
+   * cannot fall through.
+   */
+  function switchCaseIsStaticallyUnreachable(
+    switchCase: TSESTree.SwitchCase,
+    switchStatement: TSESTree.SwitchStatement,
+  ): boolean {
+    const cached = staticallyUnreachableSwitchCases.get(switchStatement);
+    if (cached != null) {
+      return cached.has(switchCase);
+    }
+
+    const unreachable = new Set<TSESTree.SwitchCase>();
+    staticallyUnreachableSwitchCases.set(switchStatement, unreachable);
+    const entryIndex = getStaticSwitchEntry(switchStatement);
+    if (entryIndex === STATIC_SWITCH_UNKNOWN) {
+      return false;
+    }
+    if (entryIndex === STATIC_SWITCH_NO_ENTRY) {
+      for (const currentCase of switchStatement.cases) {
+        unreachable.add(currentCase);
+      }
+      return unreachable.has(switchCase);
+    }
+
+    let fallthroughCanReach = true;
+    for (const [index, currentCase] of switchStatement.cases.entries()) {
+      if (index < entryIndex || !fallthroughCanReach) {
+        unreachable.add(currentCase);
+        continue;
+      }
+      fallthroughCanReach = !currentCase.consequent.some(statement => {
+        const tsStatement = services.esTreeNodeToTSNodeMap.get(statement);
+        return (
+          ts.isStatement(tsStatement) &&
+          statementCannotCompleteNormally(tsStatement)
+        );
+      });
+    }
+    return unreachable.has(switchCase);
+  }
+
+  /**
+   * Walks ancestors pruning branches whose test truthiness or switch
+   * entry is statically decided.
+   */
+  function isInStaticallyUnreachableBranch(node: TSESTree.Node): boolean {
+    let current = node;
+    while (current.parent != null) {
+      const parent = current.parent;
+      switch (parent.type) {
+        case AST_NODE_TYPES.ArrowFunctionExpression:
+        case AST_NODE_TYPES.FunctionDeclaration:
+        case AST_NODE_TYPES.FunctionExpression:
+          return false;
+
+        case AST_NODE_TYPES.ConditionalExpression:
+        case AST_NODE_TYPES.IfStatement: {
+          const truthiness = getStaticTruthiness(parent.test);
+          if (
+            (truthiness === false && current === parent.consequent) ||
+            (truthiness === true && current === parent.alternate)
+          ) {
+            return true;
+          }
+          break;
+        }
+
+        case AST_NODE_TYPES.ForStatement:
+          if (
+            current === parent.body &&
+            parent.test != null &&
+            getStaticTruthiness(parent.test) === false
+          ) {
+            return true;
+          }
+          break;
+
+        case AST_NODE_TYPES.LogicalExpression:
+          if (current === parent.right) {
+            const left = getESTreeStaticValue(parent.left);
+            if (
+              left != null &&
+              ((parent.operator === '&&' && !left.value) ||
+                (parent.operator === '||' && Boolean(left.value)) ||
+                (parent.operator === '??' && left.value != null))
+            ) {
+              return true;
+            }
+          }
+          break;
+
+        case AST_NODE_TYPES.SwitchCase:
+          if (switchCaseIsStaticallyUnreachable(parent, parent.parent)) {
+            return true;
+          }
+          break;
+
+        case AST_NODE_TYPES.WhileStatement:
+          if (
+            current === parent.body &&
+            getStaticTruthiness(parent.test) === false
+          ) {
+            return true;
+          }
+          break;
+      }
+      current = parent;
+    }
+    return false;
+  }
+
+  /**
+   * TS-node adapter for the ESTree unreachable-branch walk.
+   */
+  function isTSNodeInStaticallyUnreachableBranch(node: ts.Node): boolean {
+    if (!services.tsNodeToESTreeNodeMap.has(node)) {
+      return false;
+    }
+    return isInStaticallyUnreachableBranch(
+      services.tsNodeToESTreeNodeMap.get(node),
+    );
+  }
+
+  /**
+   * A `finally` block that cannot complete normally replaces completions
+   * from the guarded region.
+   */
+  function isOverriddenByFinally(
+    completion: ts.Node,
+    functionNode: ts.Node,
+  ): boolean {
+    return (
+      ts.findAncestor(completion, current => {
+        if (current === functionNode || ts.isSourceFile(current)) {
+          return 'quit';
+        }
+        const parent = current.parent;
+        return (
+          ts.isTryStatement(parent) &&
+          parent.finallyBlock != null &&
+          current !== parent.finallyBlock &&
+          blockCannotCompleteNormally(parent.finallyBlock)
+        );
+      }) != null
+    );
+  }
+
+  /**
+   * Combines the CodePath observation of the block's end with statement
+   * completion analysis, cached.
+   */
+  function blockCannotCompleteNormally(block: ts.Block): boolean {
+    const cached = blockCannotCompleteNormallyCache.get(block);
+    if (cached != null) {
+      return cached;
+    }
+    const result =
+      blockCanCompleteNormally.get(block) === false ||
+      block.statements.some(statementCannotCompleteNormally);
+    blockCannotCompleteNormallyCache.set(block, result);
+    return result;
+  }
+
+  /**
+   * Whether left-to-right evaluation reaches a `never`-typed call before
+   * the expression can produce a value.
+   */
+  function expressionNeverCompletes(expression: ts.Expression): boolean {
+    expression = unwrapRuntimeExpression(expression);
+    if (
+      (ts.isAwaitExpression(expression) ||
+        ts.isCallExpression(expression) ||
+        ts.isNewExpression(expression) ||
+        ts.isTaggedTemplateExpression(expression)) &&
+      tsutils.isTypeFlagSet(
+        checker.getTypeAtLocation(expression),
+        ts.TypeFlags.Never,
+      )
+    ) {
+      return true;
+    }
+
+    if (ts.isConditionalExpression(expression)) {
+      if (expressionNeverCompletes(expression.condition)) {
+        return true;
+      }
+      const truthiness = getTSStaticTruthiness(expression.condition);
+      return truthiness == null
+        ? expressionNeverCompletes(expression.whenTrue) &&
+            expressionNeverCompletes(expression.whenFalse)
+        : expressionNeverCompletes(
+            truthiness ? expression.whenTrue : expression.whenFalse,
+          );
+    }
+
+    if (ts.isBinaryExpression(expression)) {
+      if (expressionNeverCompletes(expression.left)) {
+        return true;
+      }
+      if (
+        expression.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken
+      ) {
+        return (
+          getTSStaticTruthiness(expression.left) === true &&
+          expressionNeverCompletes(expression.right)
+        );
+      }
+      if (expression.operatorToken.kind === ts.SyntaxKind.BarBarToken) {
+        return (
+          getTSStaticTruthiness(expression.left) === false &&
+          expressionNeverCompletes(expression.right)
+        );
+      }
+      if (
+        expression.operatorToken.kind === ts.SyntaxKind.QuestionQuestionToken
+      ) {
+        const left = getTSStaticValue(expression.left);
+        return (
+          left != null &&
+          left.value == null &&
+          expressionNeverCompletes(expression.right)
+        );
+      }
+      return expressionNeverCompletes(expression.right);
+    }
+
+    if (ts.isArrayLiteralExpression(expression)) {
+      return expression.elements.some(element => {
+        if (ts.isOmittedExpression(element)) {
+          return false;
+        }
+        return expressionNeverCompletes(
+          ts.isSpreadElement(element) ? element.expression : element,
+        );
+      });
+    }
+
+    if (ts.isObjectLiteralExpression(expression)) {
+      return expression.properties.some(property => {
+        const name = ts.getNameOfDeclaration(property);
+        if (
+          name != null &&
+          ts.isComputedPropertyName(name) &&
+          expressionNeverCompletes(name.expression)
+        ) {
+          return true;
+        }
+        if (ts.isPropertyAssignment(property)) {
+          return expressionNeverCompletes(property.initializer);
+        }
+        if (ts.isShorthandPropertyAssignment(property)) {
+          return (
+            expressionNeverCompletes(property.name) ||
+            (property.objectAssignmentInitializer != null &&
+              expressionNeverCompletes(property.objectAssignmentInitializer))
+          );
+        }
+        if (ts.isSpreadAssignment(property)) {
+          return expressionNeverCompletes(property.expression);
+        }
+        return false;
+      });
+    }
+
+    if (ts.isCallExpression(expression)) {
+      return (
+        expressionNeverCompletes(expression.expression) ||
+        (!ts.isCallChain(expression) &&
+          expression.arguments.some(argument =>
+            expressionNeverCompletes(
+              ts.isSpreadElement(argument) ? argument.expression : argument,
+            ),
+          ))
+      );
+    }
+
+    if (ts.isNewExpression(expression)) {
+      return (
+        expressionNeverCompletes(expression.expression) ||
+        expression.arguments?.some(argument =>
+          expressionNeverCompletes(
+            ts.isSpreadElement(argument) ? argument.expression : argument,
+          ),
+        ) === true
+      );
+    }
+
+    if (ts.isPropertyAccessExpression(expression)) {
+      return expressionNeverCompletes(expression.expression);
+    }
+
+    if (ts.isElementAccessExpression(expression)) {
+      return (
+        expressionNeverCompletes(expression.expression) ||
+        (expression.questionDotToken == null &&
+          expressionNeverCompletes(expression.argumentExpression))
+      );
+    }
+
+    if (ts.isTaggedTemplateExpression(expression)) {
+      return (
+        expressionNeverCompletes(expression.tag) ||
+        (ts.isTemplateExpression(expression.template) &&
+          expression.template.templateSpans.some(span =>
+            expressionNeverCompletes(span.expression),
+          ))
+      );
+    }
+
+    if (ts.isTemplateExpression(expression)) {
+      return expression.templateSpans.some(span =>
+        expressionNeverCompletes(span.expression),
+      );
+    }
+
+    if (
+      ts.isAwaitExpression(expression) ||
+      ts.isDeleteExpression(expression) ||
+      ts.isTypeOfExpression(expression) ||
+      ts.isVoidExpression(expression)
+    ) {
+      return expressionNeverCompletes(expression.expression);
+    }
+
+    if (
+      ts.isPostfixUnaryExpression(expression) ||
+      ts.isPrefixUnaryExpression(expression)
+    ) {
+      return expressionNeverCompletes(expression.operand);
+    }
+
+    if (ts.isYieldExpression(expression) && expression.expression != null) {
+      return expressionNeverCompletes(expression.expression);
+    }
+
+    return false;
+  }
+
+  /**
+   * Skips wrappers with no runtime effect: parentheses, `satisfies`, and
+   * every type assertion form.
+   */
+  function unwrapRuntimeExpression(expression: ts.Expression): ts.Expression {
+    for (;;) {
+      expression = unwrapTransparentExpression(expression);
+      if (
+        ts.isAsExpression(expression) ||
+        ts.isTypeAssertionExpression(expression) ||
+        ts.isNonNullExpression(expression)
+      ) {
+        expression = expression.expression;
+        continue;
+      }
+      return expression;
+    }
+  }
+
+  /**
+   * Prefers the ESTree evaluator through the reverse node map, falling
+   * back to checker constants for nodes without an ESTree counterpart.
+   */
+  function getTSStaticValue(
+    expression: ts.Expression,
+  ): { value: unknown } | undefined {
+    if (!services.tsNodeToESTreeNodeMap.has(expression)) {
+      return getTSConstantValue(expression);
+    }
+    const node =
+      services.tsNodeToESTreeNodeMap.get<TSESTree.Expression>(expression);
+    return getESTreeStaticValue(node);
+  }
+
+  /**
+   * ESLint's scoped static evaluator, extended with checker-computed
+   * constants (enum members) it cannot see.
+   */
+  function getESTreeStaticValue(
+    node: TSESTree.Expression,
+  ): { value: unknown } | undefined {
+    const staticValue = getStaticValue(node, context.sourceCode.getScope(node));
+    if (staticValue != null) {
+      return staticValue;
+    }
+    const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+    return ts.isExpression(tsNode) ? getTSConstantValue(tsNode) : undefined;
+  }
+
+  /**
+   * Checker-computed constants: enum member accesses, including element
+   * accesses whose key is itself statically known.
+   */
+  function getTSConstantValue(
+    expression: ts.Expression,
+  ): { value: unknown } | undefined {
+    expression = unwrapStaticValueExpression(expression);
+    if (
+      ts.isElementAccessExpression(expression) ||
+      ts.isPropertyAccessExpression(expression)
+    ) {
+      let declaration =
+        checker.getSymbolAtLocation(expression)?.valueDeclaration;
+      let constantValue =
+        checker.getConstantValue(expression) ??
+        (declaration != null && ts.isEnumMember(declaration)
+          ? checker.getConstantValue(declaration)
+          : undefined);
+      if (constantValue == null && ts.isElementAccessExpression(expression)) {
+        const receiver = unwrapStaticValueExpression(expression.expression);
+        let receiverSymbol = checker.getSymbolAtLocation(receiver);
+        if (
+          receiverSymbol != null &&
+          tsutils.isSymbolFlagSet(receiverSymbol, ts.SymbolFlags.Alias)
+        ) {
+          receiverSymbol = checker.getAliasedSymbol(receiverSymbol);
+        }
+        const memberName = getTSStaticValue(
+          expression.argumentExpression,
+        )?.value;
+        if (
+          receiverSymbol != null &&
+          tsutils.isSymbolFlagSet(receiverSymbol, ts.SymbolFlags.Enum) &&
+          typeof memberName === 'string'
+        ) {
+          declaration = checker.getPropertyOfType(
+            checker.getTypeAtLocation(receiver),
+            memberName,
+          )?.valueDeclaration;
+          if (declaration != null && ts.isEnumMember(declaration)) {
+            constantValue = checker.getConstantValue(declaration);
+          }
+        }
+      }
+      if (constantValue != null) {
+        return { value: constantValue };
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Runtime-transparent wrappers plus immutable `const` aliases, with
+   * cycle protection.
+   */
+  function unwrapStaticValueExpression(
+    expression: ts.Expression,
+  ): ts.Expression {
+    const seen = new Set<ts.Expression>();
+    for (;;) {
+      expression = unwrapRuntimeExpression(expression);
+      if (seen.has(expression)) {
+        return expression;
+      }
+      seen.add(expression);
+
+      const initializerExpression = unwrapImmutableAlias(expression);
+      if (initializerExpression === expression) {
+        return expression;
+      }
+      expression = initializerExpression;
+    }
+  }
+
+  /**
+   * Static-value truthiness first, then type-level truthiness.
+   */
+  function getTSStaticTruthiness(
+    expression: ts.Expression,
+  ): boolean | undefined {
+    const value = getTSStaticValue(expression);
+    if (value != null) {
+      return Boolean(value.value);
+    }
+    return getTypeLevelTruthiness(expression);
+  }
+
+  /**
+   * Whether this `break` exits the given switch rather than an inner
+   * loop, switch, or labeled statement.
+   */
+  function breakExitsSwitch(
+    statement: ts.BreakStatement,
+    switchStatement: ts.SwitchStatement,
+  ): boolean {
+    if (statement.label != null) {
+      const labelText = statement.label.text;
+      const label = ts.findAncestor(statement.parent, ancestor => {
+        if (isRuntimeFunctionLike(ancestor)) {
+          return 'quit';
+        }
+        return (
+          ts.isLabeledStatement(ancestor) && ancestor.label.text === labelText
+        );
+      });
+      return (
+        label != null &&
+        ts.isLabeledStatement(label) &&
+        ts.findAncestor(
+          switchStatement,
+          ancestor => ancestor === label.statement,
+        ) != null
+      );
+    }
+
+    return (
+      ts.findAncestor(
+        statement.parent,
+        ancestor =>
+          ts.isSwitchStatement(ancestor) ||
+          ts.isIterationStatement(ancestor, false),
+      ) === switchStatement
+    );
+  }
+
+  /**
+   * Whether a `break`/`continue` transfers control out of the given
+   * iteration statement, following labels.
+   */
+  function controlTransferTargetsIteration(
+    statement: ts.BreakOrContinueStatement,
+    iteration: ts.IterationStatement,
+  ): boolean {
+    if (statement.label != null) {
+      const labelText = statement.label.text;
+      const label = ts.findAncestor(statement.parent, ancestor => {
+        if (isRuntimeFunctionLike(ancestor)) {
+          return 'quit';
+        }
+        return (
+          ts.isLabeledStatement(ancestor) && ancestor.label.text === labelText
+        );
+      });
+      return (
+        label != null &&
+        ts.isLabeledStatement(label) &&
+        ts.findAncestor(iteration, ancestor => ancestor === label.statement) !=
+          null
+      );
+    }
+
+    return (
+      ts.findAncestor(
+        statement.parent,
+        ancestor =>
+          ts.isIterationStatement(ancestor, false) ||
+          (ts.isBreakStatement(statement) && ts.isSwitchStatement(ancestor)),
+      ) === iteration
+    );
+  }
+
+  /**
+   * Whether the loop body can exit the loop itself, which lets an
+   * otherwise-infinite loop complete normally.
+   */
+  function iterationHasTargetedControlTransfer(
+    statement: ts.IterationStatement,
+  ): boolean {
+    let found = false;
+    function visit(node: ts.Node): void {
+      if (found || isRuntimeFunctionLike(node)) {
+        return;
+      }
+      if (
+        ts.isBreakOrContinueStatement(node) &&
+        controlTransferTargetsIteration(node, statement)
+      ) {
+        found = true;
+        return;
+      }
+      ts.forEachChild(node, visit);
+    }
+    visit(statement.statement);
+    return found;
+  }
+
+  function variableDeclarationListNeverCompletes(
+    declarationList: ts.VariableDeclarationList,
+  ): boolean {
+    return declarationList.declarations.some(
+      declaration =>
+        declaration.initializer != null &&
+        expressionNeverCompletes(declaration.initializer),
+    );
+  }
+
+  /** Whether a `break` matching `exits` occurs within the same function. */
+  function hasExitingBreak(
+    root: ts.Node,
+    exits: (breakNode: ts.BreakStatement) => boolean,
+  ): boolean {
+    function visit(node: ts.Node): ts.BreakStatement | undefined {
+      if (isRuntimeFunctionLike(node)) {
+        return undefined;
+      }
+      if (ts.isBreakStatement(node) && exits(node)) {
+        return node;
+      }
+      return ts.forEachChild(node, visit);
+    }
+    return visit(root) != null;
+  }
+
+  /**
+   * A switch with a default and no exiting break completes like its last
+   * clause.
+   */
+  function switchCannotCompleteNormally(
+    statement: ts.SwitchStatement,
+  ): boolean {
+    if (expressionNeverCompletes(statement.expression)) {
+      return true;
+    }
+
+    const clauses = statement.caseBlock.clauses;
+    if (!clauses.some(ts.isDefaultClause)) {
+      return false;
+    }
+
+    if (
+      hasExitingBreak(statement.caseBlock, breakNode =>
+        breakExitsSwitch(breakNode, statement),
+      )
+    ) {
+      return false;
+    }
+
+    return (
+      clauses.at(-1)?.statements.some(statementCannotCompleteNormally) === true
+    );
+  }
+
+  /**
+   * A labeled statement completes normally wherever a matching labeled
+   * `break` escapes it.
+   */
+  function labeledStatementCannotCompleteNormally(
+    statement: ts.LabeledStatement,
+  ): boolean {
+    const labelText = statement.label.text;
+    return (
+      !hasExitingBreak(
+        statement.statement,
+        breakNode => breakNode.label?.text === labelText,
+      ) && statementCannotCompleteNormally(statement.statement)
+    );
+  }
+
+  /**
+   * Cached JavaScript completion semantics per statement.
+   */
+  function statementCannotCompleteNormally(statement: ts.Statement): boolean {
+    const cached = statementCannotCompleteNormallyCache.get(statement);
+    if (cached != null) {
+      return cached;
+    }
+    const result = computeStatementCannotCompleteNormally(statement);
+    statementCannotCompleteNormallyCache.set(statement, result);
+    return result;
+  }
+
+  /**
+   * Structural completion analysis mirroring runtime semantics per
+   * statement kind.
+   */
+  function computeStatementCannotCompleteNormally(
+    statement: ts.Statement,
+  ): boolean {
+    if (
+      ts.isBreakOrContinueStatement(statement) ||
+      ts.isReturnStatement(statement) ||
+      ts.isThrowStatement(statement)
+    ) {
+      return true;
+    }
+    if (ts.isExpressionStatement(statement)) {
+      return expressionNeverCompletes(statement.expression);
+    }
+    if (ts.isVariableStatement(statement)) {
+      return variableDeclarationListNeverCompletes(statement.declarationList);
+    }
+    if (ts.isBlock(statement)) {
+      return blockCannotCompleteNormally(statement);
+    }
+    if (ts.isIfStatement(statement)) {
+      return (
+        expressionNeverCompletes(statement.expression) ||
+        (statement.elseStatement != null &&
+          statementCannotCompleteNormally(statement.thenStatement) &&
+          statementCannotCompleteNormally(statement.elseStatement))
+      );
+    }
+    if (ts.isSwitchStatement(statement)) {
+      return switchCannotCompleteNormally(statement);
+    }
+    if (ts.isDoStatement(statement)) {
+      return (
+        !iterationHasTargetedControlTransfer(statement) &&
+        (statementCannotCompleteNormally(statement.statement) ||
+          expressionNeverCompletes(statement.expression))
+      );
+    }
+    if (ts.isWhileStatement(statement)) {
+      return expressionNeverCompletes(statement.expression);
+    }
+    if (ts.isForStatement(statement)) {
+      return (
+        (statement.initializer != null &&
+          (ts.isVariableDeclarationList(statement.initializer)
+            ? variableDeclarationListNeverCompletes(statement.initializer)
+            : expressionNeverCompletes(statement.initializer))) ||
+        (statement.condition != null &&
+          expressionNeverCompletes(statement.condition))
+      );
+    }
+    if (ts.isForInStatement(statement) || ts.isForOfStatement(statement)) {
+      return expressionNeverCompletes(statement.expression);
+    }
+    if (ts.isLabeledStatement(statement)) {
+      return labeledStatementCannotCompleteNormally(statement);
+    }
+    if (ts.isTryStatement(statement)) {
+      if (
+        statement.finallyBlock != null &&
+        blockCannotCompleteNormally(statement.finallyBlock)
+      ) {
+        return true;
+      }
+      return (
+        blockCannotCompleteNormally(statement.tryBlock) &&
+        (statement.catchClause == null ||
+          blockCannotCompleteNormally(statement.catchClause.block))
+      );
+    }
+    return false;
+  }
+
+  /**
+   * Whether a node sits after a statement that cannot complete normally
+   * within its statement list.
+   */
+  function isAfterNeverCompletion(
+    completion: ts.Node,
+    functionNode: ts.Node,
+  ): boolean {
+    function getUnreachableStatements(
+      container: ts.Block | ts.CaseClause | ts.DefaultClause,
+    ): WeakSet<ts.Statement> {
+      const cached = statementsAfterNeverCompletion.get(container);
+      if (cached != null) {
+        return cached;
+      }
+
+      const unreachable = new WeakSet<ts.Statement>();
+      let precedingStatementNeverCompletes = false;
+      for (const statement of container.statements) {
+        if (precedingStatementNeverCompletes) {
+          unreachable.add(statement);
+          continue;
+        }
+        precedingStatementNeverCompletes =
+          statementCannotCompleteNormally(statement);
+      }
+      statementsAfterNeverCompletion.set(container, unreachable);
+      return unreachable;
+    }
+
+    return (
+      ts.findAncestor(completion, current => {
+        if (current === functionNode || ts.isSourceFile(current)) {
+          return 'quit';
+        }
+        const parent = current.parent;
+        return (
+          ts.isStatement(current) &&
+          (ts.isBlock(parent) ||
+            ts.isCaseClause(parent) ||
+            ts.isDefaultClause(parent)) &&
+          getUnreachableStatements(parent).has(current)
+        );
+      }) != null
+    );
+  }
+
+  /**
+   * Captures whether the block's end was reachable when the visitor
+   * left it.
+   */
+  function recordBlockExit(block: ts.Block): void {
+    blockCanCompleteNormally.set(block, isCurrentCodePathReachable());
+  }
+
+  /**
+   * Direct `eval` can rebind any local, so its presence invalidates every
+   * binding-based conclusion in the function.
+   */
+  function containsDirectEval(
+    functionNode: FunctionLikeDeclarationWithBody,
+  ): boolean {
+    const cached = directEvalByFunction.get(functionNode);
+    if (cached != null) {
+      return cached;
+    }
+
+    let found = false;
+    function visit(node: ts.Node): void {
+      if (found) {
+        return;
+      }
+      if (ts.isCallExpression(node) && !ts.isCallChain(node)) {
+        const callee = unwrapRuntimeExpression(node.expression);
+        if (ts.isIdentifier(callee) && callee.text === 'eval') {
+          found = true;
+          return;
+        }
+      }
+      ts.forEachChild(node, visit);
+    }
+    visit(functionNode.body);
+    directEvalByFunction.set(functionNode, found);
+    return found;
+  }
+
+  /**
+   * Tracks reachable Promise settlement calls with their execution order
+   * and CodePath segments.
+   */
+  function recordCallExit(call: ts.CallExpression): void {
+    if (!promiseSettlementCalls.has(call) || !isCurrentCodePathReachable()) {
+      return;
+    }
+    reachableCalls.add(call);
+    callExecutionOrder.set(call, nextCallExecutionOrder);
+    nextCallExecutionOrder += 1;
+    callCodePathSegments.set(call, [...currentCodePathSegments]);
+  }
+
+  function recordReturn(statement: ts.ReturnStatement): void {
+    if (isCurrentCodePathReachable()) {
+      reachableReturns.add(statement);
+    }
+  }
+
+  function recordYield(expression: ts.YieldExpression): void {
+    if (isCurrentCodePathReachable()) {
+      reachableYields.add(expression);
+    }
+  }
+
+  function onCodePathEnd(): void {
+    currentCodePathSegments =
+      codePathSegmentStack.pop() ?? new Set<TSESLint.CodePathSegment>();
+  }
+
+  function onCodePathSegmentEnd(segment: TSESLint.CodePathSegment): void {
+    currentCodePathSegments.delete(segment);
+  }
+
+  function onCodePathSegmentStart(segment: TSESLint.CodePathSegment): void {
+    currentCodePathSegments.add(segment);
+  }
+
+  function onCodePathStart(): void {
+    codePathSegmentStack.push(currentCodePathSegments);
+    currentCodePathSegments = new Set();
+  }
+
+  return {
+    blockCanCompleteNormally,
+    blockCannotCompleteNormally,
+    callCodePathSegments,
+    callExecutionOrder,
+    containsDirectEval,
+    expressionNeverCompletes,
+    getTSStaticTruthiness,
+    getTSStaticValue,
+    isAfterNeverCompletion,
+    isOverriddenByFinally,
+    isTSNodeInStaticallyUnreachableBranch,
+    onCodePathEnd,
+    onCodePathSegmentEnd,
+    onCodePathSegmentStart,
+    onCodePathStart,
+    promiseSettlementCalls,
+    reachableCalls,
+    reachableReturns,
+    reachableYields,
+    recordBlockExit,
+    recordCallExit,
+    recordReturn,
+    recordYield,
+    unwrapRuntimeExpression,
+  };
+}

--- a/packages/eslint-plugin/src/rules/no-misleading-return-type-utils/expression-observations.ts
+++ b/packages/eslint-plugin/src/rules/no-misleading-return-type-utils/expression-observations.ts
@@ -1,0 +1,994 @@
+import type { TSESLint } from '@typescript-eslint/utils';
+
+import * as tsutils from 'ts-api-utils';
+import * as ts from 'typescript';
+
+import type { AnalysisState } from './analysis-state';
+import type { ControlFlowAnalysis } from './control-flow';
+import type { ExpressionUtilities } from './expression-utils';
+import type { FunctionLikeDeclarationWithBody, Observation } from './shared';
+
+import { isBuiltinSymbolLike, isSymbolFromDefaultLibrary } from '../../util';
+import { isRuntimeFunctionLike, isRuntimeFunctionLikeWithBody } from './shared';
+
+interface BuiltinPromiseExecutor {
+  executor: ts.ArrowFunction | ts.FunctionExpression;
+  rejecterSymbol: ts.Symbol | undefined;
+  resolverSymbol: ts.Symbol;
+}
+
+export interface ExpressionAnalysis {
+  collectBuiltinPromiseSettlementCalls: (
+    promiseExecutor: BuiltinPromiseExecutor,
+  ) => void;
+  collectReturns: (body: ts.Node) => Observation[];
+  getBuiltinPromiseExecutor: (
+    expression: ts.NewExpression,
+  ) => BuiltinPromiseExecutor | undefined;
+  getExpressionObservations: (expression: ts.Expression) => Observation[];
+  observationNeedsProjection: (node: ts.Node) => boolean;
+  projectAwaited: (observations: readonly Observation[]) => Observation[];
+}
+
+export function createExpressionAnalysis(
+  state: AnalysisState,
+  controlFlow: ControlFlowAnalysis,
+  expressionUtilities: ExpressionUtilities,
+): ExpressionAnalysis {
+  const {
+    analyzableUndefinedType,
+    checker,
+    isNeverLike,
+    isTypeAssignableTo,
+    isUncertain,
+    program,
+    resolveObservation,
+  } = state;
+  const {
+    callCodePathSegments,
+    callExecutionOrder,
+    containsDirectEval,
+    expressionNeverCompletes,
+    getTSStaticTruthiness,
+    getTSStaticValue,
+    isAfterNeverCompletion,
+    isOverriddenByFinally,
+    isTSNodeInStaticallyUnreachableBranch,
+    promiseSettlementCalls,
+    reachableCalls,
+    reachableReturns,
+    unwrapRuntimeExpression,
+  } = controlFlow;
+  const { unwrapImmutableAlias, unwrapTransparentExpression } =
+    expressionUtilities;
+  const symbolsWrittenFromNestedExecutionContexts = new WeakMap<
+    FunctionLikeDeclarationWithBody,
+    Set<ts.Symbol>
+  >();
+
+  /**
+   * Whether a binding can hold a different value than its flow type shows:
+   * parameters, catch variables, and non-`const` bindings that outer code
+   * or nested contexts can write.
+   */
+  function bindingCanChange(
+    declaration: ts.Declaration,
+    symbol: ts.Symbol,
+  ): boolean {
+    const binding = ts.findAncestor(
+      declaration,
+      (node): node is ts.ParameterDeclaration | ts.VariableDeclaration =>
+        ts.isParameter(node) || ts.isVariableDeclaration(node),
+    );
+    if (binding == null) {
+      return false;
+    }
+    if (ts.isParameter(binding) || ts.isCatchClause(binding.parent)) {
+      return true;
+    }
+    if (tsutils.isNodeFlagSet(binding.parent, ts.NodeFlags.Const)) {
+      return false;
+    }
+    const declaringFunction = ts.findAncestor(
+      binding.parent,
+      isRuntimeFunctionLikeWithBody,
+    );
+    return (
+      declaringFunction == null ||
+      containsDirectEval(declaringFunction) ||
+      getSymbolsWrittenFromNestedExecutionContexts(declaringFunction).has(
+        symbol,
+      )
+    );
+  }
+
+  /**
+   * Declared type for bindings owned by an enclosing scope, whose value
+   * other calls may change between reads.
+   */
+  function getDeclaredNonLocalBindingType(
+    expression: ts.Expression,
+  ): ts.Type | undefined {
+    if (!ts.isIdentifier(expression)) {
+      return undefined;
+    }
+    const containingFunction = ts.findAncestor(
+      expression.parent,
+      isRuntimeFunctionLikeWithBody,
+    );
+    let symbol = checker.getSymbolAtLocation(expression);
+    if (containingFunction == null || symbol == null) {
+      return undefined;
+    }
+    if (tsutils.isSymbolFlagSet(symbol, ts.SymbolFlags.Alias)) {
+      symbol = checker.getAliasedSymbol(symbol);
+    }
+    const declaration = symbol.valueDeclaration;
+    if (
+      declaration == null ||
+      ts.findAncestor(
+        declaration,
+        ancestor => ancestor === containingFunction,
+      ) != null ||
+      !bindingCanChange(declaration, symbol)
+    ) {
+      return undefined;
+    }
+    return checker.getTypeOfSymbolAtLocation(symbol, declaration);
+  }
+
+  /**
+   * Every symbol along a property/element access chain, receiver included.
+   */
+  function getAccessPathSymbols(expression: ts.Expression): ts.Symbol[] {
+    const symbols: ts.Symbol[] = [];
+    for (;;) {
+      expression = unwrapRuntimeExpression(expression);
+      if (ts.isPropertyAccessExpression(expression)) {
+        const symbol = checker.getSymbolAtLocation(expression.name);
+        if (symbol != null) {
+          symbols.push(symbol);
+        }
+        expression = expression.expression;
+        continue;
+      }
+      if (ts.isElementAccessExpression(expression)) {
+        const symbol = checker.getSymbolAtLocation(
+          expression.argumentExpression,
+        );
+        if (symbol != null) {
+          symbols.push(symbol);
+        }
+        expression = expression.expression;
+        continue;
+      }
+      const symbol = checker.getSymbolAtLocation(expression);
+      if (symbol != null) {
+        symbols.push(symbol);
+      }
+      return symbols;
+    }
+  }
+
+  /**
+   * The declared type of an access path, without flow narrowing, resolved member by
+   * member from the declared receiver type.
+   */
+  function getDeclaredAccessType(
+    expression: ts.Expression,
+  ): ts.Type | undefined {
+    expression = unwrapRuntimeExpression(expression);
+    if (ts.isIdentifier(expression) || tsutils.isThisExpression(expression)) {
+      const symbol = checker.getSymbolAtLocation(expression);
+      return symbol == null
+        ? undefined
+        : checker.getTypeOfSymbolAtLocation(
+            symbol,
+            symbol.valueDeclaration ?? expression,
+          );
+    }
+
+    if (ts.isPropertyAccessExpression(expression)) {
+      const receiver = getDeclaredAccessType(expression.expression);
+      const property =
+        (receiver == null
+          ? undefined
+          : checker.getPropertyOfType(
+              checker.getApparentType(receiver),
+              expression.name.text,
+            )) ?? checker.getSymbolAtLocation(expression.name);
+      return property == null
+        ? undefined
+        : checker.getTypeOfSymbolAtLocation(property, expression);
+    }
+
+    if (ts.isElementAccessExpression(expression)) {
+      const receiver = getDeclaredAccessType(expression.expression);
+      if (receiver == null) {
+        return undefined;
+      }
+
+      const keyType = checker.getTypeAtLocation(expression.argumentExpression);
+      const property = getExactElementAccessProperty(receiver, keyType);
+      if (property != null) {
+        return checker.getTypeOfSymbolAtLocation(property, expression);
+      }
+
+      const indexKind = tsutils.isTypeFlagSet(keyType, ts.TypeFlags.NumberLike)
+        ? ts.IndexKind.Number
+        : tsutils.isTypeFlagSet(keyType, ts.TypeFlags.StringLike)
+          ? ts.IndexKind.String
+          : undefined;
+      return indexKind == null
+        ? undefined
+        : checker.getIndexTypeOfType(receiver, indexKind);
+    }
+
+    return undefined;
+  }
+
+  /**
+   * The concrete property a literal-keyed element access resolves to.
+   */
+  function getExactElementAccessProperty(
+    receiver: ts.Type,
+    keyType: ts.Type,
+  ): ts.Symbol | undefined {
+    const exactName = tsutils.isStringLiteralType(keyType)
+      ? keyType.value
+      : tsutils.isNumberLiteralType(keyType)
+        ? String(keyType.value)
+        : undefined;
+    return exactName == null
+      ? undefined
+      : checker.getPropertyOfType(checker.getApparentType(receiver), exactName);
+  }
+
+  /**
+   * An element access with no exact property, served by an index
+   * signature — the position that can produce `undefined` at runtime.
+   */
+  function isUncheckedElementAccess(expression: ts.Expression): boolean {
+    if (!ts.isElementAccessExpression(expression)) {
+      return false;
+    }
+    const receiver = getDeclaredAccessType(expression.expression);
+    return (
+      receiver != null &&
+      getExactElementAccessProperty(
+        receiver,
+        checker.getTypeAtLocation(expression.argumentExpression),
+      ) == null &&
+      getDeclaredAccessType(expression) != null
+    );
+  }
+
+  /**
+   * Symbols assigned inside nested functions of this function; their flow
+   * narrowing cannot be trusted at the outer level.
+   */
+  function getSymbolsWrittenFromNestedExecutionContexts(
+    functionNode: FunctionLikeDeclarationWithBody,
+  ): Set<ts.Symbol> {
+    const cached = symbolsWrittenFromNestedExecutionContexts.get(functionNode);
+    if (cached != null) {
+      return cached;
+    }
+
+    const symbols = new Set<ts.Symbol>();
+    symbolsWrittenFromNestedExecutionContexts.set(functionNode, symbols);
+    function visit(node: ts.Node, insideNestedContext: boolean): void {
+      const nested =
+        insideNestedContext ||
+        (node !== functionNode &&
+          (isRuntimeFunctionLike(node) ||
+            ts.isClassDeclaration(node) ||
+            ts.isClassExpression(node)));
+      if (nested && ts.isExpression(node)) {
+        const access = tsutils.getAccessKind(node);
+        if (
+          (access & (tsutils.AccessKind.Write | tsutils.AccessKind.Delete)) !==
+          0
+        ) {
+          if (
+            ts.isIdentifier(node) &&
+            ts.isShorthandPropertyAssignment(node.parent) &&
+            node.parent.name === node
+          ) {
+            const symbol = checker.getShorthandAssignmentValueSymbol(
+              node.parent,
+            );
+            if (symbol != null) {
+              symbols.add(symbol);
+            }
+          } else {
+            for (const symbol of getAccessPathSymbols(node)) {
+              symbols.add(symbol);
+            }
+          }
+        }
+      }
+      ts.forEachChild(node, child => visit(child, nested));
+    }
+    visit(functionNode.body, false);
+    return symbols;
+  }
+
+  /**
+   * Declared type for reads whose access path contains a symbol written
+   * from a nested execution context.
+   */
+  function getDeclaredCapturedType(
+    expression: ts.Expression,
+  ): ts.Type | undefined {
+    const containingFunction = ts.findAncestor(
+      expression.parent,
+      isRuntimeFunctionLikeWithBody,
+    );
+    if (
+      containingFunction == null ||
+      !getAccessPathSymbols(expression).some(symbol =>
+        getSymbolsWrittenFromNestedExecutionContexts(containingFunction).has(
+          symbol,
+        ),
+      )
+    ) {
+      return undefined;
+    }
+    return getDeclaredAccessType(expression);
+  }
+
+  /**
+   * An expression's observable type: declared types where narrowing is
+   * unstable, otherwise the flow type, preserving type parameters that
+   * contextual typing resolved to their whole constraint.
+   */
+  function getExpressionType(expression: ts.Expression): ts.Type {
+    expression = unwrapTransparentExpression(expression);
+    const capturedDeclaredType = getDeclaredCapturedType(expression);
+    if (capturedDeclaredType != null) {
+      return capturedDeclaredType;
+    }
+    const nonLocalDeclaredType = getDeclaredNonLocalBindingType(expression);
+    if (nonLocalDeclaredType != null) {
+      return nonLocalDeclaredType;
+    }
+    if (
+      ts.isPropertyAccessExpression(expression) ||
+      ts.isElementAccessExpression(expression)
+    ) {
+      const declaredAccessType = getDeclaredAccessType(expression);
+      if (declaredAccessType != null) {
+        return declaredAccessType;
+      }
+    }
+    const type = checker.getTypeAtLocation(expression);
+    if (!ts.isIdentifier(expression) || tsutils.isTypeParameter(type)) {
+      return type;
+    }
+
+    // Contextual return typing can resolve an identifier whose declared type
+    // is a type parameter to its constraint. Preserve that type parameter
+    // only when the observed type is the entire constraint; a proper subset
+    // is flow narrowing and must remain visible to the rule.
+    const symbol = checker.getSymbolAtLocation(expression);
+    const declaredType =
+      symbol &&
+      checker.getTypeOfSymbolAtLocation(
+        symbol,
+        symbol.valueDeclaration ?? expression,
+      );
+    if (declaredType && tsutils.isTypeParameter(declaredType)) {
+      const constraint = checker.getBaseConstraintOfType(declaredType);
+      if (
+        (constraint == null && isUncertain(type)) ||
+        (constraint != null &&
+          isTypeAssignableTo(type, constraint) &&
+          isTypeAssignableTo(constraint, type))
+      ) {
+        return declaredType;
+      }
+    }
+    return type;
+  }
+
+  /**
+   * The set of (node, type) values an expression can produce, splitting
+   * conditionals, `??`, and comma chains and re-adding `undefined` where
+   * the location type or unchecked index access implies it.
+   */
+  function getExpressionObservations(expression: ts.Expression): Observation[] {
+    const runtimeExpression = unwrapImmutableAlias(expression, true);
+    if (
+      ts.isAsExpression(runtimeExpression) ||
+      ts.isTypeAssertionExpression(runtimeExpression) ||
+      ts.isNonNullExpression(runtimeExpression)
+    ) {
+      const operand = runtimeExpression.expression;
+      const operandType = getExpressionType(operand);
+      const assertedType = checker.getTypeAtLocation(runtimeExpression);
+      if (
+        isUncertain(operandType) ||
+        (isTypeAssignableTo(assertedType, operandType) &&
+          !isTypeAssignableTo(operandType, assertedType))
+      ) {
+        // Narrowing assertions are erased at runtime, so the operand retains
+        // every value the function can actually return. Widening assertions
+        // and incomparable casts are explicit escape hatches: the developer
+        // pinned a contract the operand's type cannot express, and the
+        // asserted type is what callers observe.
+        return getExpressionObservations(operand);
+      }
+    }
+    if (expressionNeverCompletes(runtimeExpression)) {
+      return [];
+    }
+    if (ts.isConditionalExpression(runtimeExpression)) {
+      const truthiness = getTSStaticTruthiness(runtimeExpression.condition);
+      if (truthiness != null) {
+        return getExpressionObservations(
+          truthiness ? runtimeExpression.whenTrue : runtimeExpression.whenFalse,
+        );
+      }
+      return [
+        ...getExpressionObservations(runtimeExpression.whenTrue),
+        ...getExpressionObservations(runtimeExpression.whenFalse),
+      ];
+    }
+    if (ts.isBinaryExpression(runtimeExpression)) {
+      if (runtimeExpression.operatorToken.kind === ts.SyntaxKind.CommaToken) {
+        return getExpressionObservations(runtimeExpression.right);
+      }
+      if (
+        runtimeExpression.operatorToken.kind ===
+        ts.SyntaxKind.QuestionQuestionToken
+      ) {
+        const leftValue = getTSStaticValue(runtimeExpression.left);
+        if (leftValue != null) {
+          return getExpressionObservations(
+            leftValue.value == null
+              ? runtimeExpression.right
+              : runtimeExpression.left,
+          );
+        }
+        const nonNullishLeft = getExpressionObservations(
+          runtimeExpression.left,
+        ).flatMap(observation => {
+          const resolved = resolveObservation(observation);
+          const type = checker.getNonNullableType(resolved.type);
+          return isNeverLike(type) ? [] : [{ ...observation, type }];
+        });
+        return [
+          ...nonNullishLeft,
+          ...getExpressionObservations(runtimeExpression.right),
+        ];
+      }
+    }
+    if (ts.isObjectLiteralExpression(runtimeExpression)) {
+      return [{ node: runtimeExpression }];
+    }
+
+    const type = getExpressionType(runtimeExpression);
+    const observations: Observation[] = [{ node: runtimeExpression, type }];
+    if (
+      analyzableUndefinedType != null &&
+      !isTypeAssignableTo(analyzableUndefinedType, type)
+    ) {
+      const locationType = checker.getTypeAtLocation(runtimeExpression);
+      if (
+        isTypeAssignableTo(analyzableUndefinedType, locationType) ||
+        isUncheckedElementAccess(runtimeExpression)
+      ) {
+        observations.push({
+          node: runtimeExpression,
+          type: analyzableUndefinedType,
+        });
+      }
+    }
+    return observations;
+  }
+
+  /**
+   * Syntax whose literal shape can reveal a narrower value than its
+   * contextually widened type.
+   */
+  function observationNeedsProjection(node: ts.Node): boolean {
+    return (
+      ts.isArrayLiteralExpression(node) ||
+      ts.isArrowFunction(node) ||
+      ts.isCallExpression(node) ||
+      ts.isFunctionExpression(node) ||
+      ts.isNewExpression(node) ||
+      ts.isObjectLiteralExpression(node)
+    );
+  }
+
+  /**
+   * Observations for every reachable `return`, excluding nested functions
+   * and returns overridden by a non-completing `finally`.
+   */
+  function collectReturns(body: ts.Node): Observation[] {
+    const observations: Observation[] = [];
+
+    function visit(node: ts.Node): void {
+      if (isRuntimeFunctionLike(node)) {
+        return;
+      }
+      if (ts.isReturnStatement(node)) {
+        if (
+          !reachableReturns.has(node) ||
+          isTSNodeInStaticallyUnreachableBranch(node) ||
+          isOverriddenByFinally(node, body.parent) ||
+          isAfterNeverCompletion(node, body.parent)
+        ) {
+          return;
+        }
+        observations.push(
+          ...(node.expression
+            ? getExpressionObservations(node.expression)
+            : [{ node, type: checker.getUndefinedType() }]),
+        );
+        return;
+      }
+      ts.forEachChild(node, visit);
+    }
+
+    visit(body);
+    return observations;
+  }
+
+  /**
+   * The executor of a built-in `new Promise(...)` call together with its
+   * resolver/rejecter parameter symbols.
+   */
+  function getBuiltinPromiseExecutor(
+    expression: ts.NewExpression,
+  ): BuiltinPromiseExecutor | undefined {
+    if (
+      (expression.typeArguments?.length ?? 0) > 0 ||
+      !isBuiltinSymbolLike(
+        program,
+        checker.getTypeAtLocation(expression.expression),
+        'PromiseConstructor',
+      )
+    ) {
+      return undefined;
+    }
+
+    const executorArgument = expression.arguments?.at(0);
+    if (executorArgument == null) {
+      return undefined;
+    }
+    const executor = unwrapRuntimeExpression(executorArgument);
+    if (
+      (!ts.isArrowFunction(executor) && !ts.isFunctionExpression(executor)) ||
+      executor.parameters.length === 0 ||
+      !ts.isIdentifier(executor.parameters[0].name)
+    ) {
+      return undefined;
+    }
+
+    const resolverSymbol = checker.getSymbolAtLocation(
+      executor.parameters[0].name,
+    );
+    if (resolverSymbol == null) {
+      return undefined;
+    }
+    const rejecterName = executor.parameters.at(1)?.name;
+    const rejecterSymbol =
+      rejecterName != null && ts.isIdentifier(rejecterName)
+        ? checker.getSymbolAtLocation(rejecterName)
+        : undefined;
+    return { executor, rejecterSymbol, resolverSymbol };
+  }
+
+  /**
+   * Registers every direct resolver/rejecter call inside an executor for
+   * reachability tracking.
+   */
+  function collectBuiltinPromiseSettlementCalls(
+    promiseExecutor: BuiltinPromiseExecutor,
+  ): void {
+    const { executor, rejecterSymbol, resolverSymbol } = promiseExecutor;
+    function visit(node: ts.Node): void {
+      if (ts.isCallExpression(node)) {
+        const callee = unwrapRuntimeExpression(node.expression);
+        if (ts.isIdentifier(callee)) {
+          const symbol = checker.getSymbolAtLocation(callee);
+          if (
+            symbol === resolverSymbol ||
+            (rejecterSymbol != null && symbol === rejecterSymbol)
+          ) {
+            promiseSettlementCalls.add(node);
+          }
+        }
+      }
+      ts.forEachChild(node, visit);
+    }
+    visit(executor.body);
+  }
+
+  /**
+   * The value a directly-analyzable executor settles with: its first
+   * reachable settlement per execution path, or nothing when the resolver
+   * escapes.
+   */
+  function projectBuiltinPromiseResolution(
+    observation: Observation,
+  ): Observation[] | undefined {
+    if (!ts.isNewExpression(observation.node)) {
+      return undefined;
+    }
+    const promiseExecutor = getBuiltinPromiseExecutor(observation.node);
+    if (promiseExecutor == null) {
+      return undefined;
+    }
+    const { executor, rejecterSymbol, resolverSymbol } = promiseExecutor;
+    const executorBody = executor.body;
+
+    function getFirstSettlementCalls(
+      calls: readonly ts.CallExpression[],
+    ): readonly ts.CallExpression[] | undefined {
+      const callsBySegment = new Map<
+        TSESLint.CodePathSegment,
+        ts.CallExpression[]
+      >();
+      const callSegments: TSESLint.CodePathSegment[] = [];
+      for (const call of calls) {
+        const segments = callCodePathSegments.get(call);
+        if (
+          segments == null ||
+          segments.length === 0 ||
+          !callExecutionOrder.has(call)
+        ) {
+          return undefined;
+        }
+        for (const segment of segments) {
+          callSegments.push(segment);
+          const segmentCalls = callsBySegment.get(segment);
+          if (segmentCalls == null) {
+            callsBySegment.set(segment, [call]);
+          } else {
+            segmentCalls.push(call);
+          }
+        }
+      }
+      for (const segmentCalls of callsBySegment.values()) {
+        segmentCalls.sort(
+          (a, b) =>
+            (callExecutionOrder.get(a) ?? 0) - (callExecutionOrder.get(b) ?? 0),
+        );
+      }
+
+      const initialSegments = new Set<TSESLint.CodePathSegment>();
+      const preceding = [...callSegments];
+      const visitedPreceding = new Set<TSESLint.CodePathSegment>();
+      for (
+        let segment = preceding.pop();
+        segment != null;
+        segment = preceding.pop()
+      ) {
+        if (visitedPreceding.has(segment)) {
+          continue;
+        }
+        visitedPreceding.add(segment);
+        if (segment.prevSegments.length === 0) {
+          initialSegments.add(segment);
+        } else {
+          preceding.push(...segment.prevSegments);
+        }
+      }
+      if (initialSegments.size !== 1) {
+        return undefined;
+      }
+
+      const firstCalls = new Set<ts.CallExpression>();
+      const pending = [...initialSegments];
+      const seen = new Set<TSESLint.CodePathSegment>();
+      for (
+        let segment = pending.pop();
+        segment != null;
+        segment = pending.pop()
+      ) {
+        if (seen.has(segment) || !segment.reachable) {
+          continue;
+        }
+        seen.add(segment);
+        const first = callsBySegment.get(segment)?.at(0);
+        if (first != null) {
+          firstCalls.add(first);
+          continue;
+        }
+        pending.push(...segment.nextSegments);
+      }
+      return [...firstCalls];
+    }
+
+    const localFunctionSymbols = new WeakMap<
+      ts.FunctionLikeDeclaration,
+      ts.Symbol
+    >();
+    const localFunctionBindings = new Map<ts.Symbol, Set<ts.Identifier>>();
+    const localFunctionBindingNames = new WeakSet<ts.Identifier>();
+    function collectLocalFunctionBindings(node: ts.Node): void {
+      if (node !== executor && isRuntimeFunctionLike(node)) {
+        let binding: ts.BindingName | undefined;
+        if (ts.isFunctionDeclaration(node)) {
+          binding = node.name;
+        } else if (
+          (ts.isArrowFunction(node) || ts.isFunctionExpression(node)) &&
+          ts.isVariableDeclaration(node.parent) &&
+          node.parent.initializer === node
+        ) {
+          binding = node.parent.name;
+        }
+        if (binding != null && ts.isIdentifier(binding)) {
+          const symbol = checker.getSymbolAtLocation(binding);
+          if (symbol != null) {
+            localFunctionSymbols.set(node, symbol);
+            localFunctionBindingNames.add(binding);
+            const bindings = localFunctionBindings.get(symbol);
+            if (bindings == null) {
+              localFunctionBindings.set(symbol, new Set([binding]));
+            } else {
+              bindings.add(binding);
+            }
+          }
+        }
+      }
+      ts.forEachChild(node, collectLocalFunctionBindings);
+    }
+    collectLocalFunctionBindings(executorBody);
+
+    function isInDeferredInstanceFieldInitializer(node: ts.Node): boolean {
+      let child = node;
+      return (
+        ts.findAncestor(node, ancestor => {
+          if (ancestor === executor) {
+            return 'quit';
+          }
+          const isInitializer =
+            ts.isPropertyDeclaration(ancestor) &&
+            ancestor.initializer === child;
+          child = ancestor;
+          return (
+            isInitializer &&
+            !tsutils.includesModifier(
+              ancestor.modifiers,
+              ts.SyntaxKind.StaticKeyword,
+            )
+          );
+        }) != null
+      );
+    }
+
+    const referencedByLocalFunction = new Map<ts.Symbol, Set<ts.Symbol>>();
+    const rootLocalFunctionSymbols = new Set<ts.Symbol>();
+    const opaqueRootLocalFunctionSymbols = new Set<ts.Symbol>();
+    function recordLocalFunctionReference(
+      referencedSymbol: ts.Symbol,
+      location: ts.Identifier,
+    ): void {
+      if (isInDeferredInstanceFieldInitializer(location)) {
+        opaqueRootLocalFunctionSymbols.add(referencedSymbol);
+        return;
+      }
+      const containingFunction = ts.findAncestor(
+        location.parent,
+        isRuntimeFunctionLike,
+      );
+      const containingSymbol =
+        containingFunction == null
+          ? undefined
+          : localFunctionSymbols.get(containingFunction);
+      if (containingFunction === executor) {
+        rootLocalFunctionSymbols.add(referencedSymbol);
+        return;
+      }
+      if (containingSymbol == null) {
+        opaqueRootLocalFunctionSymbols.add(referencedSymbol);
+        return;
+      }
+      const referenced = referencedByLocalFunction.get(containingSymbol);
+      if (referenced == null) {
+        referencedByLocalFunction.set(
+          containingSymbol,
+          new Set([referencedSymbol]),
+        );
+      } else {
+        referenced.add(referencedSymbol);
+      }
+    }
+
+    function collectLocalFunctionReferences(node: ts.Node): void {
+      if (ts.isTypeNode(node)) {
+        return;
+      }
+      if (ts.isIdentifier(node) && !localFunctionBindingNames.has(node)) {
+        const symbol = checker.getSymbolAtLocation(node);
+        if (symbol != null && localFunctionBindings.has(symbol)) {
+          recordLocalFunctionReference(symbol, node);
+        }
+      }
+      ts.forEachChild(node, collectLocalFunctionReferences);
+    }
+    collectLocalFunctionReferences(executorBody);
+
+    function collectReachableLocalFunctionSymbols(
+      roots: ReadonlySet<ts.Symbol>,
+    ): Set<ts.Symbol> {
+      const reachable = new Set<ts.Symbol>();
+      const pending = [...roots];
+      for (let symbol = pending.pop(); symbol != null; symbol = pending.pop()) {
+        if (reachable.has(symbol)) {
+          continue;
+        }
+        reachable.add(symbol);
+        for (const referenced of referencedByLocalFunction.get(symbol) ?? []) {
+          if (!reachable.has(referenced)) {
+            pending.push(referenced);
+          }
+        }
+      }
+      return reachable;
+    }
+    const reachableLocalFunctionSymbols = collectReachableLocalFunctionSymbols(
+      rootLocalFunctionSymbols,
+    );
+    const opaqueReachableLocalFunctionSymbols =
+      collectReachableLocalFunctionSymbols(opaqueRootLocalFunctionSymbols);
+
+    function isUnreachableLocalFunction(
+      node: ts.FunctionLikeDeclaration,
+    ): boolean {
+      const symbol = localFunctionSymbols.get(node);
+      return (
+        symbol != null &&
+        !reachableLocalFunctionSymbols.has(symbol) &&
+        !opaqueReachableLocalFunctionSymbols.has(symbol)
+      );
+    }
+
+    const resolved: Observation[] = [];
+    const resolutionsByCall = new Map<ts.CallExpression, Observation[]>();
+    const directSettlementCalls: ts.CallExpression[] = [];
+    function visit(node: ts.Node): true | undefined {
+      if (
+        node !== executor &&
+        isRuntimeFunctionLike(node) &&
+        isUnreachableLocalFunction(node)
+      ) {
+        return;
+      }
+      const settlementSymbol = ts.isIdentifier(node)
+        ? checker.getSymbolAtLocation(node)
+        : undefined;
+      if (
+        settlementSymbol === resolverSymbol ||
+        (rejecterSymbol != null && settlementSymbol === rejecterSymbol)
+      ) {
+        if (isInDeferredInstanceFieldInitializer(node)) {
+          return true;
+        }
+        const containingFunction = ts.findAncestor(
+          node.parent,
+          isRuntimeFunctionLike,
+        );
+        if (containingFunction !== executor) {
+          const containingSymbol =
+            containingFunction == null
+              ? undefined
+              : localFunctionSymbols.get(containingFunction);
+          if (
+            containingSymbol == null ||
+            (!reachableLocalFunctionSymbols.has(containingSymbol) &&
+              opaqueReachableLocalFunctionSymbols.has(containingSymbol))
+          ) {
+            return true;
+          }
+        }
+        const parent = node.parent;
+        if (ts.isCallExpression(parent) && parent.expression === node) {
+          if (
+            !reachableCalls.has(parent) ||
+            isTSNodeInStaticallyUnreachableBranch(parent)
+          ) {
+            return;
+          }
+          const isResolution = settlementSymbol === resolverSymbol;
+          const value = parent.arguments.at(0);
+          const resolution = isResolution
+            ? value == null
+              ? [{ node: parent, type: checker.getUndefinedType() }]
+              : projectAwaited(getExpressionObservations(value))
+            : [];
+          if (isResolution) {
+            resolved.push(...resolution);
+          }
+          resolutionsByCall.set(parent, resolution);
+          if (
+            ts.findAncestor(parent.parent, isRuntimeFunctionLike) === executor
+          ) {
+            directSettlementCalls.push(parent);
+          }
+          return;
+        }
+        return true;
+      }
+      return ts.forEachChild(node, visit);
+    }
+    if (visit(executorBody) === true) {
+      return undefined;
+    }
+    if (
+      directSettlementCalls.length > 0 &&
+      directSettlementCalls.length === resolutionsByCall.size
+    ) {
+      const firstCalls = getFirstSettlementCalls(directSettlementCalls);
+      if (firstCalls != null) {
+        return firstCalls.flatMap(call => resolutionsByCall.get(call) ?? []);
+      }
+    }
+    return resolved;
+  }
+
+  /**
+   * Awaited values of promise observations, using executor settlement and
+   * `Promise.resolve` syntax before falling back to `getAwaitedType`.
+   */
+  function projectAwaited(observations: readonly Observation[]): Observation[] {
+    return observations.flatMap(observation => {
+      const constructed = projectBuiltinPromiseResolution(observation);
+      if (constructed != null) {
+        return constructed;
+      }
+      if (
+        ts.isCallExpression(observation.node) &&
+        observation.node.typeArguments == null &&
+        ts.isPropertyAccessExpression(observation.node.expression) &&
+        observation.node.expression.name.text === 'resolve'
+      ) {
+        const method = checker.getSymbolAtLocation(
+          observation.node.expression.name,
+        );
+        if (
+          method != null &&
+          isSymbolFromDefaultLibrary(program, method) &&
+          isBuiltinSymbolLike(
+            program,
+            checker.getTypeAtLocation(observation.node.expression.expression),
+            'PromiseConstructor',
+          )
+        ) {
+          const value = observation.node.arguments.at(0);
+          return value == null
+            ? [
+                {
+                  node: observation.node,
+                  type: checker.getUndefinedType(),
+                },
+              ]
+            : projectAwaited(getExpressionObservations(value));
+        }
+      }
+
+      const resolved = resolveObservation(observation);
+      const awaited = checker.getAwaitedType(resolved.type);
+      return [
+        {
+          node: observation.node,
+          type: awaited ?? resolved.type,
+        },
+      ];
+    });
+  }
+
+  return {
+    collectBuiltinPromiseSettlementCalls,
+    collectReturns,
+    getBuiltinPromiseExecutor,
+    getExpressionObservations,
+    observationNeedsProjection,
+    projectAwaited,
+  };
+}

--- a/packages/eslint-plugin/src/rules/no-misleading-return-type-utils/expression-utils.ts
+++ b/packages/eslint-plugin/src/rules/no-misleading-return-type-utils/expression-utils.ts
@@ -1,0 +1,102 @@
+import * as tsutils from 'ts-api-utils';
+import * as ts from 'typescript';
+
+import type { AnalysisState } from './analysis-state';
+
+export interface ExpressionUtilities {
+  unwrapImmutableAlias: (
+    expression: ts.Expression,
+    preserveFlowType?: boolean,
+  ) => ts.Expression;
+  unwrapTransparentExpression: (expression: ts.Expression) => ts.Expression;
+}
+
+export function createExpressionUtilities(
+  state: AnalysisState,
+): ExpressionUtilities {
+  const { checker, isTypeAssignableTo } = state;
+
+  /**
+   * Skips wrappers that do not change the runtime value: parentheses,
+   * `satisfies`, and const assertions.
+   */
+  function unwrapTransparentExpression(
+    expression: ts.Expression,
+  ): ts.Expression {
+    for (;;) {
+      if (ts.isParenthesizedExpression(expression)) {
+        expression = expression.expression;
+        continue;
+      }
+      // Comparing the syntax kind directly stays inert on TypeScript
+      // versions whose parser predates `satisfies`.
+      if (expression.kind === ts.SyntaxKind.SatisfiesExpression) {
+        expression = (expression as ts.SatisfiesExpression).expression;
+        continue;
+      }
+      if (
+        (ts.isAsExpression(expression) ||
+          ts.isTypeAssertionExpression(expression)) &&
+        tsutils.isConstAssertionExpression(expression)
+      ) {
+        expression = expression.expression;
+        continue;
+      }
+      return expression;
+    }
+  }
+
+  /**
+   * Follows `const` initializers transparently; `preserveFlowType` keeps
+   * the identifier when a type guard narrowed it after initialization.
+   */
+  function unwrapImmutableAlias(
+    expression: ts.Expression,
+    preserveFlowType = false,
+  ): ts.Expression {
+    const seen = new Set<ts.Symbol>();
+    for (;;) {
+      expression = unwrapTransparentExpression(expression);
+      if (!ts.isIdentifier(expression)) {
+        return expression;
+      }
+
+      const symbol = checker.getSymbolAtLocation(expression);
+      const declaration = symbol?.valueDeclaration;
+      if (
+        symbol == null ||
+        seen.has(symbol) ||
+        declaration == null ||
+        !ts.isVariableDeclaration(declaration) ||
+        !ts.isIdentifier(declaration.name) ||
+        declaration.initializer == null ||
+        !ts.isVariableDeclarationList(declaration.parent) ||
+        !tsutils.isNodeFlagSet(declaration.parent, ts.NodeFlags.Const)
+      ) {
+        return expression;
+      }
+
+      if (preserveFlowType) {
+        const expressionType = checker.getTypeAtLocation(expression);
+        const initializerType = checker.getTypeAtLocation(
+          declaration.initializer,
+        );
+        if (
+          expressionType !== initializerType &&
+          (!isTypeAssignableTo(expressionType, initializerType) ||
+            !isTypeAssignableTo(initializerType, expressionType))
+        ) {
+          // A type guard may narrow a const identifier after its
+          // initialization. Replacing that identifier with the initializer
+          // would discard the narrower flow type at the return site.
+          return expression;
+        }
+      }
+
+      seen.add(symbol);
+      expression = declaration.initializer;
+    }
+  }
+
+  return { unwrapImmutableAlias, unwrapTransparentExpression };
+}

--- a/packages/eslint-plugin/src/rules/no-misleading-return-type-utils/property-key-matching.ts
+++ b/packages/eslint-plugin/src/rules/no-misleading-return-type-utils/property-key-matching.ts
@@ -1,0 +1,179 @@
+import * as tsutils from 'ts-api-utils';
+import * as ts from 'typescript';
+
+import type { AnalysisState } from './analysis-state';
+
+export interface PropertyKeyMatching {
+  propertyKeyTypesMayOverlap: (
+    propertyKey: ts.Type,
+    indexKey: ts.Type,
+  ) => boolean;
+  stringPropertyMatchesIndexKey: (value: string, indexKey: ts.Type) => boolean;
+}
+
+type PropertyKeyMatchingState = Pick<
+  AnalysisState,
+  'checker' | 'isDeferredType' | 'isTypeAssignableTo' | 'isUncertain'
+>;
+
+export function createPropertyKeyMatching(
+  state: PropertyKeyMatchingState,
+): PropertyKeyMatching {
+  const { checker, isDeferredType, isTypeAssignableTo, isUncertain } = state;
+
+  /**
+   * Whether any reachable constituent is deferred or a bare
+   * type parameter, making key comparisons inconclusive.
+   */
+  function typeContainsDeferredConstituent(
+    type: ts.Type,
+    seen = new Set<ts.Type>(),
+  ): boolean {
+    if (seen.has(type)) {
+      return true;
+    }
+    if (isDeferredType(type) || tsutils.isTypeParameter(type)) {
+      return true;
+    }
+
+    seen.add(type);
+    if (type.isUnion() || type.isIntersection()) {
+      return type.types.some(member =>
+        typeContainsDeferredConstituent(member, seen),
+      );
+    }
+    if (tsutils.isTemplateLiteralType(type)) {
+      return type.types.some(member =>
+        typeContainsDeferredConstituent(member, seen),
+      );
+    }
+    if (tsutils.isStringMappingType(type)) {
+      return typeContainsDeferredConstituent(type.type, seen);
+    }
+    return (
+      type.aliasTypeArguments?.some(member =>
+        typeContainsDeferredConstituent(member, seen),
+      ) === true
+    );
+  }
+
+  /**
+   * Whether a concrete property name can satisfy an index signature's key
+   * type, using the checker's own assignability relation.
+   */
+  function stringPropertyMatchesIndexKey(
+    value: string,
+    indexKey: ts.Type,
+  ): boolean {
+    if (
+      typeof checker.getStringLiteralType !== 'function' ||
+      typeof checker.getNumberLiteralType !== 'function'
+    ) {
+      // TypeScript before 5.1 cannot construct literal key types, so the
+      // assignability comparison below is unavailable. Treating the key as
+      // possibly covered only suppresses diagnostics on those runtimes.
+      return true;
+    }
+
+    // The checker's own assignability relation covers every index key form,
+    // including template literal types and intrinsic string mappings.
+    if (isTypeAssignableTo(checker.getStringLiteralType(value), indexKey)) {
+      return true;
+    }
+
+    if (
+      tsutils.isNumericPropertyName(value) &&
+      isTypeAssignableTo(checker.getNumberLiteralType(Number(value)), indexKey)
+    ) {
+      return true;
+    }
+
+    if (!typeContainsDeferredConstituent(indexKey)) {
+      return false;
+    }
+
+    const constraint = checker.getBaseConstraintOfType(indexKey);
+    return (
+      constraint == null ||
+      constraint === indexKey ||
+      isUncertain(constraint) ||
+      stringPropertyMatchesIndexKey(value, constraint)
+    );
+  }
+
+  /**
+   * Conservative overlap test for two key types; uncertainty counts as
+   * overlap so a possible collision is never ruled out.
+   */
+  function propertyKeyTypesMayOverlap(
+    propertyKey: ts.Type,
+    indexKey: ts.Type,
+  ): boolean {
+    if (propertyKey.isUnion()) {
+      return propertyKey.types.some(member =>
+        propertyKeyTypesMayOverlap(member, indexKey),
+      );
+    }
+    if (indexKey.isUnion()) {
+      return indexKey.types.some(member =>
+        propertyKeyTypesMayOverlap(propertyKey, member),
+      );
+    }
+    if (
+      isUncertain(propertyKey) ||
+      isUncertain(indexKey) ||
+      isDeferredType(propertyKey) ||
+      isDeferredType(indexKey) ||
+      tsutils.isTypeParameter(propertyKey) ||
+      tsutils.isTypeParameter(indexKey)
+    ) {
+      return true;
+    }
+    if (
+      isTypeAssignableTo(propertyKey, indexKey) ||
+      isTypeAssignableTo(indexKey, propertyKey)
+    ) {
+      return true;
+    }
+
+    const symbolFlags = ts.TypeFlags.ESSymbol | ts.TypeFlags.UniqueESSymbol;
+    if (
+      tsutils.isTypeFlagSet(propertyKey, symbolFlags) ||
+      tsutils.isTypeFlagSet(indexKey, symbolFlags)
+    ) {
+      return false;
+    }
+
+    if (
+      tsutils.isStringLiteralType(propertyKey) &&
+      tsutils.isTypeFlagSet(
+        indexKey,
+        ts.TypeFlags.Number | ts.TypeFlags.NumberLiteral,
+      )
+    ) {
+      return stringPropertyMatchesIndexKey(propertyKey.value, indexKey);
+    }
+    if (
+      tsutils.isStringLiteralType(indexKey) &&
+      tsutils.isTypeFlagSet(
+        propertyKey,
+        ts.TypeFlags.Number | ts.TypeFlags.NumberLiteral,
+      )
+    ) {
+      return stringPropertyMatchesIndexKey(indexKey.value, propertyKey);
+    }
+
+    const stringFlags =
+      ts.TypeFlags.String |
+      ts.TypeFlags.StringLiteral |
+      ts.TypeFlags.StringMapping |
+      ts.TypeFlags.TemplateLiteral;
+    const numberFlags = ts.TypeFlags.Number | ts.TypeFlags.NumberLiteral;
+    return (
+      tsutils.isTypeFlagSet(propertyKey, stringFlags | numberFlags) &&
+      tsutils.isTypeFlagSet(indexKey, stringFlags | numberFlags)
+    );
+  }
+
+  return { propertyKeyTypesMayOverlap, stringPropertyMatchesIndexKey };
+}

--- a/packages/eslint-plugin/src/rules/no-misleading-return-type-utils/property-projections.ts
+++ b/packages/eslint-plugin/src/rules/no-misleading-return-type-utils/property-projections.ts
@@ -1,0 +1,615 @@
+import * as tsutils from 'ts-api-utils';
+import * as ts from 'typescript';
+
+import type { AnalysisState } from './analysis-state';
+import type { CallableProjections } from './callable-projections';
+import type { ControlFlowAnalysis } from './control-flow';
+import type { ExpressionAnalysis } from './expression-observations';
+import type { Observation, PropertyProjection } from './shared';
+
+import { createPropertyKeyMatching } from './property-key-matching';
+import { hasAnyDecorators, MAX_ARRAY_INDEX } from './shared';
+
+export interface PropertyProjections {
+  getPropertyName: (name: ts.PropertyName) => string | undefined;
+  projectIndex: (
+    observations: readonly Observation[],
+    keyType: ts.Type,
+    coveredKeys?: ReadonlySet<string>,
+  ) => Observation[];
+  projectProperty: (
+    observations: readonly Observation[],
+    expectedProperty: ts.Symbol,
+  ) => Observation[];
+}
+
+export function createPropertyProjections(
+  state: AnalysisState,
+  controlFlow: ControlFlowAnalysis,
+  expressions: ExpressionAnalysis,
+  callables: CallableProjections,
+): PropertyProjections {
+  const {
+    checker,
+    expandObservations,
+    getAnalysisObjectId,
+    isTypeAssignableTo,
+    isUncertain,
+    resolveObservation,
+  } = state;
+  const { getTSStaticValue, unwrapRuntimeExpression } = controlFlow;
+  const { collectReturns, getExpressionObservations } = expressions;
+  const { projectTupleElement } = callables;
+  const { propertyKeyTypesMayOverlap, stringPropertyMatchesIndexKey } =
+    createPropertyKeyMatching(state);
+  const objectLiteralPropertiesByName = new WeakMap<
+    ts.ObjectLiteralExpression,
+    ReadonlyMap<string, ts.ObjectLiteralElementLike> | null
+  >();
+
+  /**
+   * A property's declared type on the observed value, marking whether the
+   * property is always present.
+   */
+  function projectPropertyFromType(
+    observation: Observation,
+    expectedProperty: ts.Symbol,
+    fromObjectSpread = false,
+  ): PropertyProjection {
+    const resolved = resolveObservation(observation);
+    const property = checker.getPropertyOfType(
+      checker.getApparentType(resolved.type),
+      expectedProperty.getName(),
+    );
+    const declarations = property?.getDeclarations();
+    const isDefinitelyNonEnumerableClassMember =
+      fromObjectSpread &&
+      declarations != null &&
+      declarations.length > 0 &&
+      declarations.every(
+        declaration =>
+          (ts.isMethodDeclaration(declaration) ||
+            ts.isGetAccessorDeclaration(declaration) ||
+            ts.isSetAccessorDeclaration(declaration)) &&
+          (ts.isClassDeclaration(declaration.parent) ||
+            ts.isClassExpression(declaration.parent)) &&
+          !hasAnyDecorators(declaration) &&
+          !hasAnyDecorators(declaration.parent),
+      );
+    return property == null || isDefinitelyNonEnumerableClassMember
+      ? { alwaysPresent: false, observations: [] }
+      : {
+          alwaysPresent: !tsutils.isSymbolFlagSet(
+            property,
+            ts.SymbolFlags.Optional,
+          ),
+          observations: [
+            {
+              node: observation.node,
+              type: checker.getTypeOfSymbolAtLocation(
+                property,
+                observation.node,
+              ),
+            },
+          ],
+        };
+  }
+
+  /**
+   * A property's values from object-literal syntax: initializers,
+   * shorthand reads, and getter returns.
+   */
+  function projectObjectLiteralProperty(
+    observation: Observation,
+    expectedProperty: ts.Symbol,
+    property: ts.ObjectLiteralElementLike,
+  ): Observation[] {
+    if (ts.isPropertyAssignment(property)) {
+      return getExpressionObservations(property.initializer);
+    }
+    if (ts.isShorthandPropertyAssignment(property)) {
+      return getExpressionObservations(property.name);
+    }
+    if (ts.isGetAccessorDeclaration(property)) {
+      return property.body == null ? [] : collectReturns(property.body);
+    }
+    return projectPropertyFromType(observation, expectedProperty).observations;
+  }
+
+  /**
+   * Statically-keyed properties of an object literal by key id, or
+   * nothing when a key cannot be resolved.
+   */
+  function getIndexedObjectLiteralProperties(
+    object: ts.ObjectLiteralExpression,
+  ): ReadonlyMap<string, ts.ObjectLiteralElementLike> | undefined {
+    const cached = objectLiteralPropertiesByName.get(object);
+    if (cached != null || objectLiteralPropertiesByName.has(object)) {
+      return cached ?? undefined;
+    }
+
+    const properties = new Map<string, ts.ObjectLiteralElementLike>();
+    for (const property of object.properties) {
+      if (ts.isSpreadAssignment(property)) {
+        objectLiteralPropertiesByName.set(object, null);
+        return undefined;
+      }
+      const name = getPropertyName(property.name);
+      if (name == null) {
+        objectLiteralPropertiesByName.set(object, null);
+        return undefined;
+      }
+      properties.set(name, property);
+    }
+    objectLiteralPropertiesByName.set(object, properties);
+    return properties;
+  }
+
+  /**
+   * A property's values from each observation, with whether the property
+   * is provably always present.
+   */
+  function projectPropertyWithPresence(
+    observations: readonly Observation[],
+    expectedProperty: ts.Symbol,
+    fromObjectSpread = false,
+  ): PropertyProjection {
+    const expanded = expandObservations(observations);
+    const projected = expanded.map((observation): PropertyProjection => {
+      if (fromObjectSpread && ts.isArrayLiteralExpression(observation.node)) {
+        const expectedName = expectedProperty.getName();
+        const index = Number(expectedName);
+        if (
+          !Number.isInteger(index) ||
+          index < 0 ||
+          index >= MAX_ARRAY_INDEX ||
+          String(index) !== expectedName
+        ) {
+          // Object spread copies an array's enumerable index properties,
+          // not non-enumerable members such as `length` or prototype
+          // methods exposed by its structural TypeScript type.
+          return { alwaysPresent: false, observations: [] };
+        }
+
+        const prefix = observation.node.elements.slice(0, index + 1);
+        if (!prefix.some(ts.isSpreadElement)) {
+          const element = observation.node.elements.at(index);
+          return element == null || ts.isOmittedExpression(element)
+            ? { alwaysPresent: false, observations: [] }
+            : {
+                alwaysPresent: true,
+                observations: getExpressionObservations(element),
+              };
+        }
+
+        return {
+          alwaysPresent: false,
+          observations: projectTupleElement([observation], index, false),
+        };
+      }
+
+      if (ts.isObjectLiteralExpression(observation.node)) {
+        const properties = observation.node.properties;
+        const expectedName = expectedProperty.getName();
+        const indexedProperties = getIndexedObjectLiteralProperties(
+          observation.node,
+        );
+        if (indexedProperties != null) {
+          const property = indexedProperties.get(expectedName);
+          return property == null
+            ? { alwaysPresent: false, observations: [] }
+            : {
+                alwaysPresent: true,
+                observations: projectObjectLiteralProperty(
+                  observation,
+                  expectedProperty,
+                  property,
+                ),
+              };
+        }
+
+        const possibleValues: Observation[] = [];
+        for (let index = properties.length - 1; index >= 0; index -= 1) {
+          const property = properties[index];
+          if (ts.isSpreadAssignment(property)) {
+            const spreadProjection = projectPropertyWithPresence(
+              getExpressionObservations(property.expression),
+              expectedProperty,
+              true,
+            );
+            possibleValues.push(...spreadProjection.observations);
+            if (spreadProjection.alwaysPresent) {
+              return {
+                alwaysPresent: true,
+                observations: possibleValues,
+              };
+            }
+            continue;
+          }
+
+          const propertyName = getPropertyName(property.name);
+          const hasUnknownComputedName =
+            propertyName == null && ts.isComputedPropertyName(property.name);
+          if (propertyName !== expectedName && !hasUnknownComputedName) {
+            continue;
+          }
+
+          possibleValues.push(
+            ...projectObjectLiteralProperty(
+              observation,
+              expectedProperty,
+              property,
+            ),
+          );
+
+          if (propertyName === expectedName) {
+            return {
+              alwaysPresent: true,
+              observations: possibleValues,
+            };
+          }
+        }
+        return { alwaysPresent: false, observations: possibleValues };
+      }
+
+      const resolved = resolveObservation(observation);
+      if (isUncertain(resolved.type)) {
+        return { alwaysPresent: false, observations: [resolved] };
+      }
+
+      const projection = projectPropertyFromType(
+        resolved,
+        expectedProperty,
+        fromObjectSpread,
+      );
+      return fromObjectSpread
+        ? { ...projection, alwaysPresent: false }
+        : projection;
+    });
+
+    return {
+      alwaysPresent:
+        projected.length > 0 &&
+        projected.every(projection => projection.alwaysPresent),
+      observations: projected.flatMap(projection => projection.observations),
+    };
+  }
+
+  /**
+   * Routes a property projection through object-literal syntax when
+   * available, otherwise through the type.
+   */
+  function projectProperty(
+    observations: readonly Observation[],
+    expectedProperty: ts.Symbol,
+  ): Observation[] {
+    const projection = projectPropertyWithPresence(
+      observations,
+      expectedProperty,
+    );
+    if (projection.alwaysPresent || observations.length === 0) {
+      return projection.observations;
+    }
+    return [
+      ...projection.observations,
+      { node: observations[0].node, type: checker.getUndefinedType() },
+    ];
+  }
+
+  /**
+   * Whether a written property name can be served by an index signature
+   * key type.
+   */
+  function propertyNameMatchesIndexKey(
+    name: ts.PropertyName,
+    indexKey: ts.Type,
+  ): boolean {
+    if (ts.isPrivateIdentifier(name)) {
+      return false;
+    }
+    if (ts.isComputedPropertyName(name)) {
+      return propertyKeyTypesMayOverlap(
+        checker.getTypeAtLocation(name.expression),
+        indexKey,
+      );
+    }
+    if (
+      ts.isIdentifier(name) ||
+      ts.isNumericLiteral(name) ||
+      ts.isStringLiteralLike(name)
+    ) {
+      return stringPropertyMatchesIndexKey(name.text, indexKey);
+    }
+    return false;
+  }
+
+  /**
+   * Whether a type's property can be served by an index signature key
+   * type, via its declarations.
+   */
+  function propertyMatchesIndexKey(
+    property: ts.Symbol,
+    indexKey: ts.Type,
+  ): boolean {
+    return (property.getDeclarations() ?? []).some(declaration => {
+      const name = ts.getNameOfDeclaration(declaration);
+      return (
+        name != null &&
+        ts.isPropertyName(name) &&
+        propertyNameMatchesIndexKey(name, indexKey)
+      );
+    });
+  }
+
+  /**
+   * A stable key id for literal and unique-symbol key types.
+   */
+  function exactPropertyKeyIdFromType(type: ts.Type): string | undefined {
+    if (tsutils.isStringLiteralType(type)) {
+      return `string:${type.value}`;
+    }
+    if (tsutils.isNumberLiteralType(type)) {
+      return `string:${String(type.value)}`;
+    }
+    if (tsutils.isUniqueESSymbolType(type)) {
+      const symbol = type.getSymbol();
+      return symbol == null
+        ? undefined
+        : `symbol:${getAnalysisObjectId(symbol)}`;
+    }
+    return undefined;
+  }
+
+  /**
+   * A stable key id for statically-resolvable property names.
+   */
+  function exactPropertyKeyId(name: ts.PropertyName): string | undefined {
+    if (ts.isIdentifier(name) || ts.isStringLiteralLike(name)) {
+      return `string:${name.text}`;
+    }
+    if (ts.isNumericLiteral(name)) {
+      return `string:${String(Number(name.text))}`;
+    }
+    if (!ts.isComputedPropertyName(name)) {
+      return undefined;
+    }
+
+    const expression = unwrapRuntimeExpression(name.expression);
+    const staticValue = getTSStaticValue(expression)?.value;
+    if (typeof staticValue === 'string' || typeof staticValue === 'number') {
+      return `string:${String(staticValue)}`;
+    }
+    return exactPropertyKeyIdFromType(checker.getTypeAtLocation(expression));
+  }
+
+  function propertyIsCoveredByLaterWrite(
+    property: ts.Symbol,
+    coveredKeys: ReadonlySet<string>,
+  ): boolean {
+    return (
+      property.getDeclarations()?.some(declaration => {
+        const name = ts.getNameOfDeclaration(declaration);
+        const key =
+          name != null && ts.isPropertyName(name)
+            ? exactPropertyKeyId(name)
+            : undefined;
+        return key != null && coveredKeys.has(key);
+      }) === true
+    );
+  }
+
+  /**
+   * Whether every key the requested key type can name was overwritten by
+   * a later property write.
+   */
+  function keyTypeIsCoveredByLaterWrites(
+    keyType: ts.Type,
+    coveredKeys: ReadonlySet<string>,
+  ): boolean {
+    if (keyType.isUnion()) {
+      return keyType.types.every(member =>
+        keyTypeIsCoveredByLaterWrites(member, coveredKeys),
+      );
+    }
+    const key = exactPropertyKeyIdFromType(keyType);
+    return key != null && coveredKeys.has(key);
+  }
+
+  /**
+   * Values an index signature can expose from an object literal,
+   * honoring last-write-wins across properties and spreads.
+   */
+  function projectObjectLiteralIndex(
+    object: ts.ObjectLiteralExpression,
+    keyType: ts.Type,
+    coveredKeys: Set<string>,
+  ): Observation[] {
+    const observations: Observation[] = [];
+    for (let index = object.properties.length - 1; index >= 0; index -= 1) {
+      const property = object.properties[index];
+      if (ts.isSpreadAssignment(property)) {
+        const spreadObservations = expandObservations(
+          getExpressionObservations(property.expression),
+        );
+        if (
+          spreadObservations.length > 0 &&
+          spreadObservations.every(observation =>
+            ts.isObjectLiteralExpression(observation.node),
+          )
+        ) {
+          const branchCoveredKeys: Set<string>[] = [];
+          for (const observation of spreadObservations) {
+            const coveredInBranch = new Set(coveredKeys);
+            observations.push(
+              ...projectObjectLiteralIndex(
+                observation.node as ts.ObjectLiteralExpression,
+                keyType,
+                coveredInBranch,
+              ),
+            );
+            branchCoveredKeys.push(coveredInBranch);
+          }
+          for (const key of branchCoveredKeys[0]) {
+            if (
+              branchCoveredKeys.every(branchCovered => branchCovered.has(key))
+            ) {
+              coveredKeys.add(key);
+            }
+          }
+        } else {
+          observations.push(
+            ...projectIndex(spreadObservations, keyType, coveredKeys),
+          );
+        }
+        continue;
+      }
+
+      const exactKey = exactPropertyKeyId(property.name);
+      const isCovered = exactKey != null && coveredKeys.has(exactKey);
+      if (!isCovered && propertyNameMatchesIndexKey(property.name, keyType)) {
+        if (ts.isPropertyAssignment(property)) {
+          observations.push(...getExpressionObservations(property.initializer));
+        } else if (ts.isShorthandPropertyAssignment(property)) {
+          observations.push(...getExpressionObservations(property.name));
+        } else if (ts.isGetAccessorDeclaration(property)) {
+          if (property.body != null) {
+            observations.push(...collectReturns(property.body));
+          }
+        } else {
+          observations.push({
+            node: property,
+            type: checker.getTypeAtLocation(property),
+          });
+        }
+      }
+      if (exactKey != null) {
+        coveredKeys.add(exactKey);
+      }
+    }
+    return observations;
+  }
+
+  /**
+   * Whether an index signature serves the requested key, including string
+   * signatures serving numeric keys.
+   */
+  function indexInfoCoversKey(
+    indexKey: ts.Type,
+    requestedKey: ts.Type,
+  ): boolean {
+    return (
+      isTypeAssignableTo(requestedKey, indexKey) ||
+      (tsutils.isTypeFlagSet(
+        requestedKey,
+        ts.TypeFlags.Number | ts.TypeFlags.NumberLiteral,
+      ) &&
+        tsutils.isTypeFlagSet(indexKey, ts.TypeFlags.String))
+    );
+  }
+
+  /**
+   * The covering index signatures, narrowed to the most specific ones.
+   */
+  function getMostSpecificIndexInfos(
+    type: ts.Type,
+    requestedKey: ts.Type,
+  ): readonly ts.IndexInfo[] {
+    const covering = checker
+      .getIndexInfosOfType(type)
+      .filter(indexInfo => indexInfoCoversKey(indexInfo.keyType, requestedKey));
+    return covering.filter(
+      candidate =>
+        !covering.some(
+          other =>
+            other !== candidate &&
+            indexInfoCoversKey(candidate.keyType, other.keyType) &&
+            !indexInfoCoversKey(other.keyType, candidate.keyType),
+        ),
+    );
+  }
+
+  /**
+   * Values observable through a type's index signature for the requested
+   * key type.
+   */
+  function projectIndex(
+    observations: readonly Observation[],
+    keyType: ts.Type,
+    coveredKeys: ReadonlySet<string> = new Set(),
+  ): Observation[] {
+    return expandObservations(observations).flatMap(observation => {
+      if (keyTypeIsCoveredByLaterWrites(keyType, coveredKeys)) {
+        return [];
+      }
+
+      if (ts.isObjectLiteralExpression(observation.node)) {
+        const projected = projectObjectLiteralIndex(
+          observation.node,
+          keyType,
+          new Set(coveredKeys),
+        );
+        if (projected.length > 0) {
+          return projected;
+        }
+      }
+
+      const resolved = resolveObservation(observation);
+      if (isUncertain(resolved.type)) {
+        return [resolved];
+      }
+
+      const indexed = getMostSpecificIndexInfos(resolved.type, keyType)
+        .map(indexInfo => indexInfo.type)
+        .filter(type => !tsutils.isTypeFlagSet(type, ts.TypeFlags.Never));
+      if (indexed.length > 0) {
+        return indexed.map(type => ({ node: observation.node, type }));
+      }
+
+      return checker
+        .getPropertiesOfType(resolved.type)
+        .filter(
+          property =>
+            propertyMatchesIndexKey(property, keyType) &&
+            !propertyIsCoveredByLaterWrite(property, coveredKeys),
+        )
+        .map(property => ({
+          node: observation.node,
+          type: checker.getTypeOfSymbolAtLocation(property, observation.node),
+        }));
+    });
+  }
+
+  /**
+   * The static text of a property name, including computed names that
+   * resolve to a well-known symbol or literal.
+   */
+  function getPropertyName(name: ts.PropertyName): string | undefined {
+    if (
+      ts.isIdentifier(name) ||
+      ts.isPrivateIdentifier(name) ||
+      ts.isStringLiteralLike(name) ||
+      ts.isNumericLiteral(name)
+    ) {
+      return name.text;
+    }
+    if (ts.isComputedPropertyName(name)) {
+      if (
+        ts.isStringLiteralLike(name.expression) ||
+        ts.isNumericLiteral(name.expression)
+      ) {
+        return name.expression.text;
+      }
+      const symbol = checker.getSymbolAtLocation(name);
+      if (symbol != null && !symbol.getName().startsWith('__computed')) {
+        return symbol.getName();
+      }
+    }
+    return undefined;
+  }
+
+  return {
+    getPropertyName,
+    projectIndex,
+    projectProperty,
+  };
+}

--- a/packages/eslint-plugin/src/rules/no-misleading-return-type-utils/shared.ts
+++ b/packages/eslint-plugin/src/rules/no-misleading-return-type-utils/shared.ts
@@ -1,0 +1,164 @@
+import type {
+  ParserServicesWithTypeInformation,
+  TSESLint,
+  TSESTree,
+} from '@typescript-eslint/utils';
+
+import * as tsutils from 'ts-api-utils';
+import * as ts from 'typescript';
+
+export const TYPE_STRING_MAX_LENGTH = 80;
+export const MAX_ANALYSIS_WORK = 10_000;
+export const MAX_ANALYSIS_SYNTAX_DEPTH = 256;
+
+/**
+ * Maximum nesting depth of structural positions the analyzer projects into.
+ * The work budget bounds how many checker operations run, but each
+ * operation's own cost grows with the depth of the types involved, so an
+ * operation count alone cannot bound wall-clock time on pathologically deep
+ * types. A depth bound is deterministic across machines, unlike a time
+ * budget, so the same code produces the same diagnostics everywhere.
+ */
+export const MAX_ANALYSIS_TYPE_DEPTH = 32;
+export const MAX_ARRAY_INDEX = 0xffff_ffff;
+export const STATIC_SWITCH_NO_ENTRY = -1;
+export const STATIC_SWITCH_UNKNOWN = -2;
+
+export const ARRAY_NAMES = [
+  'Array',
+  'ArrayLike',
+  'ConcatArray',
+  'ReadonlyArray',
+];
+export const ASYNC_ITERABLE_NAMES = [
+  'AsyncGenerator',
+  'AsyncIterable',
+  'AsyncIterableIterator',
+  'AsyncIterator',
+];
+export const GENERATOR_NAMES = [
+  'AsyncGenerator',
+  'AsyncIterable',
+  'AsyncIterableIterator',
+  'AsyncIterator',
+  'Generator',
+  'Iterable',
+  'IterableIterator',
+  'Iterator',
+];
+export const MAP_NAMES = ['Map', 'ReadonlyMap', 'WeakMap'];
+export const SET_NAMES = ['ReadonlySet', 'Set', 'WeakSet'];
+export const STRUCTURAL_DEFAULT_LIBRARY_NAMES = ['TypedPropertyDescriptor'];
+export const VALUE_WRAPPER_NAMES = [
+  'IteratorReturnResult',
+  'IteratorYieldResult',
+  'PromiseFulfilledResult',
+];
+export const WEAK_REF_NAMES = ['WeakRef'];
+
+export type FunctionNode =
+  | TSESTree.ArrowFunctionExpression
+  | TSESTree.FunctionDeclaration
+  | TSESTree.FunctionExpression;
+
+export type FunctionLikeDeclarationWithBody = ts.FunctionLikeDeclaration & {
+  body: ts.ConciseBody;
+};
+
+export type MessageIds = 'misleadingReturnType';
+export type RuleContext = Readonly<TSESLint.RuleContext<MessageIds, []>>;
+
+export interface RuleDependencies {
+  checker: ts.TypeChecker;
+  context: RuleContext;
+  program: ts.Program;
+  services: ParserServicesWithTypeInformation;
+}
+
+export interface Observation {
+  node: ts.Node;
+  type?: ts.Type;
+}
+
+export interface ResolvedObservation extends Observation {
+  type: ts.Type;
+}
+
+export interface AnalysisPath {
+  depth: number;
+  parent: AnalysisPath | undefined;
+  type: ts.Type;
+}
+
+export interface ResolvedAnalysisTask {
+  anchor: ts.Node;
+  observations: readonly Observation[];
+  path: AnalysisPath | undefined;
+  type: ts.Type;
+  unused: ts.Type[];
+}
+
+export interface PropertyProjection {
+  alwaysPresent: boolean;
+  observations: Observation[];
+}
+
+export interface SignatureParameterDomain {
+  prefix: { type: ts.Type; required: boolean }[];
+  rest: ts.Type | undefined;
+  suffix: { type: ts.Type; required: boolean }[];
+}
+
+/** An `any`, `unknown`, or checker error type proves nothing either way. */
+export function isUncertain(type: ts.Type): boolean {
+  return (
+    tsutils.isTypeFlagSet(type, ts.TypeFlags.Any | ts.TypeFlags.Unknown) ||
+    tsutils.isIntrinsicErrorType(type)
+  );
+}
+
+/**
+ * Deferred constructs cannot be compared until type parameters are
+ * instantiated.
+ */
+export function isDeferredType(type: ts.Type): boolean {
+  return (
+    tsutils.isTypeFlagSet(
+      type,
+      ts.TypeFlags.Conditional |
+        ts.TypeFlags.Index |
+        ts.TypeFlags.IndexedAccess |
+        ts.TypeFlags.Substitution,
+    ) ||
+    (tsutils.isObjectType(type) &&
+      tsutils.isObjectFlagSet(type, ts.ObjectFlags.Mapped))
+  );
+}
+
+export function truncateTypeString(type: string): string {
+  return type.length > TYPE_STRING_MAX_LENGTH
+    ? `${type.slice(0, TYPE_STRING_MAX_LENGTH)}...`
+    : type;
+}
+
+export function isRuntimeFunctionLike(
+  node: ts.Node,
+): node is ts.FunctionLikeDeclaration {
+  // `ts.isFunctionLike` also includes signature-only type nodes. Runtime
+  // function declarations are the members of that union that carry `body`.
+  return ts.isFunctionLike(node) && 'body' in node;
+}
+
+export function isRuntimeFunctionLikeWithBody(
+  node: ts.Node,
+): node is FunctionLikeDeclarationWithBody {
+  return isRuntimeFunctionLike(node) && node.body != null;
+}
+
+export function hasAnyDecorators(node: ts.Node): boolean {
+  // `ts-api-utils.hasDecorators` narrows nodes that can carry decorators; it
+  // does not test whether a node actually has any.
+  return (
+    ts.canHaveDecorators(node) && (ts.getDecorators(node)?.length ?? 0) > 0
+  );
+}

--- a/packages/eslint-plugin/src/rules/no-misleading-return-type-utils/type-analysis.ts
+++ b/packages/eslint-plugin/src/rules/no-misleading-return-type-utils/type-analysis.ts
@@ -1,0 +1,840 @@
+import * as tsutils from 'ts-api-utils';
+import * as ts from 'typescript';
+
+import type { AnalysisState } from './analysis-state';
+import type { CallableProjections } from './callable-projections';
+import type { ExpressionAnalysis } from './expression-observations';
+import type { PropertyProjections } from './property-projections';
+import type {
+  AnalysisPath,
+  Observation,
+  ResolvedAnalysisTask,
+  ResolvedObservation,
+} from './shared';
+
+import { isBuiltinSymbolLike, isSymbolFromDefaultLibrary } from '../../util';
+import {
+  ARRAY_NAMES,
+  ASYNC_ITERABLE_NAMES,
+  GENERATOR_NAMES,
+  MAP_NAMES,
+  MAX_ANALYSIS_TYPE_DEPTH,
+  SET_NAMES,
+  STRUCTURAL_DEFAULT_LIBRARY_NAMES,
+  VALUE_WRAPPER_NAMES,
+  WEAK_REF_NAMES,
+} from './shared';
+
+export interface TypeAnalysis {
+  analyzeResolvedType: (
+    type: ts.Type,
+    anchor: ts.Node,
+    observations: readonly Observation[],
+    unused: ts.Type[],
+    path: AnalysisPath | undefined,
+  ) => void;
+  analyzeTypeNode: (
+    node: ts.TypeNode,
+    observations: readonly Observation[],
+    unused: ts.Type[],
+  ) => void;
+  collectUnobservedUnionMembers: (type: ts.Type, unused: ts.Type[]) => void;
+  resetTypeAnalysis: () => void;
+}
+
+export function createTypeAnalysis(
+  state: AnalysisState,
+  expressions: ExpressionAnalysis,
+  properties: PropertyProjections,
+  callables: CallableProjections,
+): TypeAnalysis {
+  const {
+    checker,
+    consumeAnalysisWork,
+    expandResolvedObservations,
+    getAnalysisStateKey,
+    isDeferredType,
+    isExemptVoidLike,
+    isNeverLike,
+    isTypeAssignableTo,
+    isUncertain,
+    program,
+    resolveObservation,
+  } = state;
+  const { observationNeedsProjection, projectAwaited } = expressions;
+  const { projectIndex, projectProperty } = properties;
+  const {
+    projectArrayElement,
+    projectIterableElement,
+    projectMapEntry,
+    projectMethodParameter,
+    projectMethodReturn,
+    projectSignatureReturn,
+    projectTupleElement,
+  } = callables;
+  let analyzedTypeStates = new WeakMap<ts.Type, Set<string>>();
+  let analysisTasks: ResolvedAnalysisTask[] = [];
+  let analysisTaskIndex = 0;
+  let drainingAnalysisTasks = false;
+
+  // Deliberately parallel to `analyzeUnion` below: this variant walks a
+  // resolved union, where the checker has already normalized absorbed
+  // constituents and reduced literal pairs, so it needs the boolean-pair
+  // special case but no absorption handling. The syntactic variant needs the
+  // opposite. Unifying them would replace those two structural differences
+  // with injected callbacks.
+  function analyzeResolvedUnion(
+    type: ts.Type,
+    anchor: ts.Node,
+    observations: readonly Observation[],
+    unused: ts.Type[],
+    path: AnalysisPath,
+  ): void {
+    // `boolean` is represented internally as `false | true`, but its syntax
+    // deliberately abstracts both literals just like `string` abstracts all
+    // string literals.
+    if (!type.isUnion() || tsutils.isTypeFlagSet(type, ts.TypeFlags.Boolean)) {
+      return;
+    }
+
+    const candidates = expandResolvedObservations(observations);
+    if (
+      candidates.length === 0 ||
+      candidates.some(candidate => isUncertain(candidate.type)) ||
+      type.types.some(isUncertain)
+    ) {
+      return;
+    }
+
+    const observableMembers = type.types.filter(
+      member => !isNeverLike(member) && !isExemptVoidLike(member),
+    );
+    if (
+      candidates.some(
+        candidate =>
+          !tsutils.isTypeFlagSet(candidate.type, ts.TypeFlags.Never) &&
+          !isExemptVoidLike(candidate.type) &&
+          !tsutils.isTypeParameter(candidate.type) &&
+          !observableMembers.some(member =>
+            isTypeAssignableTo(candidate.type, member),
+          ) &&
+          (isDeferredType(candidate.type) ||
+            isTypeAssignableTo(candidate.type, type)),
+      )
+    ) {
+      // Deferred conditional, indexed-access, and mapped types can span a
+      // union without being assignable to any one constituent until their
+      // type parameters are instantiated. Treating every constituent as
+      // absent would be a false positive, so this union is not divisible.
+      return;
+    }
+
+    const memberTypes = new Set(type.types);
+    const trueType = checker.getTrueType();
+    const falseType = checker.getFalseType();
+    const hasBooleanPair =
+      memberTypes.has(trueType) && memberTypes.has(falseType);
+    const exactCandidates = new Map<ts.Type, ResolvedObservation[]>();
+    const nonExactCandidates: ResolvedObservation[] = [];
+    for (const candidate of candidates) {
+      if (!memberTypes.has(candidate.type)) {
+        nonExactCandidates.push(candidate);
+        continue;
+      }
+      const exact = exactCandidates.get(candidate.type);
+      if (exact == null) {
+        exactCandidates.set(candidate.type, [candidate]);
+      } else {
+        exact.push(candidate);
+      }
+    }
+
+    for (const member of type.types) {
+      if (
+        isNeverLike(member) ||
+        isExemptVoidLike(member) ||
+        isCallerInstantiatedMember(member)
+      ) {
+        continue;
+      }
+      const matching =
+        hasBooleanPair && (member === trueType || member === falseType)
+          ? candidates.filter(candidate =>
+              isTypeAssignableTo(candidate.type, checker.getBooleanType()),
+            )
+          : [
+              ...(exactCandidates.get(member) ?? []),
+              ...nonExactCandidates.filter(candidate =>
+                isTypeAssignableTo(candidate.type, member),
+              ),
+            ];
+      if (matching.length === 0) {
+        unused.push(member);
+      } else {
+        analyzeResolvedType(member, anchor, matching, unused, path);
+      }
+    }
+  }
+
+  /**
+   * An open member's value space is decided by the caller's instantiation
+   * (`RuleMap[R]` can be anything, `T` can be `null`), so its absence in the
+   * body proves nothing.
+   */
+  function isCallerInstantiatedMember(member: ts.Type): boolean {
+    return tsutils.isTypeParameter(member) || isDeferredType(member);
+  }
+
+  /**
+   * Marks every observable member unused; used when no observation
+   * reaches the position at all.
+   */
+  function collectUnobservedUnionMembers(
+    type: ts.Type,
+    unused: ts.Type[],
+  ): void {
+    if (
+      !type.isUnion() ||
+      tsutils.isTypeFlagSet(type, ts.TypeFlags.Boolean) ||
+      type.types.some(isUncertain)
+    ) {
+      return;
+    }
+    for (const member of type.types) {
+      if (
+        !isNeverLike(member) &&
+        !isExemptVoidLike(member) &&
+        !isCallerInstantiatedMember(member)
+      ) {
+        unused.push(member);
+      }
+    }
+  }
+
+  /**
+   * Private and protected members are invisible to callers and therefore
+   * not part of the misleading surface.
+   */
+  function isPubliclyObservableProperty(property: ts.Symbol): boolean {
+    const declarations = property.getDeclarations();
+    return (
+      declarations == null ||
+      declarations.some(declaration => {
+        const name = ts.getNameOfDeclaration(declaration);
+        return (
+          (name == null || !ts.isPrivateIdentifier(name)) &&
+          !tsutils.isModifierFlagSet(
+            declaration,
+            ts.ModifierFlags.Private | ts.ModifierFlags.Protected,
+          )
+        );
+      })
+    );
+  }
+
+  function analyzeStructuralMembers(
+    type: ts.Type,
+    anchor: ts.Node,
+    observations: readonly Observation[],
+    unused: ts.Type[],
+    path: AnalysisPath,
+    customBuiltinSurfaceOnly: boolean,
+  ): void {
+    const symbol = type.getSymbol();
+    if (
+      customBuiltinSurfaceOnly &&
+      symbol != null &&
+      isSymbolFromDefaultLibrary(program, symbol)
+    ) {
+      return;
+    }
+
+    for (const kind of [
+      ts.SignatureKind.Call,
+      ts.SignatureKind.Construct,
+    ] as const) {
+      for (const signature of checker.getSignaturesOfType(type, kind)) {
+        analyzeResolvedType(
+          checker.getReturnTypeOfSignature(signature),
+          anchor,
+          projectSignatureReturn(observations, kind, signature),
+          unused,
+          path,
+        );
+      }
+    }
+
+    for (const property of checker.getPropertiesOfType(type)) {
+      if (
+        !isPubliclyObservableProperty(property) ||
+        (customBuiltinSurfaceOnly &&
+          isSymbolFromDefaultLibrary(program, property))
+      ) {
+        continue;
+      }
+      analyzeResolvedType(
+        checker.getTypeOfSymbolAtLocation(property, anchor),
+        anchor,
+        projectProperty(observations, property),
+        unused,
+        path,
+      );
+    }
+
+    for (const indexInfo of checker.getIndexInfosOfType(type)) {
+      analyzeResolvedType(
+        indexInfo.type,
+        anchor,
+        projectIndex(observations, indexInfo.keyType),
+        unused,
+        path,
+      );
+    }
+  }
+
+  /**
+   * Cycle check against the chain of types currently being analyzed.
+   */
+  function analysisPathIncludes(
+    path: AnalysisPath | undefined,
+    type: ts.Type,
+  ): boolean {
+    for (let current = path; current != null; current = current.parent) {
+      if (current.type === type) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Dispatches one resolved type to the matching structural analysis,
+   * guarded by cycle, depth, and memoization checks.
+   */
+  function processResolvedType(
+    type: ts.Type,
+    anchor: ts.Node,
+    observations: readonly Observation[],
+    unused: ts.Type[],
+    path: AnalysisPath | undefined,
+  ): void {
+    if (
+      isUncertain(type) ||
+      isNeverLike(type) ||
+      tsutils.isTypeFlagSet(
+        type,
+        ts.TypeFlags.TypeParameter | ts.TypeFlags.Undefined | ts.TypeFlags.Void,
+      ) ||
+      analysisPathIncludes(path, type) ||
+      // Beyond this depth the analysis stops quietly: positions that deep are
+      // left unproven instead of reported, which can only suppress
+      // diagnostics.
+      (path != null && path.depth >= MAX_ANALYSIS_TYPE_DEPTH)
+    ) {
+      return;
+    }
+
+    if (
+      observations.some(
+        observation =>
+          observation.type === type &&
+          !observationNeedsProjection(observation.node),
+      )
+    ) {
+      // Returning an opaque expression whose type is exactly the annotated
+      // type leaves every nested possibility observable. Literals and
+      // constructor/call expressions are excluded because their syntax can
+      // reveal a narrower structural value than contextual typing does.
+      return;
+    }
+
+    const stateKey = getAnalysisStateKey(anchor, observations);
+    let completedStates = analyzedTypeStates.get(type);
+    if (completedStates?.has(stateKey) === true) {
+      return;
+    }
+    if (completedStates == null) {
+      completedStates = new Set();
+      analyzedTypeStates.set(type, completedStates);
+    }
+    completedStates.add(stateKey);
+
+    const childPath: AnalysisPath = {
+      depth: (path?.depth ?? 0) + 1,
+      parent: path,
+      type,
+    };
+    if (type.isUnion()) {
+      analyzeResolvedUnion(type, anchor, observations, unused, childPath);
+      return;
+    }
+
+    if (tsutils.isThenableType(checker, anchor, type)) {
+      const awaited = checker.getAwaitedType(type);
+      if (awaited != null && awaited !== type) {
+        analyzeResolvedType(
+          awaited,
+          anchor,
+          projectAwaited(observations),
+          unused,
+          childPath,
+        );
+        analyzeStructuralMembers(
+          type,
+          anchor,
+          observations,
+          unused,
+          childPath,
+          true,
+        );
+        return;
+      }
+    }
+
+    if (checker.isTupleType(type)) {
+      const tuple = type;
+      for (const [index, element] of checker
+        .getTypeArguments(tuple)
+        .entries()) {
+        const flags = tuple.target.elementFlags.at(index);
+        analyzeResolvedType(
+          element,
+          anchor,
+          projectTupleElement(
+            observations,
+            index,
+            flags != null && (flags & ts.ElementFlags.Variable) !== 0,
+          ),
+          unused,
+          childPath,
+        );
+      }
+      return;
+    }
+
+    const numberIndex = checker.getIndexTypeOfType(type, ts.IndexKind.Number);
+    const typeSymbol = type.getSymbol();
+    if (
+      checker.isArrayLikeType(type) ||
+      isBuiltinSymbolLike(program, type, ARRAY_NAMES) ||
+      (numberIndex != null &&
+        typeSymbol != null &&
+        isSymbolFromDefaultLibrary(program, typeSymbol))
+    ) {
+      if (numberIndex != null) {
+        analyzeResolvedType(
+          numberIndex,
+          anchor,
+          projectArrayElement(observations),
+          unused,
+          childPath,
+        );
+      }
+      analyzeStructuralMembers(
+        type,
+        anchor,
+        observations,
+        unused,
+        childPath,
+        true,
+      );
+      return;
+    }
+
+    if (isBuiltinSymbolLike(program, type, SET_NAMES)) {
+      const iterableExpectedElements = projectIterableElement(
+        [{ node: anchor, type }],
+        false,
+      );
+      const expectedElements =
+        iterableExpectedElements.length > 0
+          ? iterableExpectedElements
+          : projectMethodParameter([{ node: anchor, type }], 'has', 0);
+      const iterableProjected = projectIterableElement(observations, false);
+      const projected =
+        iterableProjected.length > 0
+          ? iterableProjected
+          : projectMethodParameter(observations, 'has', 0);
+      for (const element of expectedElements) {
+        const expectedElement = resolveObservation(element);
+        analyzeResolvedType(
+          expectedElement.type,
+          anchor,
+          projected,
+          unused,
+          childPath,
+        );
+      }
+      analyzeStructuralMembers(
+        type,
+        anchor,
+        observations,
+        unused,
+        childPath,
+        true,
+      );
+      return;
+    }
+
+    if (isBuiltinSymbolLike(program, type, MAP_NAMES)) {
+      for (const index of [0, 1] as const) {
+        const expectedArguments = projectMapEntry(
+          [{ node: anchor, type }],
+          index,
+        );
+        const projected = projectMapEntry(observations, index);
+        for (const argument of expectedArguments) {
+          const expectedArgument = resolveObservation(argument);
+          analyzeResolvedType(
+            expectedArgument.type,
+            anchor,
+            projected,
+            unused,
+            childPath,
+          );
+        }
+      }
+      analyzeStructuralMembers(
+        type,
+        anchor,
+        observations,
+        unused,
+        childPath,
+        true,
+      );
+      return;
+    }
+
+    if (isBuiltinSymbolLike(program, type, WEAK_REF_NAMES)) {
+      const expectedValues = projectMethodReturn(
+        [{ node: anchor, type }],
+        'deref',
+      );
+      const projectedValues = projectMethodReturn(observations, 'deref');
+      for (const value of expectedValues) {
+        const expectedValue = resolveObservation(value);
+        analyzeResolvedType(
+          expectedValue.type,
+          anchor,
+          projectedValues,
+          unused,
+          childPath,
+        );
+      }
+      analyzeStructuralMembers(
+        type,
+        anchor,
+        observations,
+        unused,
+        childPath,
+        true,
+      );
+      return;
+    }
+
+    if (isBuiltinSymbolLike(program, type, VALUE_WRAPPER_NAMES)) {
+      const value = checker.getPropertyOfType(type, 'value');
+      if (value != null) {
+        analyzeResolvedType(
+          checker.getTypeOfSymbolAtLocation(value, anchor),
+          anchor,
+          projectProperty(observations, value),
+          unused,
+          childPath,
+        );
+      }
+      analyzeStructuralMembers(
+        type,
+        anchor,
+        observations,
+        unused,
+        childPath,
+        true,
+      );
+      return;
+    }
+
+    if (isBuiltinSymbolLike(program, type, GENERATOR_NAMES)) {
+      const isAsync = isBuiltinSymbolLike(program, type, ASYNC_ITERABLE_NAMES);
+      const expectedYields = projectIterableElement(
+        [{ node: anchor, type }],
+        isAsync,
+      );
+      const projectedYields = projectIterableElement(observations, isAsync);
+      for (const element of expectedYields) {
+        const expectedYield = resolveObservation(element);
+        analyzeResolvedType(
+          expectedYield.type,
+          anchor,
+          projectedYields,
+          unused,
+          childPath,
+        );
+      }
+      analyzeStructuralMembers(
+        type,
+        anchor,
+        observations,
+        unused,
+        childPath,
+        true,
+      );
+      return;
+    }
+
+    if (
+      !type.isIntersection() &&
+      !tsutils.isTypeFlagSet(type, ts.TypeFlags.Object)
+    ) {
+      return;
+    }
+
+    const symbol = type.getSymbol();
+    if (
+      symbol != null &&
+      isSymbolFromDefaultLibrary(program, symbol) &&
+      !isBuiltinSymbolLike(program, type, STRUCTURAL_DEFAULT_LIBRARY_NAMES) &&
+      (!tsutils.isObjectType(type) ||
+        !tsutils.isObjectFlagSet(type, ts.ObjectFlags.Mapped))
+    ) {
+      return;
+    }
+
+    analyzeStructuralMembers(
+      type,
+      anchor,
+      observations,
+      unused,
+      childPath,
+      false,
+    );
+  }
+
+  /**
+   * Runs queued structural tasks breadth-first so a single wide type
+   * cannot recurse unboundedly before others are seen.
+   */
+  function drainAnalysisTasks(): void {
+    if (drainingAnalysisTasks) {
+      return;
+    }
+
+    drainingAnalysisTasks = true;
+    try {
+      while (analysisTaskIndex < analysisTasks.length) {
+        const task = analysisTasks[analysisTaskIndex];
+        analysisTaskIndex += 1;
+        processResolvedType(
+          task.type,
+          task.anchor,
+          task.observations,
+          task.unused,
+          task.path,
+        );
+      }
+    } finally {
+      analysisTasks = [];
+      analysisTaskIndex = 0;
+      drainingAnalysisTasks = false;
+    }
+  }
+
+  function analyzeResolvedType(
+    type: ts.Type,
+    anchor: ts.Node,
+    observations: readonly Observation[],
+    unused: ts.Type[],
+    path: AnalysisPath | undefined,
+  ): void {
+    // Charge work before enqueueing so a single very wide structural type
+    // cannot build an unbounded pending-task array before the drain catches up.
+    consumeAnalysisWork();
+    analysisTasks.push({ anchor, observations, path, type, unused });
+    drainAnalysisTasks();
+  }
+
+  /**
+   * Entry point for written annotations: analyzes the syntactic union
+   * first, then the resolved type behind it.
+   */
+  function analyzeTypeNode(
+    node: ts.TypeNode,
+    observations: readonly Observation[],
+    unused: ts.Type[],
+  ): void {
+    if (ts.isParenthesizedTypeNode(node)) {
+      analyzeTypeNode(node.type, observations, unused);
+      return;
+    }
+
+    if (typeNodeNamesWholeEnum(node)) {
+      return;
+    }
+
+    if (ts.isUnionTypeNode(node)) {
+      analyzeUnion(node, observations, unused);
+      return;
+    }
+
+    if (ts.isFunctionTypeNode(node)) {
+      analyzeTypeNode(
+        node.type,
+        projectSignatureReturn(observations, ts.SignatureKind.Call),
+        unused,
+      );
+      return;
+    }
+
+    if (ts.isConstructorTypeNode(node)) {
+      analyzeTypeNode(
+        node.type,
+        projectSignatureReturn(observations, ts.SignatureKind.Construct),
+        unused,
+      );
+      return;
+    }
+
+    analyzeResolvedType(
+      checker.getTypeFromTypeNode(node),
+      node,
+      observations,
+      unused,
+      undefined,
+    );
+  }
+
+  /**
+   * A bare enum reference abstracts its members the way `string` abstracts
+   * string literals, so it is not treated as a union of members.
+   */
+  function typeNodeNamesWholeEnum(node: ts.TypeNode): boolean {
+    if (!ts.isTypeReferenceNode(node) || node.typeArguments != null) {
+      return false;
+    }
+    const symbol = checker.getTypeFromTypeNode(node).getSymbol();
+    return (
+      symbol != null && tsutils.isSymbolFlagSet(symbol, ts.SymbolFlags.Enum)
+    );
+  }
+
+  // The syntactic counterpart of `analyzeResolvedUnion` above: written
+  // constituents keep their source order and absorbed siblings, so this
+  // variant handles absorption and recurses into member type nodes.
+  function analyzeUnion(
+    node: ts.UnionTypeNode,
+    observations: readonly Observation[],
+    unused: ts.Type[],
+  ): void {
+    const candidates = expandResolvedObservations(observations);
+    if (
+      candidates.length === 0 ||
+      candidates.some(({ type }) => isUncertain(type))
+    ) {
+      return;
+    }
+
+    const members = node.types.map(typeNode => ({
+      node: typeNode,
+      type: checker.getTypeFromTypeNode(typeNode),
+    }));
+    if (members.some(({ type }) => isUncertain(type))) {
+      return;
+    }
+
+    const observableMembers = members.filter(
+      member => !isNeverLike(member.type) && !isExemptVoidLike(member.type),
+    );
+    const union = checker.getTypeFromTypeNode(node);
+    if (
+      candidates.some(
+        candidate =>
+          !tsutils.isTypeFlagSet(candidate.type, ts.TypeFlags.Never) &&
+          !isExemptVoidLike(candidate.type) &&
+          !tsutils.isTypeParameter(candidate.type) &&
+          !observableMembers.some(member =>
+            isTypeAssignableTo(candidate.type, member.type),
+          ) &&
+          (isDeferredType(candidate.type) ||
+            isTypeAssignableTo(candidate.type, union)),
+      )
+    ) {
+      return;
+    }
+
+    const memberTypes = new Set(members.map(member => member.type));
+    const exactCandidates = new Map<ts.Type, ResolvedObservation[]>();
+    const nonExactCandidates: ResolvedObservation[] = [];
+    for (const candidate of candidates) {
+      if (
+        !memberTypes.has(candidate.type) ||
+        members.some(
+          member =>
+            member.type !== candidate.type &&
+            isTypeAssignableTo(candidate.type, member.type),
+        )
+      ) {
+        // A candidate exactly matching a constituent that is itself
+        // absorbed by a wider sibling still satisfies that wider sibling.
+        // Keep it in the assignability bucket so the syntactic ordering of
+        // `"a" | string` cannot make `string` look unused.
+        nonExactCandidates.push(candidate);
+        continue;
+      }
+      const exact = exactCandidates.get(candidate.type);
+      if (exact == null) {
+        exactCandidates.set(candidate.type, [candidate]);
+      } else {
+        exact.push(candidate);
+      }
+    }
+
+    for (const member of members) {
+      if (
+        isNeverLike(member.type) ||
+        isExemptVoidLike(member.type) ||
+        isCallerInstantiatedMember(member.type)
+      ) {
+        continue;
+      }
+
+      // TypeScript reduces constituents that are already represented by a
+      // wider sibling (`string | 'literal'` is just `string`). Such a
+      // constituent does not expose an additional possibility to callers,
+      // so it cannot be misleading on its own.
+      if (
+        members.some(
+          other =>
+            other !== member && isTypeAssignableTo(member.type, other.type),
+        )
+      ) {
+        continue;
+      }
+
+      const matching = [
+        ...(exactCandidates.get(member.type) ?? []),
+        ...nonExactCandidates.filter(candidate =>
+          isTypeAssignableTo(candidate.type, member.type),
+        ),
+      ];
+      if (matching.length === 0) {
+        unused.push(member.type);
+      } else {
+        analyzeTypeNode(member.node, matching, unused);
+      }
+    }
+  }
+
+  function resetTypeAnalysis(): void {
+    analyzedTypeStates = new WeakMap();
+    analysisTasks = [];
+    analysisTaskIndex = 0;
+    drainingAnalysisTasks = false;
+  }
+
+  return {
+    analyzeResolvedType,
+    analyzeTypeNode,
+    collectUnobservedUnionMembers,
+    resetTypeAnalysis,
+  };
+}

--- a/packages/eslint-plugin/src/rules/no-misleading-return-type.ts
+++ b/packages/eslint-plugin/src/rules/no-misleading-return-type.ts
@@ -1,0 +1,24 @@
+import { createRule, getParserServices } from '../util';
+import { createNoMisleadingReturnTypeAnalyzer } from './no-misleading-return-type-utils/analyzer';
+
+export default createRule<[], 'misleadingReturnType'>({
+  name: 'no-misleading-return-type',
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Disallow return type annotations that include types the function never returns',
+      requiresTypeChecking: true,
+    },
+    messages: {
+      misleadingReturnType:
+        "Return type '{{annotated}}' includes '{{unused}}', which the function never returns.",
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    const services = getParserServices(context);
+    return createNoMisleadingReturnTypeAnalyzer(context, services);
+  },
+});

--- a/packages/eslint-plugin/src/util/getBaseTypesOfClassMember.ts
+++ b/packages/eslint-plugin/src/util/getBaseTypesOfClassMember.ts
@@ -2,7 +2,8 @@ import type {
   TSESTree,
   ParserServicesWithTypeInformation,
 } from '@typescript-eslint/utils';
-import type * as ts from 'typescript';
+
+import * as ts from 'typescript';
 
 /**
  * Given a member of a class which extends another class or implements an interface,
@@ -26,9 +27,19 @@ export function* getBaseTypesOfClassMember(
     return;
   }
   const classNode = memberTsNode.parent as ts.ClassLikeDeclaration;
+  const isStaticMember = memberNode.static;
   for (const clauseNode of classNode.heritageClauses ?? []) {
+    if (
+      isStaticMember &&
+      clauseNode.token === ts.SyntaxKind.ImplementsKeyword
+    ) {
+      // `implements` constrains only the instance side of a class.
+      continue;
+    }
     for (const baseTypeNode of clauseNode.types) {
-      const baseType = checker.getTypeAtLocation(baseTypeNode);
+      const baseType = checker.getTypeAtLocation(
+        isStaticMember ? baseTypeNode.expression : baseTypeNode,
+      );
       const baseMemberSymbol = checker.getPropertyOfType(
         baseType,
         memberSymbol.name,

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-misleading-return-type.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-misleading-return-type.shot
@@ -1,0 +1,51 @@
+Incorrect
+
+function getName(): string | null {
+                  ~~~~~~~~~~~~~~~ Return type 'string | null' includes 'null', which the function never returns.
+  return 'Bea';
+}
+
+function getStatus(done: boolean): 'idle' | 'loading' | 'errored' {
+                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Return type '"idle" | "loading" | "errored"' includes '"errored"', which the function never returns.
+  if (done) {
+    return 'idle';
+  }
+  return 'loading';
+}
+
+async function fetchCount(): Promise<number | null> {
+                           ~~~~~~~~~~~~~~~~~~~~~~~~ Return type 'Promise<number | null>' includes 'null', which the function never returns.
+  return 42;
+}
+
+function createValues(): Array<string | null> {
+                       ~~~~~~~~~~~~~~~~~~~~~~ Return type '(string | null)[]' includes 'null', which the function never returns.
+  return ['ready'];
+}
+
+Correct
+
+function getName(): string {
+  return 'Bea';
+}
+
+function getStatus(done: boolean): 'idle' | 'loading' {
+  if (done) {
+    return 'idle';
+  }
+  return 'loading';
+}
+
+async function fetchCount(): Promise<number> {
+  return 42;
+}
+
+function getMessage(done: boolean): string {
+  return done ? 'complete' : 'pending';
+}
+
+function firstItem(items: string[]): string | undefined {
+  // Indexed access may produce undefined. TypeScript models that possibility
+  // explicitly when `noUncheckedIndexedAccess` is enabled.
+  return items[0];
+}

--- a/packages/eslint-plugin/tests/fixtures/no-misleading-return-type.ts
+++ b/packages/eslint-plugin/tests/fixtures/no-misleading-return-type.ts
@@ -1,0 +1,13 @@
+export type ImportedResult = string | null;
+
+export interface ImportedBox<T> {
+  readonly value: T;
+}
+
+export type ImportedEnvelope<T> = Promise<Readonly<ImportedBox<T>>>;
+
+export declare const importedTextBox: ImportedBox<string>;
+
+export let importedMutableValue: string | null = 'ready';
+
+export declare function mutateImportedValue(): void;

--- a/packages/eslint-plugin/tests/rules/no-misleading-return-type-utils.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-misleading-return-type-utils.test.ts
@@ -1,0 +1,248 @@
+import * as tsutils from 'ts-api-utils';
+import * as ts from 'typescript';
+
+import type { RuleDependencies } from '../../src/rules/no-misleading-return-type-utils/shared';
+
+import { createAnalysisState } from '../../src/rules/no-misleading-return-type-utils/analysis-state';
+import { createPropertyKeyMatching } from '../../src/rules/no-misleading-return-type-utils/property-key-matching';
+
+const fileName = '/no-misleading-return-type-property-keys.ts';
+const sourceText = [
+  'type AnyKey = any;',
+  'type UnknownKey = unknown;',
+  'type NeverKey = never;',
+  'type StringKey = string;',
+  'type NumberKey = number;',
+  'type SymbolKey = symbol;',
+  'type NullKey = null;',
+  'type UndefinedKey = undefined;',
+  "type StringOne = '1';",
+  "type StringX = 'x';",
+  'type NumberOne = 1;',
+  "type Exact = 'exact';",
+  'type NumericTemplate = `${number}`;',
+  'type BigIntTemplate = `${bigint}`;',
+  'type IntrinsicTemplate = `value-${boolean | null | undefined}-${string}`;',
+  'type DelimitedTemplate = `pre-${string}-${number}-post`;',
+  'type AdjacentTemplate = `${number}${bigint}`;',
+  'type UppercaseKey = Uppercase<string>;',
+  'type LowercaseKey = Lowercase<string>;',
+  'type CapitalizeKey = Capitalize<string>;',
+  'type UncapitalizeKey = Uncapitalize<string>;',
+  'type NestedMapping = `data-${Capitalize<Uppercase<string>>}`;',
+  "type KeyUnion = `data-${string}` | 'other';",
+  'type KeyIntersection = Uppercase<string> & `A${string}`;',
+  'type IntersectionTemplate = `key-${Uppercase<string> & `A${string}`}`;',
+  'type GenericTemplate<T extends string> = `data-${Uppercase<T>}`;',
+  "type DeferredKey<T> = T extends string ? 'yes' : 'no';",
+  'declare const firstSymbol: unique symbol;',
+  'declare const secondSymbol: unique symbol;',
+  'type FirstSymbol = typeof firstSymbol;',
+  'type SecondSymbol = typeof secondSymbol;',
+].join('\n');
+
+function createProgram(): ts.Program {
+  const options: ts.CompilerOptions = {
+    noEmit: true,
+    strict: true,
+    target: ts.ScriptTarget.ESNext,
+  };
+  const host = ts.createCompilerHost(options);
+  const getSourceFile = host.getSourceFile.bind(host);
+  host.fileExists = path => path === fileName || ts.sys.fileExists(path);
+  host.readFile = path =>
+    path === fileName ? sourceText : ts.sys.readFile(path);
+  host.getSourceFile = (
+    path,
+    languageVersion,
+    onError,
+    shouldCreateNewSourceFile,
+  ) =>
+    path === fileName
+      ? ts.createSourceFile(
+          path,
+          sourceText,
+          languageVersion,
+          true,
+          ts.ScriptKind.TS,
+        )
+      : getSourceFile(
+          path,
+          languageVersion,
+          onError,
+          shouldCreateNewSourceFile,
+        );
+  return ts.createProgram([fileName], options, host);
+}
+
+function createMatching(checker: ts.TypeChecker) {
+  return createPropertyKeyMatching({
+    checker,
+    isDeferredType(type): boolean {
+      return (
+        tsutils.isTypeFlagSet(
+          type,
+          ts.TypeFlags.Conditional |
+            ts.TypeFlags.Index |
+            ts.TypeFlags.IndexedAccess |
+            ts.TypeFlags.Substitution,
+        ) ||
+        (tsutils.isObjectType(type) &&
+          tsutils.isObjectFlagSet(type, ts.ObjectFlags.Mapped))
+      );
+    },
+    isTypeAssignableTo: (source, target) =>
+      checker.isTypeAssignableTo(source, target),
+    isUncertain: type =>
+      tsutils.isTypeFlagSet(type, ts.TypeFlags.Any | ts.TypeFlags.Unknown) ||
+      tsutils.isIntrinsicErrorType(type),
+  });
+}
+
+const program = createProgram();
+const checker = program.getTypeChecker();
+const sourceFile = program.getSourceFile(fileName)!;
+const types = new Map<string, ts.Type>();
+for (const statement of sourceFile.statements) {
+  if (ts.isTypeAliasDeclaration(statement)) {
+    types.set(statement.name.text, checker.getTypeFromTypeNode(statement.type));
+  }
+}
+
+function getType(name: string): ts.Type {
+  const type = types.get(name);
+  if (type == null) {
+    throw new Error(`Missing test type: ${name}`);
+  }
+  return type;
+}
+
+function createState() {
+  return createAnalysisState({
+    checker,
+    program,
+    services: {
+      program,
+    } as RuleDependencies['services'],
+  } as RuleDependencies);
+}
+
+const checkerWithoutLiteralFactories = new Proxy(checker, {
+  get(target, property, receiver) {
+    if (
+      property === 'getNumberLiteralType' ||
+      property === 'getStringLiteralType'
+    ) {
+      return undefined;
+    }
+    return Reflect.get(target, property, receiver);
+  },
+});
+const officialMatching = createMatching(checker);
+const legacyMatching = createMatching(checkerWithoutLiteralFactories);
+
+describe('no-misleading-return-type property key matching', () => {
+  it('uses syntactically valid test types', () => {
+    expect(ts.getPreEmitDiagnostics(program)).toEqual([]);
+  });
+
+  it('matches keys against template and intrinsic mapping index types', () => {
+    const cases: [string, string, boolean][] = [
+      ['ABC', 'UppercaseKey', true],
+      ['Abc', 'UppercaseKey', false],
+      ['abc', 'LowercaseKey', true],
+      ['Abc', 'CapitalizeKey', true],
+      ['abc', 'CapitalizeKey', false],
+      ['data-ABC', 'NestedMapping', true],
+      ['data-Abc', 'NestedMapping', false],
+      ['1e3', 'NumericTemplate', true],
+      ['NaN', 'NumericTemplate', false],
+      ['1_0', 'NumericTemplate', false],
+      ['11', 'BigIntTemplate', true],
+      ['1.5', 'BigIntTemplate', false],
+      ['pre-x-1-post', 'DelimitedTemplate', true],
+      ['pre-x-y-post', 'DelimitedTemplate', false],
+      ['other', 'KeyUnion', true],
+      ['data-anything', 'KeyUnion', true],
+      ['unrelated', 'KeyUnion', false],
+      ['0', 'NumberKey', true],
+      ['-0', 'NumberKey', false],
+      ['01', 'NumberKey', false],
+    ];
+    for (const [value, keyType, expected] of cases) {
+      expect(
+        officialMatching.stringPropertyMatchesIndexKey(value, getType(keyType)),
+        `${JSON.stringify(value)} against ${keyType}`,
+      ).toBe(expected);
+    }
+  });
+
+  it('treats keys as covered when literal type factories are unavailable', () => {
+    // TypeScript before 5.1 cannot construct literal key types; the matcher
+    // must degrade toward reporting nothing rather than reimplementing the
+    // checker's relation.
+    expect(
+      legacyMatching.stringPropertyMatchesIndexKey('other', getType('Exact')),
+    ).toBe(true);
+    expect(
+      legacyMatching.stringPropertyMatchesIndexKey(
+        'abc',
+        getType('UppercaseKey'),
+      ),
+    ).toBe(true);
+  });
+
+  it.each([
+    ['StringOne', 'NumberKey', true],
+    ['StringX', 'NumberKey', false],
+    ['StringKey', 'NumberKey', true],
+    ['NumberKey', 'StringOne', true],
+    ['FirstSymbol', 'FirstSymbol', true],
+    ['FirstSymbol', 'SecondSymbol', false],
+    ['FirstSymbol', 'StringKey', false],
+    ['UnknownKey', 'StringKey', true],
+    ['KeyUnion', 'StringKey', true],
+    ['StringKey', 'KeyUnion', true],
+  ] as const)(
+    'detects overlap between %s and %s as %s',
+    (left, right, expected) => {
+      expect(
+        officialMatching.propertyKeyTypesMayOverlap(
+          getType(left),
+          getType(right),
+        ),
+      ).toBe(expected);
+    },
+  );
+});
+
+describe('no-misleading-return-type analysis state', () => {
+  it('expands a recursive synthetic union without looping', () => {
+    const state = createState();
+    const recursiveUnion = {
+      flags: ts.TypeFlags.Union,
+      isIntersection: () => false,
+      isUnion: () => true,
+      types: [] as ts.Type[],
+    } as unknown as ts.UnionType;
+    recursiveUnion.types.push(recursiveUnion);
+
+    expect(
+      state.expandObservations([{ node: sourceFile, type: recursiveUnion }]),
+    ).toEqual([]);
+  });
+
+  it('recognizes only call-stack RangeErrors as stack overflows', () => {
+    const state = createState();
+
+    expect(
+      state.isStackOverflowError(new RangeError('Maximum call stack')),
+    ).toBe(true);
+    expect(state.isStackOverflowError(new RangeError('Out of range'))).toBe(
+      false,
+    );
+    expect(state.isStackOverflowError(new Error('Maximum call stack'))).toBe(
+      false,
+    );
+  });
+});

--- a/packages/eslint-plugin/tests/rules/no-misleading-return-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-misleading-return-type.test.ts
@@ -1,0 +1,5629 @@
+import { noFormat } from '@typescript-eslint/rule-tester';
+import * as path from 'node:path';
+
+import rule from '../../src/rules/no-misleading-return-type';
+import { createRuleTesterWithTypes, getFixturesRootDir } from '../RuleTester';
+
+const ruleTester = createRuleTesterWithTypes();
+
+ruleTester.run('no-misleading-return-type', rule, {
+  valid: [
+    // Only explicitly written union positions are analyzed. A primitive
+    // annotation deliberately abstracts any number of returned literals.
+    `
+function noAnnotation() {
+  return 'loading';
+}
+    `,
+    `
+function primitiveCoversLiterals(flag: boolean): string {
+  return flag ? 'loading' : 'idle';
+}
+    `,
+    `
+function primitiveCoversConstLiteral(): string {
+  return 'loading' as const;
+}
+    `,
+    `
+function primitiveBooleanCoversLiteral(): boolean {
+  return true;
+}
+    `,
+    `
+function allConstituents(flag: boolean): 'loading' | 'idle' {
+  return flag ? 'loading' : 'idle';
+}
+    `,
+    `
+function allKinds(flag: 0 | 1 | 2): string | number | null {
+  if (flag === 0) return 'ready';
+  if (flag === 1) return 1;
+  return null;
+}
+    `,
+    // Escape hatches cannot prove that a constituent is unused.
+    `
+declare const dynamic: any;
+function anyReturn(): string | null {
+  return dynamic;
+}
+    `,
+    `
+function unknownReturn(value: unknown): unknown {
+  return value;
+}
+    `,
+    `
+declare function invokeMutatingCallback(callback: () => void): void;
+function callbackMutatedReturn(): string | null {
+  let value: string | null = 'ready';
+  invokeMutatingCallback(() => {
+    value = null;
+  });
+  return value;
+}
+    `,
+    `
+declare function runCapturedMutation(callback: () => void): void;
+function capturedArrayDestructuring(): 'ready' | null {
+  let value: 'ready' | null = 'ready';
+  runCapturedMutation(() => {
+    [value] = [null];
+  });
+  return value;
+}
+function capturedObjectDestructuring(): 'ready' | null {
+  let value: 'ready' | null = 'ready';
+  runCapturedMutation(() => {
+    ({ value } = { value: null });
+  });
+  return value;
+}
+enum CapturedCount {
+  Zero,
+  One,
+}
+function capturedUpdate(): CapturedCount.Zero | CapturedCount.One {
+  let value: CapturedCount.Zero | CapturedCount.One = CapturedCount.Zero;
+  runCapturedMutation(() => {
+    value++;
+  });
+  return value;
+}
+function capturedForOfTarget(): 'ready' | null {
+  let value: 'ready' | null = 'ready';
+  runCapturedMutation(() => {
+    for (value of [null]) {
+      // The loop assignment itself mutates the captured binding.
+    }
+  });
+  return value;
+}
+function capturedNestedObjectTarget(): 'ready' | null {
+  let value: 'ready' | null = 'ready';
+  runCapturedMutation(() => {
+    ({
+      nested: { value },
+    } = { nested: { value: null } });
+  });
+  return value;
+}
+type CapturedObjectRestState =
+  { readonly kind: 'ready' } | { readonly kind: null };
+function capturedObjectRestTarget(): CapturedObjectRestState {
+  let state: CapturedObjectRestState = { kind: 'ready' };
+  runCapturedMutation(() => {
+    ({ ...state } = { kind: null });
+  });
+  return state;
+}
+    `,
+    `
+interface CapturedPropertyState {
+  nested: { value: string | null };
+}
+declare function runCapturedMutation(callback: () => void): void;
+function capturedPropertyMutation(state: CapturedPropertyState): string | null {
+  if (state.nested.value === null) {
+    throw new Error('missing');
+  }
+  runCapturedMutation(() => {
+    state.nested.value = null;
+  });
+  return state.nested.value;
+}
+function capturedElementMutation(state: [string | null]): string | null {
+  const alias = state;
+  if (state[0] === null) {
+    throw new Error('missing');
+  }
+  runCapturedMutation(() => {
+    alias[0] = null;
+  });
+  return state[0];
+}
+    `,
+    `
+interface ExternallyMutableState {
+  value: string | null;
+}
+declare function mutateState(state: ExternallyMutableState): void;
+function externallyMutatedProperty(
+  state: ExternallyMutableState,
+): string | null {
+  if (state.value === null) {
+    throw new Error('missing');
+  }
+  mutateState(state);
+  return state.value;
+}
+declare const sharedMutableState: ExternallyMutableState;
+declare function mutateSharedState(): void;
+function globallyMutatedProperty(): string | null {
+  if (sharedMutableState.value === null) {
+    throw new Error('missing');
+  }
+  mutateSharedState();
+  return sharedMutableState.value;
+}
+    `,
+    `
+let sharedMutableValue: string | null = 'ready';
+declare function mutateSharedValue(): void;
+function externallyMutatedBinding(): string | null {
+  if (sharedMutableValue === null) {
+    throw new Error('missing');
+  }
+  mutateSharedValue();
+  return sharedMutableValue;
+}
+    `,
+    `
+function createClosureMutatedReader() {
+  let value: string | null = 'ready';
+  const mutate = () => {
+    value = null;
+  };
+  return function closureMutatedReader(): string | null {
+    if (value === null) {
+      throw new Error('missing');
+    }
+    mutate();
+    return value;
+  };
+}
+    `,
+    `
+import {
+  importedMutableValue,
+  mutateImportedValue,
+} from './no-misleading-return-type';
+function externallyMutatedImport(): string | null {
+  if (importedMutableValue === null) {
+    throw new Error('missing');
+  }
+  mutateImportedValue();
+  return importedMutableValue;
+}
+    `,
+    `
+function classInitializerMutatedReturn(): string | null {
+  let value: string | null = 'ready';
+  class SideEffect {
+    static field = (value = null);
+  }
+  void SideEffect;
+  return value;
+}
+    `,
+    `
+function directlyEvaluatedMutation(): string | null {
+  let value: string | null = 'ready';
+  eval('value = null');
+  return value;
+}
+    `,
+    // Explicit assertions and generic arguments pin the expression type. The
+    // rule compares that type rather than trying to disprove the assertion.
+    `
+function pinnedAssertion(): string | null {
+  return 'ready' as string | null;
+}
+function pinnedCollection(): Set<string | null> {
+  return new Set<string | null>(['ready']);
+}
+    `,
+    `
+function erasedNarrowing(value: string | null): string | null {
+  return value as string;
+}
+function erasedNonNull(value: string | null): string | null {
+  return value!;
+}
+function erasedUnknown(value: unknown): string | null {
+  return value as string;
+}
+function erasedNarrowingAlias(value: string | null): string | null {
+  const narrowed = value as string;
+  return narrowed;
+}
+function pinnedWideningAlias(): string | null {
+  const widened = 'ready' as string | null;
+  return widened;
+}
+    `,
+    // Unwrapping a const initializer must not discard control-flow narrowing
+    // established at the identifier use site.
+    `
+function narrowedConstCollection(
+  values: readonly (string | undefined)[],
+): readonly string[] | undefined {
+  const strings = values.map(value => value);
+  return strings.every((value): value is string => value !== undefined)
+    ? strings
+    : undefined;
+}
+    `,
+    {
+      code: `
+function narrowedConstNode(node: Node): Element | undefined {
+  const parent = node.parentNode;
+  return parent instanceof Element ? parent : undefined;
+}
+      `,
+      languageOptions: {
+        parserOptions: {
+          project: './tsconfig.lib-dom.json',
+          projectService: false,
+          tsconfigRootDir: getFixturesRootDir(),
+        },
+      },
+    },
+    `
+function neverReturns(): string | null {
+  throw new Error('unreachable');
+}
+    `,
+    `
+declare const textBeforeNeverValue: string;
+const assertedNeverValue = null as never;
+function readingNeverTypedValue(flag: boolean): string | null {
+  if (flag) return textBeforeNeverValue;
+  assertedNeverValue;
+  return null;
+}
+    `,
+    // Referenced aliases are analyzed when every constituent is observable.
+    // Keeping this valid case prevents alias expansion from treating the alias
+    // itself as one opaque unused type.
+    `
+type Result = string | null;
+function completeAlias(flag: boolean): Result {
+  return flag ? 'ready' : null;
+}
+    `,
+    `
+interface CompleteObjectAlias {
+  value: string | null;
+}
+function completeObjectAlias(flag: boolean): CompleteObjectAlias {
+  return { value: flag ? 'ready' : null };
+}
+    `,
+    // An unresolved computed write can replace the explicit property at
+    // runtime, so both annotated constituents remain observable.
+    `
+declare const dynamicPropertyKey: string;
+function dynamicComputedProperty(): {
+  readonly value: 'ready' | 'idle';
+} {
+  return { value: 'ready', [dynamicPropertyKey]: 'idle' };
+}
+    `,
+    `
+enum DynamicPropertyKey {
+  Other = 'other',
+  Value = 'value',
+}
+declare const dynamicEnumPropertyKey: DynamicPropertyKey;
+function dynamicEnumComputedProperty(): {
+  readonly value: 'idle' | 'ready';
+} {
+  return { value: 'ready', [dynamicEnumPropertyKey]: 'idle' };
+}
+    `,
+    // Void-like constituents remain exempt when the configured TypeScript
+    // program does not model unchecked indexed access.
+    `
+function uncheckedIndex(values: string[]): string | undefined {
+  return values[0];
+}
+    `,
+    `
+function uncheckedIndexFallback(values: string[]): string | null {
+  return values[values.length - 1] ?? null;
+}
+    `,
+    // `??` only strips nullish constituents; a falsy `0` still flows through.
+    `
+declare const zeroSource: 0 | null;
+function coalescedZero(): 0 | 'fallback' {
+  return zeroSource ?? 'fallback';
+}
+    `,
+    `
+function optionalReturn(flag: boolean): string | void {
+  if (flag) return 'ready';
+}
+    `,
+    // Once indexed access includes undefined, real undefined-producing paths
+    // remain observable, including after conservative flow narrowing.
+    {
+      code: `
+function checkedIndex(values: string[]): string | undefined {
+  return values[0];
+}
+      `,
+      languageOptions: {
+        parserOptions: {
+          project: './tsconfig.noUncheckedIndexedAccess.json',
+          projectService: false,
+          tsconfigRootDir: getFixturesRootDir(),
+        },
+      },
+    },
+    {
+      code: `
+function narrowedCheckedIndex(values: string[]): string | undefined {
+  if (values[0] === undefined) {
+    throw new Error('missing');
+  }
+  return values[0];
+}
+      `,
+      languageOptions: {
+        parserOptions: {
+          project: './tsconfig.noUncheckedIndexedAccess.json',
+          projectService: false,
+          tsconfigRootDir: getFixturesRootDir(),
+        },
+      },
+    },
+    {
+      code: `
+function checkedFallthrough(flag: boolean): string | void {
+  if (flag) return 'ready';
+}
+      `,
+      languageOptions: {
+        parserOptions: {
+          project: './tsconfig.noUncheckedIndexedAccess.json',
+          projectService: false,
+          tsconfigRootDir: getFixturesRootDir(),
+        },
+      },
+    },
+    // Contextual and inherited annotations are contracts, not claims local to
+    // one implementation.
+    `
+type Callback = () => string | null;
+const contextualArrow: Callback = (): string | null => 'ready';
+    `,
+    `
+declare function register(callback: () => string | null): void;
+register(function contextualArgument(): string | null {
+  return 'ready';
+});
+    `,
+    `
+interface ObjectContract {
+  read(): string | null;
+}
+const contextualObject: ObjectContract = {
+  read(): string | null {
+    return 'ready';
+  },
+};
+    `,
+    `
+interface GetterContract {
+  readonly value: string | null;
+}
+const contextualGetter: GetterContract = {
+  get value(): string | null {
+    return 'ready';
+  },
+};
+    `,
+    `
+class Base {
+  read(): string | null {
+    return Math.random() > 0.5 ? 'ready' : null;
+  }
+}
+class Derived extends Base {
+  override read(): string | null {
+    return 'ready';
+  }
+}
+    `,
+    `
+class StaticBase {
+  static read(flag: boolean): string | null {
+    return flag ? 'ready' : null;
+  }
+}
+class StaticDerived extends StaticBase {
+  static override read(): string | null {
+    return 'ready';
+  }
+}
+    `,
+    `
+interface Reader {
+  read(): string | null;
+}
+class ReaderImpl implements Reader {
+  read(): string | null {
+    return 'ready';
+  }
+}
+    `,
+    `
+function replaceDecoratedMethod(
+  _target: object,
+  _key: string | symbol,
+  descriptor: TypedPropertyDescriptor<() => string | null>,
+): void {
+  descriptor.value = () => null;
+}
+class DecoratedImplementation {
+  @replaceDecoratedMethod
+  read(): string | null {
+    return 'ready';
+  }
+}
+    `,
+    `
+function replaceFieldClass<T extends new (...args: any[]) => object>(Base: T) {
+  return class extends Base {
+    read = () => null;
+  };
+}
+@replaceFieldClass
+class DecoratedWrappedField {
+  read = [(): string | null => 'ready'][0];
+}
+    `,
+    `
+function replaceDecoratedClass(target: {
+  prototype: { read(): string | null };
+}): void {
+  target.prototype.read = () => null;
+}
+@replaceDecoratedClass
+class DecoratedClassImplementation {
+  read(): string | null {
+    return 'ready';
+  }
+}
+    `,
+    `
+function replaceDecoratedField(target: object, key: string | symbol): void {
+  Object.defineProperty(target, key, {
+    configurable: true,
+    get: () => () => null,
+    set: () => {},
+  });
+}
+class DecoratedFieldImplementation {
+  @replaceDecoratedField
+  read = (): string | null => 'ready';
+}
+    `,
+    `
+function replaceSibling(target: { read(): string | null }, _key: string): void {
+  target.read = () => null;
+}
+class SiblingDecoratedImplementation {
+  read(): string | null {
+    return 'ready';
+  }
+  @replaceSibling
+  other(): void {}
+}
+    `,
+    // Overload implementations carry declarations shared with other
+    // signatures.
+    `
+function overloaded(value: 'a'): 'a';
+function overloaded(value: 'b'): 'b' | null;
+function overloaded(value: 'a' | 'b'): 'a' | 'b' | null {
+  return value;
+}
+    `,
+    `
+class OverloadedReader {
+  read(value: 'a'): 'a';
+  read(value: 'b'): 'b' | null;
+  read(value: 'a' | 'b'): 'a' | 'b' | null {
+    return value;
+  }
+}
+    `,
+    // A variadic tuple's required suffix is matched from the right. Treating
+    // it as part of the fixed prefix can discard a reachable overload.
+    `
+interface VariadicSuffixResult {
+  (...args: [...string[], number]): 'A' | 'B';
+}
+function variadicSuffix(...args: [string, ...never[], number]): 'B';
+function variadicSuffix(...args: [...string[], number]): 'A';
+function variadicSuffix(...args: (string | number)[]): 'A' | 'B' {
+  return args.length === 2 ? 'B' : 'A';
+}
+function preservesVariadicSuffixOverload(): VariadicSuffixResult {
+  return variadicSuffix;
+}
+    `,
+    `
+const accessorKey = 'value' as const;
+class AccessorPair {
+  get [accessorKey](): string | null {
+    return Math.random() > 0.5 ? 'ready' : null;
+  }
+  set [accessorKey](value: string | null) {}
+}
+    `,
+    `
+const objectAccessorPair = {
+  get value(): string | null {
+    return Math.random() > 0.5 ? 'ready' : null;
+  },
+  set value(value: string | null) {},
+};
+    `,
+    // Empty mutable containers do not provide evidence about their future
+    // element types and are therefore left alone.
+    `
+function emptyArray(): Array<string | null> {
+  return [];
+}
+    `,
+    `
+function emptyMap(): Map<string, number | null> {
+  return new Map();
+}
+    `,
+    // A syntactically written constituent that is already subsumed by another
+    // constituent does not widen the caller-visible type.
+    `
+function subsumedStringLiteral(): string | 'ready' {
+  return 'idle';
+}
+function returnedSubsumedStringLiteral(): 'ready' | string {
+  return 'ready';
+}
+function returnedSubsumedNumberLiteral(): 1 | 2 | number {
+  return 1;
+}
+function returnedSubsumedBigintLiteral(): 1n | bigint {
+  return BigInt(1) as 1n;
+}
+    `,
+    `
+function subsumedBooleanLiteral(): boolean | true {
+  return true;
+}
+    `,
+    `
+enum WholeState {
+  Loading,
+  Ready,
+}
+function wholeEnum(): WholeState {
+  return WholeState.Loading;
+}
+type WholeStateAlias = WholeState;
+function aliasedWholeEnum(): WholeStateAlias {
+  return WholeState.Loading;
+}
+    `,
+    // Function-valued class fields can carry the same inherited contract as
+    // methods do.
+    `
+class FieldBase {
+  read: () => string | null = () => null;
+}
+class FieldDerived extends FieldBase {
+  override read = (): string | null => 'ready';
+}
+    `,
+    // A constrained type parameter is subsumed by its wider sibling and does
+    // not add a caller-visible possibility of its own.
+    `
+function constrainedSubsumption<T extends string>(value: T): T | string {
+  return value;
+}
+    `,
+    `
+function constrainedGenericUnion<T extends 'ready' | 'idle'>(
+  value: T,
+): 'ready' | 'idle' {
+  return value;
+}
+function constrainedGenericArray<T extends string | null>(
+  value: T,
+): Array<string | null> {
+  return [value];
+}
+    `,
+    `
+declare function wrapCompleteCall<T>(value: T): { readonly value: T };
+declare const completeCallValue: 'idle' | 'ready';
+function completeResolvedGenericCall(): {
+  readonly value: 'idle' | 'ready';
+} {
+  return wrapCompleteCall(completeCallValue);
+}
+    `,
+    `
+declare function selectCompleteCall(value: 'ready'): {
+  readonly state: 'ready';
+};
+declare function selectCompleteCall(value: 'idle'): {
+  readonly state: 'idle';
+};
+declare function selectCompleteCall(value: 'idle' | 'ready'): {
+  readonly state: 'idle' | 'ready';
+};
+declare const completeCallState: 'idle' | 'ready';
+function completeResolvedOverloadCall(): {
+  readonly state: 'idle' | 'ready';
+} {
+  return selectCompleteCall(completeCallState);
+}
+    `,
+    `
+function completePromiseExecutor(flag: boolean): Promise<string | null> {
+  return new Promise(resolve => {
+    resolve(flag ? 'ready' : null);
+  });
+}
+    `,
+    `
+function branchedPromiseSettlement(flag: boolean): Promise<string | null> {
+  return new Promise(resolve => {
+    if (flag) resolve('ready');
+    else resolve(null);
+    resolve('ignored');
+  });
+}
+    `,
+    `
+function referencedPromiseResolverClosure(
+  flag: boolean,
+): Promise<string | null> {
+  return new Promise(resolve => {
+    function resolveNull() {
+      resolve(null);
+    }
+    if (flag) resolveNull();
+    else resolve('ready');
+  });
+}
+    `,
+    `
+function referencedPromiseResolverArrow(flag: boolean): Promise<string | null> {
+  return new Promise(resolve => {
+    const resolveNull = () => resolve(null);
+    if (flag) resolveNull();
+    else resolve('ready');
+  });
+}
+    `,
+    `
+function unreferencedRecursivePromiseResolvers(): Promise<string | null> {
+  return new Promise(resolve => {
+    function first(): void {
+      second();
+    }
+    function second(): void {
+      first();
+      resolve('ready');
+    }
+  });
+}
+function referencedRecursivePromiseResolvers(
+  flag: boolean,
+): Promise<string | null> {
+  return new Promise(resolve => {
+    function first(depth: number): void {
+      second(depth);
+    }
+    function second(depth: number): void {
+      if (depth > 0) first(depth - 1);
+      else resolve(null);
+    }
+    if (flag) first(1);
+    else resolve('ready');
+  });
+}
+function typeOnlyPromiseResolverReference(): Promise<string | null> {
+  return new Promise(resolve => {
+    function neverInvoked(): void {
+      resolve('ready');
+    }
+    const typeOnly: typeof neverInvoked | undefined = undefined;
+    void typeOnly;
+  });
+}
+    `,
+    `
+function uninvokedPromiseMethod(): Promise<string | null> {
+  return new Promise(resolve => {
+    const holder = {
+      settle(): void {
+        function settleLater(): void {
+          resolve('ready');
+        }
+        settleLater();
+      },
+    };
+    void holder;
+  });
+}
+    `,
+    `
+function uninstantiatedPromiseField(): Promise<string | null> {
+  return new Promise(resolve => {
+    class Holder {
+      value = resolve('ready');
+    }
+    void Holder;
+  });
+}
+function uninstantiatedPromiseFieldThroughLocalFunction(): Promise<
+  string | null
+> {
+  return new Promise(resolve => {
+    function settle(): void {
+      resolve('ready');
+    }
+    class Holder {
+      value = settle();
+    }
+    void Holder;
+  });
+}
+    `,
+    `
+function explicitlyPinnedPromiseExecutor(): Promise<string | null> {
+  return new Promise<string | null>(resolve => {
+    resolve('ready');
+  });
+}
+    `,
+    `
+declare function resolveLater(resolver: (value: string | null) => void): void;
+function escapedPromiseResolver(): Promise<string | null> {
+  return new Promise(resolve => {
+    resolveLater(resolve);
+  });
+}
+    `,
+    // Resolved mapped types and default-library members remain safe when every
+    // observable union constituent is represented by the implementation.
+    `
+type CompleteSource = { value: string | null; count: number };
+function completePick(flag: boolean): Pick<CompleteSource, 'value'> {
+  return { value: flag ? 'ready' : null };
+}
+    `,
+    `
+interface DatedResult {
+  createdAt: Date;
+  value: string | null;
+}
+function completeDatedResult(flag: boolean): DatedResult {
+  return { createdAt: new Date(), value: flag ? 'ready' : null };
+}
+    `,
+    `
+class ProtectedResult {
+  protected state: 'ready' | 'idle' = 'ready';
+}
+class ReadyProtectedResult extends ProtectedResult {
+  declare protected state: 'ready';
+}
+function protectedImplementationDetail(): ProtectedResult {
+  return new ReadyProtectedResult();
+}
+    `,
+    `
+import type { ImportedResult } from './no-misleading-return-type';
+function completeImportedAlias(flag: boolean): ImportedResult {
+  return flag ? 'ready' : null;
+}
+    `,
+    // When a finally block can complete normally, the preceding return still
+    // contributes to the function's observable completions.
+    `
+function conditionalFinally(flag: boolean): string | null {
+  try {
+    return null;
+  } finally {
+    if (flag) return 'ready';
+  }
+}
+    `,
+    `
+function labeledBreakLetsFinallyComplete(flag: boolean): string | null {
+  if (flag) return 'ready';
+  try {
+    return null;
+  } finally {
+    escape: {
+      break escape;
+    }
+  }
+}
+    `,
+    `
+function reachableSwitchFallthrough(flag: boolean): 'ready' | 'fallthrough' {
+  switch ('ready' as 'ready' | 'unmatched') {
+    case 'ready':
+      if (flag) return 'ready';
+    case 'unmatched':
+      return 'fallthrough';
+  }
+}
+    `,
+    `
+enum DynamicSwitchState {
+  Idle = 'idle',
+  Ready = 'ready',
+}
+function dynamicEnumSwitch(
+  state: DynamicSwitchState,
+): DynamicSwitchState.Idle | DynamicSwitchState.Ready {
+  switch (state) {
+    case DynamicSwitchState.Idle:
+      return DynamicSwitchState.Idle;
+    case DynamicSwitchState.Ready:
+      return DynamicSwitchState.Ready;
+  }
+}
+    `,
+    `
+enum DynamicElementSwitchState {
+  Idle = 'idle',
+  Ready = 'ready',
+}
+function dynamicElementEnumSwitch(
+  key: keyof typeof DynamicElementSwitchState,
+): DynamicElementSwitchState.Idle | DynamicElementSwitchState.Ready {
+  switch (DynamicElementSwitchState[key]) {
+    case DynamicElementSwitchState.Idle:
+      return DynamicElementSwitchState.Idle;
+    default:
+      return DynamicElementSwitchState.Ready;
+  }
+}
+    `,
+    `
+enum MutableSwitchState {
+  Idle = 'idle',
+  Ready = 'ready',
+}
+let mutableSwitchState: MutableSwitchState = MutableSwitchState.Ready;
+function mutableEnumSwitch():
+  MutableSwitchState.Idle | MutableSwitchState.Ready {
+  switch (mutableSwitchState as MutableSwitchState) {
+    case MutableSwitchState.Idle:
+      return MutableSwitchState.Idle;
+    default:
+      return MutableSwitchState.Ready;
+  }
+}
+    `,
+    `
+function nestedLoopBreakDoesNotExitSwitch(
+  loop: boolean,
+  returnReady: boolean,
+): 'ready' | 'fallthrough' {
+  switch ('ready' as 'ready' | 'unmatched') {
+    case 'ready':
+      if (returnReady) return 'ready';
+      while (loop) {
+        break;
+      }
+    case 'unmatched':
+      return 'fallthrough';
+  }
+}
+    `,
+    `
+declare function haltAfterLabeledSwitchBreak(): never;
+function labeledSwitchLetsFinallyComplete(
+  mode: boolean,
+  text: boolean,
+): string | null {
+  if (text) return 'ready';
+  try {
+    return null;
+  } finally {
+    done: switch (mode) {
+      case true:
+        break done;
+      default:
+        haltAfterLabeledSwitchBreak();
+    }
+  }
+}
+    `,
+    // A labeled break that targets the switch's containing label reaches the
+    // statement after the switch.
+    `
+function labeledSwitchCanExit(flag: boolean): string | null {
+  done: switch (flag) {
+    case true:
+      return 'ready';
+    default:
+      break done;
+  }
+  return null;
+}
+    `,
+    `
+declare const runtimeCaseValue: string;
+function unknownSwitchCaseMustRemainReachable(): string | null {
+  switch ('ready') {
+    case runtimeCaseValue:
+      return null;
+    default:
+      return 'ready';
+  }
+}
+    `,
+    `
+declare function haltInFinally(): never;
+function neverCompletingFinally(): string | null {
+  try {
+    return null;
+  } finally {
+    haltInFinally();
+  }
+}
+    `,
+    `
+function throwingFinally(): string | null {
+  try {
+    return null;
+  } finally {
+    throw new Error('halt');
+  }
+}
+    `,
+    `
+declare function haltInFinallyBranch(): never;
+function branchingNeverFinally(flag: boolean): string | null {
+  try {
+    return null;
+  } finally {
+    if (flag) haltInFinallyBranch();
+    else haltInFinallyBranch();
+  }
+}
+    `,
+    `
+declare function haltInFinallySwitch(): never;
+function switchingNeverFinally(flag: boolean): string | null {
+  try {
+    return null;
+  } finally {
+    switch (flag) {
+      case true:
+        haltInFinallySwitch();
+      default:
+        haltInFinallySwitch();
+    }
+  }
+}
+    `,
+    `
+declare function haltInFinallyLoop(): never;
+function doWhileNeverFinally(): string | null {
+  try {
+    return null;
+  } finally {
+    do {
+      haltInFinallyLoop();
+    } while (false);
+  }
+}
+    `,
+    // Unresolved conditional members cannot be compared soundly and must not
+    // contaminate otherwise structural generic aliases.
+    `
+type ConditionalBox<T> = {
+  value: T extends string ? string | null : number | null;
+};
+function preserveConditionalBox<T>(
+  value: ConditionalBox<T>,
+): ConditionalBox<T> {
+  return value;
+}
+    `,
+    `
+type DeferredConditionalBox<T> = {
+  value: T extends true ? string : number;
+};
+type DeferredIndexedBox<
+  T extends { first: string; second: number },
+  K extends 'first' | 'second',
+> = { value: T[K] };
+type DeferredMappedBox<T> = {
+  [K in keyof T]: T[K] extends string ? string : number;
+};
+function preserveDeferredConditional<T extends boolean>(
+  value: DeferredConditionalBox<T>,
+): { value: string | number } {
+  return value;
+}
+function preserveDeferredIndexed<
+  T extends { first: string; second: number },
+  K extends 'first' | 'second',
+>(value: DeferredIndexedBox<T, K>): { value: string | number } {
+  return value;
+}
+function preserveDeferredMapped<T extends { value: string | number }>(
+  value: DeferredMappedBox<T>,
+): { value: string | number } {
+  return value;
+}
+function preserveDeferredArray<T extends boolean>(
+  value: Array<T extends true ? string : number>,
+): Array<string | number> {
+  return value;
+}
+    `,
+    `
+type DeferredNullableValue<T extends boolean> = T extends true ? string : null;
+function preserveDeferredNullable<T extends boolean>(
+  value: DeferredNullableValue<T>,
+): string | null {
+  return value;
+}
+    `,
+    // Both members are deferred over an open `T`; with `T = ''` the same
+    // value inhabits both, so neither can be proven unused.
+    `
+type RecursiveA<T extends string> = T extends \`\${infer F}\${infer R}\`
+  ? \`\${F}a\${RecursiveA<R>}\`
+  : '';
+type RecursiveB<T extends string> = T extends \`\${infer F}\${infer R}\`
+  ? \`\${F}b\${RecursiveB<R>}\`
+  : '';
+function recursiveGenericSubset<T extends string>(
+  value: RecursiveA<T>,
+): RecursiveA<T> | RecursiveB<T> {
+  return value;
+}
+    `,
+    // TypeScript can overflow while comparing structurally equivalent
+    // recursive template-literal aliases. The rule must not crash.
+    `
+type RecursiveA<T extends string> = T extends \`\${infer F}\${infer R}\`
+  ? \`\${F}a\${RecursiveA<R>}\`
+  : '';
+type RecursiveB<T extends string> = T extends \`\${infer F}\${infer R}\`
+  ? \`\${F}a\${RecursiveB<R>}\`
+  : '';
+function recursiveRelation<T extends string>(
+  value: RecursiveA<T>,
+): RecursiveA<T> | RecursiveB<T> {
+  return value;
+}
+    `,
+    `
+type CompleteIntersection = { value: string | null } & { tag: 'result' };
+function completeIntersection(flag: boolean): CompleteIntersection {
+  return { value: flag ? 'ready' : null, tag: 'result' };
+}
+    `,
+    `
+type ReducedIntersection = { value: string | null } & { value: string };
+function effectiveIntersection(): ReducedIntersection {
+  return { value: 'ready' };
+}
+    `,
+    `
+enum DefinitionKind {
+  First,
+  Second,
+}
+type Definition =
+  | { first: string; kind: DefinitionKind.First }
+  | { kind: DefinitionKind.Second; second: number };
+type WrappedDefinition =
+  | {
+      definition: Definition & { kind: DefinitionKind.First };
+      kind: DefinitionKind.First;
+    }
+  | {
+      definition: Definition & { kind: DefinitionKind.Second };
+      kind: DefinitionKind.Second;
+    };
+function wrapDefinition(definition: Definition): WrappedDefinition {
+  switch (definition.kind) {
+    case DefinitionKind.First:
+      return { definition, kind: DefinitionKind.First };
+    case DefinitionKind.Second:
+      return { definition, kind: DefinitionKind.Second };
+  }
+}
+    `,
+    `
+type Wide0 = { value: string | null };
+type Complete0 = { value: string | null };
+type Wide1 = { left: Wide0; right: Wide0 };
+type Complete1 = { left: Complete0; right: Complete0 };
+type Wide2 = { left: Wide1; right: Wide1 };
+type Complete2 = { left: Complete1; right: Complete1 };
+type Wide3 = { left: Wide2; right: Wide2 };
+type Complete3 = { left: Complete2; right: Complete2 };
+type Wide4 = { left: Wide3; right: Wide3 };
+type Complete4 = { left: Complete3; right: Complete3 };
+type Wide5 = { left: Wide4; right: Wide4 };
+type Complete5 = { left: Complete4; right: Complete4 };
+type Wide6 = { left: Wide5; right: Wide5 };
+type Complete6 = { left: Complete5; right: Complete5 };
+type Wide7 = { left: Wide6; right: Wide6 };
+type Complete7 = { left: Complete6; right: Complete6 };
+type Wide8 = { left: Wide7; right: Wide7 };
+type Complete8 = { left: Complete7; right: Complete7 };
+type Wide9 = { left: Wide8; right: Wide8 };
+type Complete9 = { left: Complete8; right: Complete8 };
+type Wide10 = { left: Wide9; right: Wide9 };
+type Complete10 = { left: Complete9; right: Complete9 };
+type Wide11 = { left: Wide10; right: Wide10 };
+type Complete11 = { left: Complete10; right: Complete10 };
+type Wide12 = { left: Wide11; right: Wide11 };
+type Complete12 = { left: Complete11; right: Complete11 };
+type Wide13 = { left: Wide12; right: Wide12 };
+type Complete13 = { left: Complete12; right: Complete12 };
+type Wide14 = { left: Wide13; right: Wide13 };
+type Complete14 = { left: Complete13; right: Complete13 };
+type Wide15 = { left: Wide14; right: Wide14 };
+type Complete15 = { left: Complete14; right: Complete14 };
+type Wide16 = { left: Wide15; right: Wide15 };
+type Complete16 = { left: Complete15; right: Complete15 };
+type Wide17 = { left: Wide16; right: Wide16 };
+type Complete17 = { left: Complete16; right: Complete16 };
+declare const completeSharedDAG: Complete17;
+function preserveSharedDAG(): Wide17 {
+  return completeSharedDAG;
+}
+    `,
+    // A wide generic tree can expose more unique structural states than a lint
+    // rule should exhaustively traverse. Reaching the analysis budget must
+    // abandon the whole function without emitting a partial diagnostic.
+    `
+type WideTree<T, Depth extends unknown[]> = Depth extends [
+  unknown,
+  ...infer Rest,
+]
+  ? {
+      left: WideTree<[T, 0], Rest>;
+      right: WideTree<[T, 1], Rest>;
+    }
+  : { value: string | null };
+type CompleteTree<T, Depth extends unknown[]> = Depth extends [
+  unknown,
+  ...infer Rest,
+]
+  ? {
+      left: CompleteTree<[T, 0], Rest>;
+      right: CompleteTree<[T, 1], Rest>;
+    }
+  : { value: string | null };
+type TreeDepth = [
+  unknown,
+  unknown,
+  unknown,
+  unknown,
+  unknown,
+  unknown,
+  unknown,
+  unknown,
+  unknown,
+  unknown,
+  unknown,
+  unknown,
+  unknown,
+];
+declare const completeWideTree: CompleteTree<string, TreeDepth>;
+function analysisBudgetBailout(): WideTree<string, TreeDepth> {
+  return completeWideTree;
+}
+    `,
+    // Pathological syntax depth must conservatively bail out instead of
+    // overflowing either the rule's recursive projections or the TS checker.
+    {
+      code: noFormat`
+function deeplyNestedPromiseDoesNotOverflow(): Promise<string | null> {
+  return Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve(Promise.resolve('ready'))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
+}
+      `,
+    },
+    `
+type ComparisonBit = '0' | '1';
+type ComparisonKey =
+  \`\${ComparisonBit}\${ComparisonBit}\${ComparisonBit}\${ComparisonBit}\${ComparisonBit}\${ComparisonBit}\${ComparisonBit}\`;
+type ComparisonMember<Key extends string, Value> = Key extends unknown
+  ? { kind: Key; value: Value }
+  : never;
+type WideComparisonBudget = ComparisonMember<ComparisonKey, string | null>;
+type NarrowComparisonBudget = ComparisonMember<ComparisonKey, string>;
+declare const narrowComparisonBudget: NarrowComparisonBudget;
+function comparisonBudgetBailout(): WideComparisonBudget {
+  return narrowComparisonBudget;
+}
+    `,
+    // An unresolved indexed-access member is decided by the caller's
+    // instantiation, and the generic call's result must cover it.
+    `
+interface RuleMap {
+  alpha: { readonly kind: 'alpha' };
+  beta: { readonly kind: 'beta' };
+}
+declare function getRule<Id extends keyof RuleMap>(id: Id): RuleMap[Id];
+function maybeGetRule<Id extends keyof RuleMap>(id: Id): RuleMap[Id] | null {
+  try {
+    return getRule(id);
+  } catch {
+    return null;
+  }
+}
+    `,
+    // A type-parameter member can be instantiated as the returned value
+    // (\`T\` may be \`null\`), so its absence in the body proves nothing.
+    `
+function alwaysEmpty<T>(seed: T): T | null {
+  void seed;
+  return null;
+}
+    `,
+    // A trailing never-returning call ends the function without an
+    // implicit undefined, so nested positions gain no phantom observation.
+    `
+declare function fail(): never;
+function alwaysThrowsViaHelper(): { value: string | null } {
+  fail();
+}
+    `,
+    // An incomparable cast pins a contract the operand cannot express;
+    // the asserted type is what callers observe.
+    `
+interface BuiltNode {
+  readonly kind: string;
+  readonly parent: object;
+}
+function buildNode(flag: boolean): BuiltNode | undefined {
+  if (!flag) {
+    return undefined;
+  }
+  return { kind: 'built' } as BuiltNode;
+}
+    `,
+    // A contextual contract behind a literal-or-callable union property
+    // still supplies the return contract the annotation mirrors.
+    `
+type Level = 0 | 1 | 2 | 'error' | 'off' | 'warn';
+interface PropertySchema {
+  merge: string | ((first: Level, second: Level) => Level);
+}
+const levelSchema: PropertySchema = {
+  merge(first: Level, second: Level): Level {
+    void second;
+    return first === 'error' ? 2 : first;
+  },
+};
+void levelSchema;
+    `,
+    // A possibly-falsy test type keeps both branches reachable.
+    `
+declare const label: string;
+function possiblyFalsyKeepsBranches(): 'ready' | 'fallback' {
+  if (label) return 'ready';
+  return 'fallback';
+}
+    `,
+    // Beyond the structural depth budget the analysis stops quietly instead
+    // of spending unbounded checker time on pathologically deep types.
+    `
+type Depth1 = [unknown];
+type Depth2 = [...Depth1, ...Depth1];
+type Depth4 = [...Depth2, ...Depth2];
+type Depth8 = [...Depth4, ...Depth4];
+type Depth16 = [...Depth8, ...Depth8];
+type Depth32 = [...Depth16, ...Depth16];
+type Depth64 = [...Depth32, ...Depth32];
+type Depth128 = [...Depth64, ...Depth64];
+type Depth256 = [...Depth128, ...Depth128];
+type Depth512 = [...Depth256, ...Depth256];
+type Depth1024 = [...Depth512, ...Depth512];
+type Depth1088 = [...Depth1024, ...Depth64];
+type DeepValue<T, Depth extends unknown[]> = Depth extends [
+  unknown,
+  ...infer Rest,
+]
+  ? { readonly next: DeepValue<T, Rest> }
+  : { readonly value: T };
+declare const veryDeepText: DeepValue<string, Depth1088>;
+function veryDeepAcyclicType(): DeepValue<string | null, Depth1088> {
+  return veryDeepText;
+}
+    `,
+    // Index projections only inspect keys covered by the declared signature.
+    `
+declare const completeSymbolKey: unique symbol;
+function completeSymbolIndex(flag: boolean): { [key: symbol]: string | null } {
+  const result = {
+    [completeSymbolKey]: flag ? 'ready' : null,
+    unrelated: 1,
+  };
+  return result;
+}
+    `,
+    `
+const unrelatedTemplateIndexSource = { abc: 1 };
+function unrelatedTemplateIndexProperty(): {
+  [key: \`\${number}\`]: number | null;
+} {
+  return unrelatedTemplateIndexSource;
+}
+    `,
+    `
+function numberTemplateAcceptsFiniteNumericStrings(): {
+  [key: \`\${number}\`]: string | null;
+  Infinity: string;
+} {
+  return { '01': null, '1e3': 'ready', Infinity: 'unrelated' };
+}
+    `,
+    `
+function bigintTemplateAcceptsNegativeHex(): {
+  [key: \`\${bigint}\`]: string | null;
+} {
+  return { '-0x10': null, '1': 'ready' };
+}
+    `,
+    `
+type MappedTemplateKey = \`data-\${Uppercase<string>}\`;
+const dynamicMappedTemplateKey: MappedTemplateKey =
+  Math.random() > 0.5 ? 'data-B' : 'data-C';
+function stringMappingTemplateIndex(): {
+  [key: MappedTemplateKey]: string | null;
+} {
+  return { [dynamicMappedTemplateKey]: 'ready', 'data-A': null };
+}
+    `,
+    `
+const specialNumericIndexSource = {
+  0: 'ready',
+  '-Infinity': false,
+  Infinity: 1,
+  NaN: null,
+};
+function specialNumericIndexKeys(): {
+  [key: number]: boolean | number | string | null;
+} {
+  return specialNumericIndexSource;
+}
+    `,
+    `
+declare const overlappingComputedIndexKey: \`data-\${string}\` | 'other';
+function overlappingComputedIndexKeyValue(): {
+  [key: \`data-\${string}\`]: string | null;
+} {
+  return { 'data-ready': 'ready', [overlappingComputedIndexKey]: null };
+}
+    `,
+    // Both nested yield expressions are observable, including the inner yield
+    // whose result becomes the value of the outer yield.
+    `
+function* nestedYields(): Generator<string | null, void, null> {
+  yield yield 'ready';
+}
+    `,
+    `
+async function* delegatedPromises(): AsyncGenerator<string | null> {
+  yield* [Promise.resolve('ready'), Promise.resolve(null)];
+}
+    `,
+    // A primitive string is iterable through its apparent type, yielding its
+    // characters as `string`.
+    `
+function* delegatedStringYield(): Generator<string | number> {
+  yield* 'ready';
+  yield 1;
+}
+    `,
+    `
+function spreadStringElements(): (string | number)[] {
+  return [...'ready', 1];
+}
+    `,
+    `
+function* callerProvidedCompletion(): Generator<
+  string,
+  number | null,
+  unknown
+> {
+  yield 'ready';
+  return 1;
+}
+callerProvidedCompletion().return(null);
+    `,
+    `
+declare const numberCompletionGenerator: Generator<string, number, unknown>;
+function widenedGeneratorCompletion(): Generator<
+  string,
+  number | null,
+  unknown
+> {
+  return numberCompletionGenerator;
+}
+widenedGeneratorCompletion().return(null);
+    `,
+    `
+declare const completeIndexedText: { [key: string]: string | null };
+function completeReturnedIndex(): { [key: string]: string | null } {
+  return completeIndexedText;
+}
+    `,
+    `
+declare const optionalIndexedNullOverlay: {} | { status: null };
+function optionalIndexSpreadPreservesEarlierValue(): {
+  [key: string]: string | null;
+} {
+  return { status: 'ready', ...optionalIndexedNullOverlay };
+}
+    `,
+    `
+interface CompleteSwappedMap<Value, Key> extends Map<Key, Value> {}
+function completeSwappedMap(): CompleteSwappedMap<number | null, string> {
+  return new Map<string, number | null>([
+    ['ready', 1],
+    ['empty', null],
+  ]);
+}
+    `,
+    `
+interface CompleteSwappedGenerator<Return, Yield> extends Generator<
+  Yield,
+  Return,
+  unknown
+> {}
+function* completeSwappedGenerator(
+  flag: boolean,
+): CompleteSwappedGenerator<number | null, string | null> {
+  yield flag ? 'ready' : null;
+  return flag ? 1 : null;
+}
+    `,
+    `
+declare const completeGeneratorObject: Generator<
+  string,
+  number | null,
+  unknown
+>;
+function returnCompleteGeneratorObject(): Generator<
+  string,
+  number | null,
+  unknown
+> {
+  return completeGeneratorObject;
+}
+    `,
+    `
+type CompleteWeakKey = { id: string };
+interface CompleteSwappedWeakMap<Value, Key extends object> extends WeakMap<
+  Key,
+  Value
+> {}
+function completeSwappedWeakMap(): CompleteSwappedWeakMap<
+  string | null,
+  CompleteWeakKey
+> {
+  return new WeakMap<CompleteWeakKey, string | null>([
+    [{ id: 'ready' }, 'ready'],
+    [{ id: 'empty' }, null],
+  ]);
+}
+    `,
+    `
+declare const optionalNullOverlay: {} | { value: null };
+function optionalSpreadPreservesEarlierValue(): { value: string | null } {
+  return { value: 'ready', ...optionalNullOverlay };
+}
+    `,
+    `
+interface OverlappingExpectedCallable {
+  (value: string): string | null;
+}
+interface OverlappingSourceCallable {
+  (value: 'empty'): null;
+  (value: string): string;
+}
+declare const overlappingSourceCallable: OverlappingSourceCallable;
+function overlappingCallableOverloads(): OverlappingExpectedCallable {
+  return overlappingSourceCallable;
+}
+    `,
+    // A structurally compatible generator protocol is not necessarily one of
+    // the standard-library Generator types whose yielded slot we understand.
+    `
+interface DomainIterator<T> {
+  next(...args: [] | [unknown]): IteratorResult<T, void>;
+  return(value: void): IteratorResult<T, void>;
+  throw(error: unknown): IteratorResult<T, void>;
+  [Symbol.iterator](): DomainIterator<T>;
+}
+function* opaqueGeneratorProtocol(): DomainIterator<string | null> {
+  yield 'ready';
+}
+    `,
+    // `any` remains an escape hatch at nested projected output positions.
+    `
+declare const opaqueNestedValue: any;
+function opaqueArrayElement(): readonly (string | null)[] {
+  return opaqueNestedValue;
+}
+    `,
+    `
+declare const opaqueNestedValue: any;
+function opaqueCallableReturn(): () => string | null {
+  return opaqueNestedValue;
+}
+    `,
+    `
+declare const opaqueNestedValue: any;
+function opaqueWeakReference(): WeakRef<
+  { readonly kind: 'idle' } | { readonly kind: 'ready' }
+> {
+  return opaqueNestedValue;
+}
+    `,
+    // An external Promise executor can call either continuation, so its
+    // settlement values cannot be inferred from this function body.
+    `
+declare const opaquePromiseExecutor: (
+  resolve: (value: string | null | PromiseLike<string | null>) => void,
+  reject: (reason?: any) => void,
+) => void;
+function opaquePromiseSettlement(): Promise<string | null> {
+  return new Promise(opaquePromiseExecutor);
+}
+    `,
+    // Getter overrides expose the inherited property contract directly.
+    `
+abstract class GetterContractBase {
+  abstract get value(): string | null;
+}
+class GetterContractDerived extends GetterContractBase {
+  override get value(): string | null {
+    return 'ready';
+  }
+}
+    `,
+    // Individual nested projections preserve an opaque source.
+    `
+declare const opaqueNestedValue: any;
+function opaqueTupleElement(): readonly [string | null] {
+  return opaqueNestedValue;
+}
+    `,
+    `
+declare const opaqueNestedValue: any;
+function opaqueSetElement(): ReadonlySet<string | null> {
+  return opaqueNestedValue;
+}
+    `,
+    `
+declare const opaqueNestedValue: any;
+function opaqueObjectProperty(): { readonly value: string | null } {
+  return opaqueNestedValue;
+}
+    `,
+    // Type-invalid partial programs must bail out instead of crashing.
+    `
+type WeakReferenceValue =
+  { readonly kind: 'idle' } | { readonly kind: 'ready' };
+function incompleteWeakReference(): WeakRef<WeakReferenceValue> {
+  return {};
+}
+    `,
+    `
+type WeakSetValue = { readonly kind: 'idle' } | { readonly kind: 'ready' };
+function incompleteWeakSet(): WeakSet<WeakSetValue> {
+  return {
+    has() {
+      return true;
+    },
+  };
+}
+    `,
+    `
+interface MissingValueIterator {
+  next(): { done?: false };
+}
+interface MissingValueIterable {
+  [Symbol.iterator](): MissingValueIterator;
+}
+declare const missingValueIterable: MissingValueIterable;
+function incompleteIterableResult(): Iterable<string | null> {
+  return missingValueIterable;
+}
+    `,
+    // A partial program with disjoint callable parameters keeps every source
+    // return possibility instead of guessing at signature correspondence.
+    `
+interface DisjointExpectedCallable {
+  (value: string): string | null;
+}
+interface DisjointSourceCallable {
+  (value: boolean): string | null;
+}
+declare const disjointSourceCallable: DisjointSourceCallable;
+function disjointCallableParameters(): DisjointExpectedCallable {
+  return disjointSourceCallable;
+}
+    `,
+    // Missing numeric index information in a partial program cannot prove an
+    // array element constituent absent.
+    `
+function incompleteArrayProjection(): readonly (string | null)[] {
+  return {};
+}
+    `,
+    // Unknown object spreads can populate any string index value.
+    `
+declare const opaqueIndexSpread: any;
+function opaqueIndexValues(): { readonly [key: string]: string | null } {
+  return { ...opaqueIndexSpread };
+}
+    `,
+    // A Promise without an inspectable executor is opaque in a partial
+    // type-invalid program.
+    `
+function missingPromiseExecutor(): Promise<string | null> {
+  return new Promise();
+}
+    `,
+    // Dynamic loop and logical conditions keep their yielded branch reachable.
+    `
+type TextGenerator = Generator<string | null, void, unknown>;
+function* reachableForYield(flag: boolean): TextGenerator {
+  for (; flag;) {
+    yield null;
+    break;
+  }
+  yield 'ready';
+}
+    `,
+    `
+type TextGenerator = Generator<string | null, void, unknown>;
+function* reachableLogicalYield(flag: boolean): TextGenerator {
+  flag && (yield null);
+  yield 'ready';
+}
+    `,
+    `
+type TextGenerator = Generator<string | null, void, unknown>;
+function* reachableWhileYield(flag: boolean): TextGenerator {
+  while (flag) {
+    yield null;
+    break;
+  }
+  yield 'ready';
+}
+    `,
+    // Computed literal method names still inherit contextual contracts.
+    `
+interface ComputedMethodContract {
+  read(): string | null;
+}
+const computedMethodContract: ComputedMethodContract = {
+  ['read'](): string | null {
+    return 'ready';
+  },
+};
+    `,
+    {
+      code: `
+function checkedStringIndex(
+  values: Readonly<Record<string, string>>,
+): string | undefined {
+  return values['known'];
+}
+      `,
+      languageOptions: {
+        parserOptions: {
+          project: './tsconfig.noUncheckedIndexedAccess.json',
+          projectService: false,
+          tsconfigRootDir: getFixturesRootDir(),
+        },
+      },
+    },
+    {
+      code: `
+interface MixedNodes extends NodeListOf<HTMLDivElement | SVGElement> {
+  readonly source: 'mixed';
+}
+declare const mixedNodes: MixedNodes;
+function completeNodeList(): NodeListOf<HTMLDivElement | SVGElement> {
+  return mixedNodes;
+}
+      `,
+      languageOptions: {
+        parserOptions: {
+          project: './tsconfig.lib-dom.json',
+          projectService: false,
+          tsconfigRootDir: getFixturesRootDir(),
+        },
+      },
+    },
+  ],
+  invalid: [
+    {
+      code: noFormat`
+function unrelatedNestedDepth(): string | null {
+  const ignored = () => !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!0;
+  void ignored;
+  return 'ready';
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    // Original #6442 cases and the literal/primitive relationship agreed on in
+    // the issue discussion.
+    {
+      code: `
+function original(): string | null {
+  return 'ready';
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+function text(): string | undefined {
+  return 'ready';
+}
+      `,
+      errors: [
+        {
+          column: 16,
+          data: { annotated: 'string | undefined', unused: 'undefined' },
+          endColumn: 36,
+          endLine: 2,
+          line: 2,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+      languageOptions: {
+        parserOptions: {
+          project: './tsconfig.noUncheckedIndexedAccess.json',
+          projectService: false,
+          tsconfigRootDir: getFixturesRootDir(),
+        },
+      },
+    },
+    {
+      code: `
+function text(): string | void {
+  return 'ready';
+}
+      `,
+      errors: [
+        {
+          column: 16,
+          data: { annotated: 'string | void', unused: 'void' },
+          endColumn: 31,
+          endLine: 2,
+          line: 2,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+      languageOptions: {
+        parserOptions: {
+          project: './tsconfig.noUncheckedIndexedAccess.json',
+          projectService: false,
+          tsconfigRootDir: getFixturesRootDir(),
+        },
+      },
+    },
+    {
+      code: `
+function knownTupleIndex(value: readonly [string]): string | undefined {
+  return value[0];
+}
+      `,
+      errors: [
+        {
+          column: 51,
+          data: { annotated: 'string | undefined', unused: 'undefined' },
+          endColumn: 71,
+          endLine: 2,
+          line: 2,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+      languageOptions: {
+        parserOptions: {
+          project: './tsconfig.noUncheckedIndexedAccess.json',
+          projectService: false,
+          tsconfigRootDir: getFixturesRootDir(),
+        },
+      },
+    },
+    {
+      code: `
+type MaybeText = string | undefined;
+function aliasedUndefined(): MaybeText {
+  return 'ready';
+}
+      `,
+      errors: [
+        {
+          column: 28,
+          data: { annotated: 'MaybeText', unused: 'undefined' },
+          endColumn: 39,
+          endLine: 3,
+          line: 3,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+      languageOptions: {
+        parserOptions: {
+          project: './tsconfig.noUncheckedIndexedAccess.json',
+          projectService: false,
+          tsconfigRootDir: getFixturesRootDir(),
+        },
+      },
+    },
+    {
+      code: `
+function primitiveBooleanWithUnusedNull(): boolean | null {
+  return true;
+}
+      `,
+      errors: [
+        {
+          data: { annotated: 'boolean | null', unused: 'null' },
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+type WideContextualReturn = () => string | number | null;
+const narrowedContextualReturn: WideContextualReturn = (): string | null =>
+  'ready';
+
+class WideReturnBase {
+  read(flag: 0 | 1 | 2): string | number | null {
+    if (flag === 0) return 'ready';
+    return flag === 1 ? 1 : null;
+  }
+}
+class NarrowReturnOverride extends WideReturnBase {
+  override read(): string | null {
+    return 'ready';
+  }
+}
+      `,
+      errors: [
+        { messageId: 'misleadingReturnType' },
+        { messageId: 'misleadingReturnType' },
+      ],
+    },
+    {
+      code: `
+interface InstanceReader {
+  read(): string | null;
+}
+class StaticReader implements InstanceReader {
+  read(): string {
+    return 'ready';
+  }
+  static read(): string | null {
+    return 'ready';
+  }
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: "const conciseArrow = (): string | null => 'ready';",
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+const directObjectMethod = {
+  read(): string | null {
+    return 'ready';
+  },
+};
+const getterOnlyObject = {
+  get value(): string | null {
+    return 'ready';
+  },
+};
+      `,
+      errors: [
+        { messageId: 'misleadingReturnType' },
+        { messageId: 'misleadingReturnType' },
+      ],
+    },
+    {
+      code: `
+function transparentExpressionWrappers(): 'ready' | 'idle' {
+  return 'ready' as const satisfies string;
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+function wideningAssertion(): string | null {
+  return 'ready' as string;
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+class OriginalClass {
+  static read(): string | null {
+    return 'ready';
+  }
+  read(): string | null {
+    return 'ready';
+  }
+}
+      `,
+      errors: [
+        { messageId: 'misleadingReturnType' },
+        { messageId: 'misleadingReturnType' },
+      ],
+    },
+    {
+      code: `
+function literalSubset(): 'loading' | 'idle' {
+  return 'loading';
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+type TextAlias = string;
+type Count = number;
+function inlineAliases(): TextAlias | Count {
+  return 'ready';
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+enum State {
+  Loading,
+  Ready,
+}
+function enumSubset(): State.Loading | State.Ready {
+  return State.Loading;
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+declare const firstSymbol: unique symbol;
+declare const secondSymbol: unique symbol;
+function symbolSubset(): typeof firstSymbol | typeof secondSymbol {
+  return firstSymbol;
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+function shapeSubset(): { kind: 'one' } | { kind: 'two' } {
+  return { kind: 'one' };
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+type FirstCallback = () => 1;
+type SecondCallback = () => 2;
+declare const firstCallback: FirstCallback;
+function callbackSubset(): FirstCallback | SecondCallback {
+  return firstCallback;
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+declare const brand: unique symbol;
+type Branded = { value: string } & { readonly [brand]: true };
+declare const branded: Branded;
+function intersectionConstituent():
+  ({ value: string } & { readonly [brand]: true }) | null {
+  return branded;
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    // Type parameters, conditional types, mapped types, and indexed access
+    // types are safe when they are explicit top-level union constituents: the
+    // implementation returns that same constituent and not the sibling.
+    {
+      code: `
+function generic<T>(value: T): T | null {
+  return value;
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+declare function wrapNarrowCall<T>(value: T): { readonly value: T };
+function resolvedGenericCall(): { readonly value: 'idle' | 'ready' } {
+  return wrapNarrowCall('ready' as const);
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+declare function selectNarrowCall(value: 'ready'): {
+  readonly state: 'ready';
+};
+declare function selectNarrowCall(value: string): {
+  readonly state: 'idle' | 'ready';
+};
+function resolvedOverloadCall(): { readonly state: 'idle' | 'ready' } {
+  return selectNarrowCall('ready');
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+function narrowedGeneric<T extends string | null>(value: T): string | null {
+  if (value === null) {
+    return 'fallback';
+  }
+  return value;
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+type Result = string | null;
+function aliasedReturn(): Result {
+  return 'ready';
+}
+      `,
+      errors: [
+        {
+          data: { annotated: 'Result', unused: 'null' },
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+type Maybe<T> = T | null;
+function genericAlias<T>(value: T): Maybe<T> {
+  return value;
+}
+      `,
+      errors: [
+        {
+          data: { annotated: 'Maybe<T>', unused: 'null' },
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+type ObjectResult = { readonly value: string | null };
+function objectAlias(): ObjectResult {
+  return { value: 'ready' };
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+interface InterfaceResult {
+  readonly value: string | null;
+}
+function interfaceResult(): InterfaceResult {
+  return { value: 'ready' };
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+type Box<T> = { readonly value: T };
+declare const textBox: Box<string>;
+function genericObjectAlias(): Box<string | null> {
+  return textBox;
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+type TextPromise = Promise<string | null>;
+declare const promisedText: Promise<string>;
+function opaquePromiseAlias(): TextPromise {
+  return promisedText;
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+type TextArray = ReadonlyArray<string | null>;
+declare const textArray: readonly string[];
+function opaqueArrayAlias(): TextArray {
+  return textArray;
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+type Model = { ready: 1; idle: 2 };
+function keyOfAlias(): keyof Model {
+  return 'ready';
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+type MappedResult = { readonly [Key in 'value']: string | null };
+function mappedObjectAlias(): MappedResult {
+  return { value: 'ready' };
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+type FullResult = { readonly value: string | null; count: number };
+function pickedObject(): Pick<FullResult, 'value'> {
+  return { value: 'ready' };
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+type Handler = () => string | null;
+declare const textHandler: () => string;
+function functionAlias(): Handler {
+  return textHandler;
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+function createStableReader() {
+  let value: string | null = 'ready';
+  return function stableReader(): string | null {
+    return value;
+  };
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+interface RecursiveResult {
+  readonly next?: RecursiveResult;
+  readonly value: string | null;
+}
+function recursiveAlias(): RecursiveResult {
+  return { value: 'ready' };
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    // Deep but acyclic structures are analyzed within the depth budget; the
+    // cycle memoization must not mistake repetition for a cycle.
+    {
+      code: `
+type Depth1 = [unknown];
+type Depth2 = [...Depth1, ...Depth1];
+type Depth4 = [...Depth2, ...Depth2];
+type Depth8 = [...Depth4, ...Depth4];
+type Depth16 = [...Depth8, ...Depth8];
+type DeepValue<T, Depth extends unknown[]> = Depth extends [
+  unknown,
+  ...infer Rest,
+]
+  ? { readonly next: DeepValue<T, Rest> }
+  : { readonly value: T };
+declare const deepText: DeepValue<string, Depth16>;
+function deepAcyclicType(): DeepValue<string | null, Depth16> {
+  return deepText;
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+type AliasLeaf = { readonly value: string | null };
+type AliasEnvelope = Promise<Readonly<AliasLeaf>>;
+async function nestedAliasChain(): AliasEnvelope {
+  return { value: 'ready' };
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+import type { ImportedResult } from './no-misleading-return-type';
+function importedAlias(): ImportedResult {
+  return 'ready';
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+import { type ImportedBox, importedTextBox } from './no-misleading-return-type';
+function importedGenericAlias(): ImportedBox<string | null> {
+  return importedTextBox;
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+import type { ImportedEnvelope } from './no-misleading-return-type';
+async function importedNestedAlias(): ImportedEnvelope<string | null> {
+  return { value: 'ready' };
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+type ExtractedState = Extract<'ready' | 'idle' | 0, string>;
+function concreteConditional(): ExtractedState {
+  return 'ready';
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+type IntersectedResult = { readonly value: string | null } & {
+  readonly tag: 'result';
+};
+function intersectionAlias(): IntersectedResult {
+  return { value: 'ready', tag: 'result' };
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+type StatefulArray = string[] & { readonly state: 'ready' | 'idle' };
+declare const readyArray: string[] & { readonly state: 'ready' };
+function builtinIntersection(): StatefulArray {
+  return readyArray;
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+type EventName = \`on\${'Ready' | 'Idle'}\`;
+function templateLiteralUnion(): EventName {
+  return 'onReady';
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+type ReturnedState = ReturnType<() => 'ready' | 'idle'>;
+function utilityReturnType(): ReturnedState {
+  return 'ready';
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+function bigintSubset(): 1n | 2n {
+  return BigInt(1) as 1n;
+}
+type DataKey = \`data-\${string}\`;
+function templatePattern(): DataKey | null {
+  return 'data-ready';
+}
+type UpperState = Uppercase<'ready' | 'idle'>;
+function intrinsicStringMapping(): UpperState {
+  return 'READY';
+}
+function noInferGeneric<T>(value: T): NoInfer<T> | null {
+  return value;
+}
+function genericKey<T>(key: keyof T): keyof T | null {
+  return key;
+}
+type NullableParameter = (value: string | null) => void;
+declare const textParameter: readonly [string];
+function utilityTuple(): Readonly<Parameters<NullableParameter>> {
+  return textParameter;
+}
+      `,
+      errors: [
+        { messageId: 'misleadingReturnType' },
+        { messageId: 'misleadingReturnType' },
+        { messageId: 'misleadingReturnType' },
+        { messageId: 'misleadingReturnType' },
+        { messageId: 'misleadingReturnType' },
+        { messageId: 'misleadingReturnType' },
+      ],
+    },
+    {
+      code: `
+declare const queriedValue: { readonly value: string | null };
+declare const queriedText: { readonly value: string };
+function typeQuery(): typeof queriedValue {
+  return queriedText;
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+type Accessors<T> = {
+  readonly [Key in keyof T as \`get\${Capitalize<string & Key>}\`]: T[Key];
+};
+function keyRemappedMappedType(): Accessors<{ state: string | null }> {
+  return { getState: 'ready' };
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+function capitalizeStringIndex(): {
+  readonly [key: \`get\${Capitalize<string>}\`]: 'A' | 'B';
+  readonly getState: 'A';
+  readonly getother: 'B';
+} {
+  return { getState: 'A', getother: 'B' };
+}
+function uppercaseStringIndex(): {
+  readonly [key: Uppercase<string>]: 'A' | 'B';
+  readonly READY: 'A';
+  readonly ready: 'B';
+} {
+  return { READY: 'A', ready: 'B' };
+}
+function lowercaseStringIndex(): {
+  readonly [key: Lowercase<string>]: 'A' | 'B';
+  readonly ready: 'A';
+  readonly READY: 'B';
+} {
+  return { ready: 'A', READY: 'B' };
+}
+function uncapitalizeStringIndex(): {
+  readonly [key: Uncapitalize<string>]: 'A' | 'B';
+  readonly ready: 'A';
+  readonly Ready: 'B';
+} {
+  return { ready: 'A', Ready: 'B' };
+}
+      `,
+      errors: [
+        { messageId: 'misleadingReturnType' },
+        { messageId: 'misleadingReturnType' },
+        { messageId: 'misleadingReturnType' },
+        { messageId: 'misleadingReturnType' },
+      ],
+    },
+    {
+      code: `
+namespace Domain {
+  export interface Promise<T> {
+    readonly value: T;
+  }
+}
+declare const domainText: Domain.Promise<string>;
+function shadowedBuiltin(): Domain.Promise<string | null> {
+  return domainText;
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+class FluentResult {
+  narrow(): this | null {
+    return this;
+  }
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+type IndexedModel = { state: 'ready' | 'idle' };
+function concreteIndexedAccess(): IndexedModel['state'] {
+  return 'ready';
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+type OmittedSource = { readonly value: string | null; ignored: number };
+function omittedObject(): Omit<OmittedSource, 'ignored'> {
+  return { value: 'ready' };
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+function partialObject(): Partial<{ readonly value: string | null }> {
+  return { value: 'ready' };
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+function recordedObject(): Readonly<Record<'value', string | null>> {
+  return { value: 'ready' };
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+type Conditional<T> = T extends string ? string : number;
+function conditional<T>(value: Conditional<T>): Conditional<T> | null {
+  return value;
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+type DeferredValueBox<T extends boolean> = {
+  readonly value: T extends true ? string : number;
+};
+function constrainedDeferredMember<T extends boolean>(
+  value: DeferredValueBox<T>,
+): { readonly value: string | number | null } {
+  return value;
+}
+      `,
+      errors: [
+        {
+          data: {
+            annotated: '{ readonly value: string | number | null; }',
+            unused: 'null',
+          },
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+type DeferredIndexedValue<
+  K extends PropertyKey,
+  T extends Record<K, string | number>,
+> = { readonly value: T[K] };
+function constrainedIndexedMember<
+  K extends PropertyKey,
+  T extends Record<K, string | number>,
+>(
+  value: DeferredIndexedValue<K, T>,
+): {
+  readonly value: string | number | null;
+} {
+  return value;
+}
+      `,
+      errors: [
+        {
+          data: {
+            annotated: '{ readonly value: string | number | null; }',
+            unused: 'null',
+          },
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+type Mapped<T> = { [Key in keyof T]: T[Key] };
+function mapped<T>(value: Mapped<T>): Mapped<T> | null {
+  return value;
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+function indexed<T, Key extends keyof T>(value: T[Key]): T[Key] | null {
+  return value;
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+function enclosingGeneric<T>(value: T) {
+  return function nested(): T | null {
+    return value;
+  };
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    // Promise and PromiseLike positions use awaited semantics for both async
+    // and synchronous functions.
+    {
+      code: `
+async function asyncPromise(): Promise<string | null> {
+  return 'ready';
+}
+      `,
+      errors: [
+        {
+          data: { annotated: 'Promise<string | null>', unused: 'null' },
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+function syncPromise(): Promise<string | null> {
+  return Promise.resolve('ready');
+}
+      `,
+      errors: [
+        {
+          data: { annotated: 'Promise<string | null>', unused: 'null' },
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+function promiseConstructor(): Promise<string | null> {
+  return new Promise(resolve => {
+    resolve('ready');
+  });
+}
+      `,
+      errors: [
+        {
+          data: { annotated: 'Promise<string | null>', unused: 'null' },
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+function staticPromiseField(): Promise<string | null> {
+  return new Promise(resolve => {
+    class Holder {
+      static value = resolve('ready');
+    }
+    void Holder;
+  });
+}
+function staticPromiseFieldThroughLocalFunction(): Promise<string | null> {
+  return new Promise(resolve => {
+    function settle(): void {
+      resolve('ready');
+    }
+    class Holder {
+      static value = settle();
+    }
+    void Holder;
+  });
+}
+      `,
+      errors: [
+        {
+          data: { annotated: 'Promise<string | null>', unused: 'null' },
+          messageId: 'misleadingReturnType',
+        },
+        {
+          data: { annotated: 'Promise<string | null>', unused: 'null' },
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+function nestedPromiseConstructor(): Promise<string | null> {
+  return new Promise(resolve => {
+    resolve(Promise.resolve('ready'));
+  });
+}
+      `,
+      errors: [
+        {
+          data: { annotated: 'Promise<string | null>', unused: 'null' },
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+function unusedPromiseResolverClosure(): Promise<string | null> {
+  return new Promise(resolve => {
+    function neverInvoked() {
+      resolve(null);
+    }
+    resolve('ready');
+  });
+}
+      `,
+      errors: [
+        {
+          data: { annotated: 'Promise<string | null>', unused: 'null' },
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+function unusedPromiseResolverArrow(): Promise<string | null> {
+  return new Promise(resolve => {
+    const neverInvoked = () => resolve(null);
+    resolve('ready');
+  });
+}
+      `,
+      errors: [
+        {
+          data: { annotated: 'Promise<string | null>', unused: 'null' },
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+function unreachablePromiseSettlement(): Promise<string | null> {
+  return new Promise(resolve => {
+    resolve('ready');
+    return;
+    resolve(null);
+  });
+}
+function repeatedPromiseSettlement(): Promise<string | null> {
+  return new Promise(resolve => {
+    resolve('ready');
+    resolve(null);
+  });
+}
+function branchedThenSettledPromise(
+  flag: boolean,
+): Promise<string | number | null> {
+  return new Promise(resolve => {
+    if (flag) resolve('ready');
+    resolve(null);
+    resolve(1);
+  });
+}
+      `,
+      errors: [
+        { messageId: 'misleadingReturnType' },
+        { messageId: 'misleadingReturnType' },
+        {
+          data: {
+            annotated: 'Promise<string | number | null>',
+            unused: 'number',
+          },
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+function rejectionIsASettlementBarrier(flag: boolean): Promise<string | null> {
+  return new Promise((resolve, reject) => {
+    if (flag) resolve('ready');
+    else reject(new Error('rejected'));
+    resolve(null);
+  });
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+function wrappedPromiseSettlement(): Promise<string | null> {
+  return new Promise(resolve => {
+    void resolve('ready');
+    resolve(null);
+  });
+}
+function sequencedPromiseSettlement(): Promise<string | null> {
+  return new Promise(resolve => {
+    (resolve('ready'), resolve(null));
+  });
+}
+function nestedPromiseSettlement(): Promise<string | null> {
+  return new Promise(resolve => {
+    resolve((resolve(null), 'ready'));
+  });
+}
+      `,
+      errors: [
+        {
+          data: { annotated: 'Promise<string | null>', unused: 'null' },
+          messageId: 'misleadingReturnType',
+        },
+        {
+          data: { annotated: 'Promise<string | null>', unused: 'null' },
+          messageId: 'misleadingReturnType',
+        },
+        {
+          data: { annotated: 'Promise<string | null>', unused: 'string' },
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+interface CustomPromise<T> extends PromiseLike<T> {}
+declare const textPromise: CustomPromise<string>;
+function customPromise(): CustomPromise<string | null> {
+  return textPromise;
+}
+      `,
+      errors: [
+        {
+          data: { annotated: 'CustomPromise<string | null>', unused: 'null' },
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+declare const fulfilledText: PromiseFulfilledResult<string>;
+function fulfilledResult(): PromiseFulfilledResult<string | null> {
+  return fulfilledText;
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+function propertyDescriptor(): Readonly<
+  TypedPropertyDescriptor<string | null>
+> {
+  return { value: 'ready' };
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+declare const textIteratorResult: IteratorResult<string, number>;
+function iteratorResult(): IteratorResult<string | null, number | boolean> {
+  return textIteratorResult;
+}
+      `,
+      errors: [
+        {
+          data: {
+            annotated: 'IteratorResult<string | null, number | boolean>',
+            unused: 'null | boolean',
+          },
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    // Readonly collection projections inspect the content position rather
+    // than incorrectly reporting the entire returned container.
+    {
+      code: `
+function mutableArray(): Array<string | null> {
+  return ['ready'];
+}
+function mutableObjectProperty(): { value: string | null } {
+  return { value: 'ready' };
+}
+function mutableTuple(): [string | null] {
+  return ['ready'];
+}
+function mutableIndex(): { [key: string]: string | null } {
+  return { state: 'ready' };
+}
+      `,
+      errors: [
+        { messageId: 'misleadingReturnType' },
+        { messageId: 'misleadingReturnType' },
+        { messageId: 'misleadingReturnType' },
+        { messageId: 'misleadingReturnType' },
+      ],
+    },
+    {
+      code: `
+const mutableCollectionKey = {};
+function mutableSet(): Set<string | null> {
+  return new Set(['ready']);
+}
+function mutableMap(): Map<'ready' | 'idle', number | null> {
+  return new Map([['ready', 1]]);
+}
+function mutableWeakMap(): WeakMap<object, string | null> {
+  return new WeakMap([[mutableCollectionKey, 'ready']]);
+}
+type ReadyWeakValue = { readonly kind: 'ready' };
+type IdleWeakValue = { readonly kind: 'idle' };
+const readyWeakValue: ReadyWeakValue = { kind: 'ready' };
+function mutableWeakSet(): WeakSet<ReadyWeakValue | IdleWeakValue> {
+  return new WeakSet([readyWeakValue]);
+}
+      `,
+      errors: [
+        { messageId: 'misleadingReturnType' },
+        { messageId: 'misleadingReturnType' },
+        { messageId: 'misleadingReturnType' },
+        { messageId: 'misleadingReturnType' },
+      ],
+    },
+    {
+      code: `
+function arrayGeneric(): ReadonlyArray<string | null> {
+  return ['ready'];
+}
+      `,
+      errors: [
+        {
+          data: { annotated: 'readonly (string | null)[]', unused: 'null' },
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+function arraySyntax(): readonly (string | null)[] {
+  return ['ready'];
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+declare const textArrayLike: ArrayLike<string>;
+function arrayLike(): ArrayLike<string | null> {
+  return textArrayLike;
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+declare const htmlNodes: NodeListOf<HTMLDivElement>;
+function narrowedNodeList(): NodeListOf<HTMLDivElement | SVGElement> {
+  return htmlNodes;
+}
+      `,
+      errors: [
+        {
+          column: 28,
+          endColumn: 69,
+          endLine: 3,
+          line: 3,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+      languageOptions: {
+        parserOptions: {
+          project: './tsconfig.lib-dom.json',
+          projectService: false,
+          tsconfigRootDir: getFixturesRootDir(),
+        },
+      },
+    },
+    {
+      code: `
+declare const spreadTextValues: string[];
+function spreadArray(): ReadonlyArray<string | null> {
+  return [...spreadTextValues];
+}
+function sparseArray(): ReadonlyArray<string | null | undefined> {
+  return ['ready', ,];
+}
+      `,
+      errors: [
+        { messageId: 'misleadingReturnType' },
+        { messageId: 'misleadingReturnType' },
+      ],
+    },
+    {
+      code: `
+function tupleElement(): readonly [string | null, number] {
+  return ['ready', 1];
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+function tupleVariant(): [string] | [string, number] {
+  return ['ready'];
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+function namedReadonlyTuple(): readonly [value: string | null, count?: number] {
+  return ['ready'];
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+function restTuple(): readonly [head: string, ...tail: (number | null)[]] {
+  return ['ready', 1, 2];
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+function setElement(): ReadonlySet<string | null> {
+  return new Set(['ready']);
+}
+      `,
+      errors: [
+        {
+          data: { annotated: 'ReadonlySet<string | null>', unused: 'null' },
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+function mapValue(): ReadonlyMap<string, number | null> {
+  return new Map([['count', 1]]);
+}
+      `,
+      errors: [
+        {
+          data: {
+            annotated: 'ReadonlyMap<string, number | null>',
+            unused: 'null',
+          },
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+function readonlyMapKey(): ReadonlyMap<string | null, number> {
+  return new Map([['count', 1]]);
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+type FirstWeakRefValue = { kind: 'first' };
+type SecondWeakRefValue = { kind: 'second' };
+declare const firstWeakRef: WeakRef<FirstWeakRefValue>;
+function weakRefValue(): WeakRef<FirstWeakRefValue | SecondWeakRefValue> {
+  return firstWeakRef;
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+interface Values<T> extends Iterable<T> {}
+declare const textValues: Values<string>;
+function customIterable(): Values<string | null> {
+  return textValues;
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+interface NullableSet extends ReadonlySet<string | null> {}
+declare const derivedTextSet: ReadonlySet<string>;
+function derivedSet(): NullableSet {
+  return derivedTextSet;
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+interface StatefulSet extends Set<string> {
+  readonly state: 'ready' | 'idle';
+}
+declare const readySet: Set<string> & { readonly state: 'ready' };
+function derivedSetProperty(): StatefulSet {
+  return readySet;
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+interface TaggedSet<Tag, Value> extends ReadonlySet<Value> {}
+declare const taggedTextSet: ReadonlySet<string>;
+function reorderedSet(): TaggedSet<'tag', string | null> {
+  return taggedTextSet;
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+interface NullableMap extends ReadonlyMap<string, number | null> {}
+declare const derivedNumberMap: ReadonlyMap<string, number>;
+function derivedMap(): NullableMap {
+  return derivedNumberMap;
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+interface NullableValues extends Iterable<string | null> {}
+declare const derivedTextValues: Iterable<string>;
+function derivedIterable(): NullableValues {
+  return derivedTextValues;
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+async function nestedContainers(): Promise<ReadonlyArray<string | null>> {
+  return ['ready'];
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+declare const textTupleAsArray: readonly [string];
+function tupleProjectedAsArray(): ReadonlyArray<string | null> {
+  return textTupleAsArray;
+}
+function sparseTupleRest(): readonly [
+  string,
+  ...(string | null | undefined)[],
+] {
+  return ['ready', , 'ready'];
+}
+      `,
+      errors: [
+        { messageId: 'misleadingReturnType' },
+        { messageId: 'misleadingReturnType' },
+      ],
+    },
+    // Generic variadic tuple elements contribute their constrained element
+    // type when the tuple is projected through an array return type.
+    {
+      code: `
+function genericVariadicArray<T extends readonly number[]>(
+  value: readonly [string, ...T],
+): readonly (string | number | null)[] {
+  return value;
+}
+      `,
+      errors: [
+        {
+          column: 2,
+          data: {
+            annotated: 'readonly (string | number | null)[]',
+            unused: 'null',
+          },
+          endColumn: 39,
+          endLine: 4,
+          line: 4,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    // Readonly structural return types expose output-only property, index, and
+    // callback positions that can be projected with public checker APIs.
+    {
+      code: `
+function objectProperty(): { readonly value: string | null } {
+  return { value: 'ready' };
+}
+      `,
+      errors: [
+        {
+          data: {
+            annotated: '{ readonly value: string | null; }',
+            unused: 'null',
+          },
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+declare const spreadTextResult: { value: string };
+function objectSpreadProperty(): { readonly value: string | null } {
+  return { ...spreadTextResult };
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+function nonEnumerableArrayPropertyIsNotSpread(): {
+  readonly length: number | string;
+} {
+  const base = { length: 'kept' };
+  return { ...base, ...[] };
+}
+      `,
+      errors: [
+        {
+          data: {
+            annotated: '{ readonly length: string | number; }',
+            unused: 'number',
+          },
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+function enumerableArrayIndexIsSpread(): { readonly 0: string | null } {
+  return { ...['ready'] };
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+class PrototypeSpreadValue {
+  get value(): null {
+    return null;
+  }
+}
+function prototypeGetterIsNotSpread(flag: boolean): {
+  readonly value: string | null;
+} {
+  return {
+    value: 'ready',
+    ...(flag ? new PrototypeSpreadValue() : {}),
+  };
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+declare const optionalNullOverlay: {} | { value: null };
+function optionalSpreadStillExcludesNumber(): {
+  readonly value: string | number | null;
+} {
+  return { value: 'ready', ...optionalNullOverlay };
+}
+      `,
+      errors: [
+        {
+          data: {
+            annotated: '{ readonly value: string | number | null; }',
+            unused: 'number',
+          },
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+function nestedObjectProperty(): {
+  readonly state: { readonly value: 'on' | 'off' };
+} {
+  return { state: { value: 'on' } };
+}
+      `,
+      errors: [
+        {
+          data: {
+            annotated: '{ readonly state: { readonly value: "on" | "off"; }; }',
+            unused: '"off"',
+          },
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+function stringIndex(): { readonly [key: string]: string | null } {
+  return { status: 'ready' };
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+declare const nullableStatusSpread: { status: null };
+function explicitIndexPropertyOverridesSpread(): {
+  readonly [key: string]: string | null;
+} {
+  return { ...nullableStatusSpread, status: 'ready' };
+}
+      `,
+      errors: [
+        {
+          data: {
+            annotated: '{ readonly [key: string]: string | null; }',
+            unused: 'null',
+          },
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+function laterIndexSpreadOverridesEarlierSpread(): {
+  readonly [key: string]: 'ready' | 'idle';
+} {
+  return { ...{ status: 'idle' }, ...{ status: 'ready' } };
+}
+      `,
+      errors: [
+        {
+          data: {
+            annotated: '{ readonly [key: string]: "ready" | "idle"; }',
+            unused: '"idle"',
+          },
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+declare const nullableStringIndex: Record<string, string | null>;
+function indexBearingSpread(): Readonly<
+  Record<string, string | number | null>
+> {
+  return { fixed: 'ready', ...nullableStringIndex };
+}
+      `,
+      errors: [
+        {
+          data: {
+            annotated: 'Readonly<Record<string, string | number | null>>',
+            unused: 'number',
+          },
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+function callbackProperty(): { readonly callback: () => string | null } {
+  return { callback: () => 'ready' };
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+function objectMethodProperty(): { readonly callback: () => string | null } {
+  return {
+    callback() {
+      return 'ready';
+    },
+  };
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+function returnedArrowLiteralUnion(): () => 'ready' | 'idle' {
+  return () => 'ready';
+}
+function returnedFunctionLiteralUnion(): () => 'ready' | 'idle' {
+  return function () {
+    return 'ready';
+  };
+}
+function returnedMethodLiteralUnion(): {
+  readonly read: () => 'ready' | 'idle';
+} {
+  return {
+    read() {
+      return 'ready';
+    },
+  };
+}
+function returnedGetterLiteralUnion(): {
+  readonly value: 'ready' | 'idle';
+} {
+  return {
+    get value() {
+      return 'ready' as const;
+    },
+  };
+}
+      `,
+      errors: [
+        {
+          data: {
+            annotated: '() => "ready" | "idle"',
+            unused: '"idle"',
+          },
+          messageId: 'misleadingReturnType',
+        },
+        {
+          data: {
+            annotated: '() => "ready" | "idle"',
+            unused: '"idle"',
+          },
+          messageId: 'misleadingReturnType',
+        },
+        {
+          data: {
+            annotated: '{ readonly read: () => "ready" | "idle"; }',
+            unused: '"idle"',
+          },
+          messageId: 'misleadingReturnType',
+        },
+        {
+          data: {
+            annotated: '{ readonly value: "ready" | "idle"; }',
+            unused: '"idle"',
+          },
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+declare const computedPropertyKey: unique symbol;
+function computedSymbolProperty(): {
+  readonly [computedPropertyKey]: string | null;
+} {
+  return { [computedPropertyKey]: 'ready' };
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+const computedStringKey = 'value' as const;
+function computedStringProperty(): { readonly value: 'ready' | 'idle' } {
+  return { [computedStringKey]: 'ready' };
+}
+declare const spreadIdleResult: { value: 'idle' };
+function explicitPropertyOverridesSpread(): {
+  readonly value: 'ready' | 'idle';
+} {
+  return { ...spreadIdleResult, value: 'ready' };
+}
+      `,
+      errors: [
+        {
+          data: {
+            annotated: '{ readonly value: "ready" | "idle"; }',
+            unused: '"idle"',
+          },
+          messageId: 'misleadingReturnType',
+        },
+        {
+          data: {
+            annotated: '{ readonly value: "ready" | "idle"; }',
+            unused: '"idle"',
+          },
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+interface ServiceResult {
+  readonly read: () => string | null;
+}
+declare const textService: { read(): string };
+function methodSignature(): ServiceResult {
+  return textService;
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+interface ResultConstructor {
+  new (): { readonly value: string | null };
+}
+declare const TextResult: new () => { value: string };
+function constructSignature(): ResultConstructor {
+  return TextResult;
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+declare const directTextFunction: () => string;
+function directFunctionType(): () => string | null {
+  return directTextFunction;
+}
+declare const DirectTextConstructor: new () => string;
+function directConstructorType(): new () => string | null {
+  return DirectTextConstructor;
+}
+      `,
+      errors: [
+        { messageId: 'misleadingReturnType' },
+        { messageId: 'misleadingReturnType' },
+      ],
+    },
+    {
+      code: `
+interface WideCallableOverloads {
+  (): 'zero' | 'from-string';
+  (value: string): 'from-string' | 'from-number';
+  (value: number): 'from-number';
+}
+interface NarrowCallableOverloads {
+  (): 'zero';
+  (value: string): 'from-string';
+  (value: number): 'from-number';
+}
+declare const narrowCallableOverloads: NarrowCallableOverloads;
+function callableOverloadProjection(): WideCallableOverloads {
+  return narrowCallableOverloads;
+}
+      `,
+      errors: [
+        {
+          data: {
+            annotated: 'WideCallableOverloads',
+            unused: '"from-string" | "from-number"',
+          },
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+interface WideGenericCallableOverloads {
+  <T extends string>(value: T): 'from-string' | 'from-number';
+  <T extends number>(value: T): 'from-number';
+}
+interface NarrowGenericCallableOverloads {
+  <T extends string>(value: T): 'from-string';
+  <T extends number>(value: T): 'from-number';
+}
+declare const narrowGenericCallableOverloads: NarrowGenericCallableOverloads;
+function genericCallableOverloadProjection(): WideGenericCallableOverloads {
+  return narrowGenericCallableOverloads;
+}
+      `,
+      errors: [
+        {
+          data: {
+            annotated: 'WideGenericCallableOverloads',
+            unused: '"from-number"',
+          },
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+interface BigIntCallableResult {
+  (
+    value: bigint,
+  ):
+    | 'bigint'
+    | 'boolean'
+    | 'null'
+    | 'number'
+    | 'object'
+    | 'string'
+    | 'symbol'
+    | 'undefined';
+}
+interface PrimitiveCallableOverloads {
+  (value: bigint): 'bigint';
+  (value: boolean): 'boolean';
+  (value: null): 'null';
+  (value: number): 'number';
+  (value: object): 'object';
+  (value: string): 'string';
+  (value: symbol): 'symbol';
+  (value: undefined): 'undefined';
+}
+declare const primitiveCallableOverloads: PrimitiveCallableOverloads;
+function primitiveCallableProjection(): BigIntCallableResult {
+  return primitiveCallableOverloads;
+}
+      `,
+      errors: [
+        {
+          data: {
+            annotated: 'BigIntCallableResult',
+            unused:
+              '"string" | "number" | "boolean" | "symbol" | "undefined" | "object" | "null"',
+          },
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+interface WideRestCallableOverloads {
+  (value: string, ...rest: string[]): 'from-string' | 'from-number';
+  (value: number, ...rest: number[]): 'from-number';
+}
+interface NarrowRestCallableOverloads {
+  (value: string, ...rest: string[]): 'from-string';
+  (value: number, ...rest: number[]): 'from-number';
+}
+declare const narrowRestCallableOverloads: NarrowRestCallableOverloads;
+function restCallableOverloadProjection(): WideRestCallableOverloads {
+  return narrowRestCallableOverloads;
+}
+      `,
+      errors: [
+        {
+          data: {
+            annotated: 'WideRestCallableOverloads',
+            unused: '"from-number"',
+          },
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+interface WideVariadicSuffix {
+  (...args: [...string[], number]): 'matching' | 'disjoint';
+}
+function variadicSuffixSource(...args: [...string[], number]): 'matching';
+function variadicSuffixSource(...args: [...string[], boolean]): 'disjoint';
+function variadicSuffixSource(
+  ...args: (string | number | boolean)[]
+): 'matching' | 'disjoint' {
+  return typeof args.at(-1) === 'number' ? 'matching' : 'disjoint';
+}
+function disjointVariadicSuffix(): WideVariadicSuffix {
+  return variadicSuffixSource;
+}
+      `,
+      errors: [
+        {
+          data: {
+            annotated: 'WideVariadicSuffix',
+            unused: '"disjoint"',
+          },
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+type ConstrainedVariadicTarget = (
+  ...args: [...string[], number]
+) => 'matching' | 'disjoint';
+declare function constrainedVariadicSource<T extends [...string[], number]>(
+  ...args: T
+): 'matching';
+declare function constrainedVariadicSource<T extends [...number[], string]>(
+  ...args: T
+): 'disjoint';
+function constrainedVariadicSuffix(): ConstrainedVariadicTarget {
+  return constrainedVariadicSource;
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+interface WideConstructableOverloads {
+  new (): { readonly kind: 'zero' | 'from-string' };
+  new (value: string): { readonly kind: 'from-string' | 'from-number' };
+  new (value: number): { readonly kind: 'from-number' };
+}
+interface NarrowConstructableOverloads {
+  new (): { readonly kind: 'zero' };
+  new (value: string): { readonly kind: 'from-string' };
+  new (value: number): { readonly kind: 'from-number' };
+}
+declare const NarrowConstructable: NarrowConstructableOverloads;
+function constructableOverloadProjection(): WideConstructableOverloads {
+  return NarrowConstructable;
+}
+      `,
+      errors: [
+        {
+          data: {
+            annotated: 'WideConstructableOverloads',
+            unused: '"from-string" | "from-number"',
+          },
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+function numberIndex(): { readonly [key: number]: string | null } {
+  return { 0: 'ready' };
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+declare const symbolKey: unique symbol;
+function symbolIndex(): { readonly [key: symbol]: string | null } {
+  const result = { [symbolKey]: 'ready', unrelated: null };
+  return result;
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+declare const unrelatedSymbol: unique symbol;
+function stringIndexIgnoresSymbols(): {
+  readonly [key: string]: string | null;
+} {
+  return { status: 'ready', [unrelatedSymbol]: null };
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+const shorthandIndexValue = 'ready';
+function shorthandStringIndex(): {
+  readonly [key: string]: string | null;
+} {
+  return { shorthandIndexValue };
+}
+function getterStringIndex(): {
+  readonly [key: string]: string | null;
+} {
+  return {
+    get value(): string {
+      return 'ready';
+    },
+  };
+}
+      `,
+      errors: [
+        { messageId: 'misleadingReturnType' },
+        { messageId: 'misleadingReturnType' },
+      ],
+    },
+    {
+      code: `
+function templateIndex(): {
+  readonly [key: \`data-\${string}\`]: string | null;
+} {
+  const result = { 'data-ready': 'ready', unrelated: null };
+  return result;
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+function finiteNumericStringTemplateIndex(): {
+  readonly [key: \`\${number}\`]: string | null;
+} {
+  return { '01': 'ready' };
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+function bigintTemplateIgnoresFraction(): {
+  readonly [key: \`\${bigint}\`]: string | null;
+  readonly '1.5': null;
+} {
+  return { '1': 'ready', '1.5': null };
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+function bigintTemplateRejectsLeadingPlus(): {
+  readonly [key: \`\${bigint}\`]: 'A' | 'B';
+  readonly '+1': 'B';
+} {
+  return { '+1': 'B', '1': 'A' };
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+function intrinsicTemplateIgnoresUnrelatedKeys(): {
+  readonly [key: \`value-\${boolean | null | undefined}-\${string}\`]:
+    string | null;
+  readonly 'value-other': null;
+} {
+  return { 'value-other': null, 'value-true-result': 'ready' };
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+type UppercaseThenCapitalize = \`data-\${Capitalize<Uppercase<string>>}\`;
+function nestedStringMapping(): {
+  readonly [key: UppercaseThenCapitalize]: 'A' | 'B';
+  readonly 'data-Abc': 'B';
+} {
+  return { 'data-ABC': 'A', 'data-Abc': 'B' };
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+interface WideSpecializedIndex {
+  readonly [key: string]: string | null;
+  readonly [key: \`data-\${string}\`]: string | null;
+}
+interface NarrowSpecializedIndex {
+  readonly [key: string]: string | null;
+  readonly [key: \`data-\${string}\`]: string;
+}
+declare const narrowSpecializedIndex: NarrowSpecializedIndex;
+function specializedIndexPrecedence(): WideSpecializedIndex {
+  return narrowSpecializedIndex;
+}
+      `,
+      errors: [
+        {
+          data: { annotated: 'WideSpecializedIndex', unused: 'null' },
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+declare const indexedText: { readonly [key: string]: string };
+function returnedIndexSignature(): {
+  readonly [key: string]: string | null;
+} {
+  return indexedText;
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+declare const weakKey: object;
+declare const narrowWeakMap: WeakMap<object, string>;
+function returnedWeakMap(): WeakMap<object, string | null> {
+  return narrowWeakMap;
+}
+function constructedWeakMap(): WeakMap<object, string | null> {
+  return new WeakMap([[weakKey, 'ready']]);
+}
+      `,
+      errors: [
+        { messageId: 'misleadingReturnType' },
+        { messageId: 'misleadingReturnType' },
+      ],
+    },
+    {
+      code: `
+function readonlyProperty(): Readonly<{ value: string | null }> {
+  return { value: 'ready' };
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+class NarrowFieldReturn {
+  private readonly value = 'ready';
+  read(): string | null {
+    return this.value;
+  }
+}
+declare const narrowIndexedValues: readonly string[];
+function indexedAccessReturn(): string | null {
+  return narrowIndexedValues[0];
+}
+      `,
+      errors: [
+        { messageId: 'misleadingReturnType' },
+        { messageId: 'misleadingReturnType' },
+      ],
+    },
+    {
+      code: `
+function omittedOptionalProperty(): {
+  readonly value?: string | null;
+} {
+  return {};
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    // Getters and generator yielded-value positions are independently
+    // analyzable.
+    {
+      code: `
+const computedKey = 'value' as const;
+class ComputedGetter {
+  get [computedKey](): string | null {
+    return 'ready';
+  }
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+class AccessorPairSubset {
+  get value(): string | null {
+    return 'ready';
+  }
+  set value(value: string | null) {}
+}
+      `,
+      errors: [
+        {
+          column: 14,
+          data: { annotated: 'string | null', unused: 'null' },
+          endColumn: 29,
+          endLine: 3,
+          line: 3,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+function* directYield(): Generator<string | null> {
+  yield 'ready';
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+function* noReachableYield(): Generator<'ready' | undefined, void, unknown> {}
+      `,
+      errors: [
+        {
+          column: 29,
+          data: {
+            annotated: 'Generator<"ready" | undefined, void, unknown>',
+            unused: 'undefined | "ready"',
+          },
+          endColumn: 76,
+          endLine: 2,
+          line: 2,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+      languageOptions: {
+        parserOptions: {
+          project: './tsconfig.noUncheckedIndexedAccess.json',
+          projectService: false,
+          tsconfigRootDir: getFixturesRootDir(),
+        },
+      },
+    },
+    {
+      code: `
+function* bareYield(): Generator<string | null | undefined> {
+  yield;
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+declare const values: Iterable<string>;
+function* delegatedYield(): Generator<string | null> {
+  yield* values;
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+function* delegatedCompletion(): Generator<string, number, unknown> {
+  yield 'ready';
+  return 1;
+}
+function* returnDelegatedCompletion(): Generator<
+  string | null,
+  number,
+  unknown
+> {
+  return yield* delegatedCompletion();
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+async function* asyncYield(): AsyncGenerator<string | null> {
+  yield 'ready';
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+async function* asyncYieldFirstPromiseSettlement(): AsyncGenerator<
+  string | null
+> {
+  const promised: Promise<string | null> = new Promise(resolve => {
+    resolve('ready');
+    resolve(null);
+  });
+  yield promised;
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+declare const asyncTextValues: AsyncIterable<string>;
+async function* delegatedAsyncYield(): AsyncGenerator<string | null> {
+  yield* asyncTextValues;
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+function* constantDeadYield(): Generator<string | null> {
+  if (false) {
+    yield null;
+  }
+  yield 'ready';
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+type TextGenerator = Generator<string | null, void, unknown>;
+function* aliasedGenerator(): TextGenerator {
+  yield 'ready';
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+interface DerivedGenerator extends Generator<string | null, void, unknown> {}
+function* derivedGenerator(): DerivedGenerator {
+  yield 'ready';
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+interface SwappedGenerator<Return, Yield> extends Generator<
+  Yield,
+  Return,
+  unknown
+> {}
+function* reorderedGenerator(): SwappedGenerator<void, string | null> {
+  yield 'ready';
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+function* unreachableYield(): Generator<string | null, void, unknown> {
+  yield 'ready';
+  return;
+  yield null;
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+function* shortCircuitedYield(): Generator<string | null, void, unknown> {
+  false && (yield null);
+  yield 'ready';
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    // Under the default compiler configuration, undefined remains exempt while
+    // unrelated unused constituents are still reported.
+    {
+      code: `
+function implicitVoidOnly(): 'value' | void {}
+      `,
+      errors: [
+        {
+          data: { annotated: 'void | "value"', unused: '"value"' },
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+function fallthrough(flag: boolean): string | number | undefined {
+  if (flag) return 'ready';
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+function bareReturn(flag: boolean): string | number | undefined {
+  if (flag) return 'ready';
+  return;
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    // Only reachable completions contribute to the implementation's return
+    // type. Dead statements must not keep a constituent alive.
+    {
+      code: `
+function returnAfterReturn(): string | null {
+  return 'ready';
+  return null;
+}
+      `,
+      errors: [
+        {
+          data: { annotated: 'string | null', unused: 'null' },
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+function returnAfterThrow(flag: boolean): string | null {
+  if (flag) return 'ready';
+  throw new Error('stop');
+  return null;
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+declare function stop(): never;
+function returnAfterNeverCall(flag: boolean): string | null {
+  if (flag) return 'ready';
+  stop();
+  return null;
+}
+function returnAfterNeverInitializer(flag: boolean): string | null {
+  if (flag) return 'ready';
+  const unreachable = stop();
+  return null;
+}
+      `,
+      errors: [
+        { messageId: 'misleadingReturnType' },
+        { messageId: 'misleadingReturnType' },
+      ],
+    },
+    {
+      code: `
+declare function stopInSwitch(): never;
+function returnAfterNeverInSwitch(flag: boolean): string | null {
+  switch (flag) {
+    case true:
+      return 'ready';
+    default:
+      stopInSwitch();
+      return null;
+  }
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+declare function stopInReturn(): never;
+function abruptReturnExpression(flag: boolean): string | null {
+  if (flag) return 'ready';
+  return (stopInReturn(), null);
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+declare function stopWhileEvaluating(): never;
+function abruptObjectConstruction(flag: boolean): {
+  readonly first: string;
+  readonly second: string | null;
+} {
+  if (flag) return { first: 'ready', second: 'ready' };
+  return { first: stopWhileEvaluating(), second: null };
+}
+function abruptArrayConstruction(
+  flag: boolean,
+): readonly [first: string, second: string | null] {
+  if (flag) return ['ready', 'ready'];
+  return [stopWhileEvaluating(), null];
+}
+declare function assemble(first: string, second: string | null): string | null;
+function abruptCallArguments(flag: boolean): string | null {
+  if (flag) return 'ready';
+  return assemble(stopWhileEvaluating(), null);
+}
+      `,
+      errors: [
+        { messageId: 'misleadingReturnType' },
+        { messageId: 'misleadingReturnType' },
+        { messageId: 'misleadingReturnType' },
+      ],
+    },
+    {
+      code: `
+declare function stopDuringEvaluation(): never;
+declare function abruptTag(
+  strings: TemplateStringsArray,
+  ...values: unknown[]
+): string | null;
+function abruptConditionalCondition(flag: boolean): string | null {
+  if (flag) return 'ready';
+  return stopDuringEvaluation() ? null : null;
+}
+function abruptLogicalRight(flag: boolean): string | null {
+  if (flag) return 'ready';
+  return false || stopDuringEvaluation();
+}
+function abruptComputedProperty(flag: boolean): {
+  readonly value: string | null;
+} {
+  if (flag) return { value: 'ready' };
+  return { [stopDuringEvaluation()]: 0, value: null };
+}
+function abruptTaggedTemplate(flag: boolean): string | null {
+  if (flag) return 'ready';
+  return abruptTag\`value-\${stopDuringEvaluation()}-\${null}\`;
+}
+function abruptTemplateInterpolation(flag: boolean): string | null {
+  if (flag) return 'ready';
+  return \`\${stopDuringEvaluation()}-\${null}\`;
+}
+function abruptUnaryExpression(flag: boolean): string | null | undefined {
+  if (flag) return 'ready';
+  return void stopDuringEvaluation();
+}
+function abruptPrefixUnary(flag: boolean): boolean | null {
+  if (flag) return true;
+  return !stopDuringEvaluation();
+}
+function abruptSatisfies(flag: boolean): string | null {
+  if (flag) return 'ready';
+  return (stopDuringEvaluation() satisfies never, null);
+}
+      `,
+      errors: [
+        { messageId: 'misleadingReturnType' },
+        { messageId: 'misleadingReturnType' },
+        { messageId: 'misleadingReturnType' },
+        { messageId: 'misleadingReturnType' },
+        { messageId: 'misleadingReturnType' },
+        { messageId: 'misleadingReturnType' },
+        { messageId: 'misleadingReturnType' },
+        { messageId: 'misleadingReturnType' },
+      ],
+    },
+    {
+      code: `
+function staticReturnExpression(): string | null {
+  return true ? 'ready' : null;
+}
+function nestedStaticReturnExpression(): { readonly value: string | null } {
+  return { value: true ? 'ready' : null };
+}
+      `,
+      errors: [
+        { messageId: 'misleadingReturnType' },
+        { messageId: 'misleadingReturnType' },
+      ],
+    },
+    {
+      code: `
+function nestedConstructorDoesNotContribute(): string | null {
+  class Inner {
+    constructor() {
+      return Object.create(null);
+    }
+  }
+  void Inner;
+  return 'ready';
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+declare const nullableCoalescedValue: 'ready' | null;
+function dynamicNullishCoalescing(): 'ready' | 'fallback' | null {
+  return nullableCoalescedValue ?? 'fallback';
+}
+      `,
+      errors: [
+        {
+          data: {
+            annotated: '"ready" | "fallback" | null',
+            unused: 'null',
+          },
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+function constantDeadBranch(): string | null {
+  if (false) return null;
+  return 'ready';
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+function deadElseBranch(): string | null {
+  if (true) return 'ready';
+  else return null;
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+function labeledBlockBreak(): string | null {
+  labeled: {
+    break labeled;
+  }
+  return 'ready';
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+declare function step(): boolean;
+function loopExitedByBreak(): string | null {
+  while (true) {
+    if (step()) break;
+  }
+  return 'ready';
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+declare function halt(): never;
+declare const flag: boolean;
+function neverCompletingBranch(): string | null {
+  return flag ? halt() : 'ready';
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+function deadLoopBody(): string | null {
+  while (false) return null;
+  return 'ready';
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+function deadForBody(): string | null {
+  for (; false;) return null;
+  return 'ready';
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+function constantSwitch(): 'ready' | 'unreachable' {
+  switch ('ready' as 'ready' | 'unreachable') {
+    case 'unreachable':
+      return 'unreachable';
+    default:
+      return 'ready';
+  }
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+function unmatchedConstantSwitch(): 'ready' | 'unreachable' {
+  switch ('ready' as 'ready' | 'unreachable') {
+    case 'unreachable':
+      return 'unreachable';
+  }
+  return 'ready';
+}
+      `,
+      errors: [
+        {
+          column: 35,
+          endColumn: 60,
+          endLine: 2,
+          line: 2,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+enum ConstantSwitchState {
+  Idle = 'idle',
+  Ready = 'ready',
+}
+function constantEnumSwitch():
+  ConstantSwitchState.Idle | ConstantSwitchState.Ready {
+  switch (ConstantSwitchState.Ready as ConstantSwitchState) {
+    case ConstantSwitchState.Idle:
+      return ConstantSwitchState.Idle;
+    default:
+      return ConstantSwitchState.Ready;
+  }
+}
+      `,
+      errors: [
+        {
+          column: 30,
+          endColumn: 55,
+          endLine: 7,
+          line: 6,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+const enum ConstantInlineSwitchState {
+  Idle = 'idle',
+  Ready = 'ready',
+}
+function constantInlineEnumSwitch():
+  ConstantInlineSwitchState.Idle | ConstantInlineSwitchState.Ready {
+  switch (ConstantInlineSwitchState.Ready as ConstantInlineSwitchState) {
+    case ConstantInlineSwitchState.Idle:
+      return ConstantInlineSwitchState.Idle;
+    default:
+      return ConstantInlineSwitchState.Ready;
+  }
+}
+      `,
+      errors: [
+        {
+          column: 36,
+          endColumn: 67,
+          endLine: 7,
+          line: 6,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+enum ConstantElementSwitchState {
+  Idle = 'idle',
+  Ready = 'ready',
+}
+function constantElementEnumSwitch():
+  ConstantElementSwitchState.Idle | ConstantElementSwitchState.Ready {
+  switch (ConstantElementSwitchState['Ready'] as ConstantElementSwitchState) {
+    case ConstantElementSwitchState.Idle:
+      return ConstantElementSwitchState.Idle;
+    default:
+      return ConstantElementSwitchState.Ready;
+  }
+}
+      `,
+      errors: [
+        {
+          column: 37,
+          endColumn: 69,
+          endLine: 7,
+          line: 6,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+enum AliasedSwitchState {
+  Idle = 'idle',
+  Ready = 'ready',
+}
+const aliasedSwitchState: AliasedSwitchState = AliasedSwitchState.Ready;
+function aliasedEnumSwitch():
+  AliasedSwitchState.Idle | AliasedSwitchState.Ready {
+  switch (aliasedSwitchState as AliasedSwitchState) {
+    case AliasedSwitchState.Idle:
+      return AliasedSwitchState.Idle;
+    default:
+      return AliasedSwitchState.Ready;
+  }
+}
+      `,
+      errors: [
+        {
+          column: 29,
+          endColumn: 53,
+          endLine: 8,
+          line: 7,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+function switchBreakStopsFallthrough(): 'ready' | 'unreachable' {
+  switch ('ready' as 'ready' | 'unreachable') {
+    case 'ready':
+      break;
+    case 'unreachable':
+      return 'unreachable';
+  }
+  return 'ready';
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+function labeledSwitchBreakStopsFallthrough(): 'ready' | 'unreachable' {
+  done: switch ('ready' as 'ready' | 'unreachable') {
+    case 'ready':
+      break done;
+    case 'unreachable':
+      return 'unreachable';
+  }
+  return 'ready';
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+function dynamicSwitch(value: boolean): 'ready' | 'unused' {
+  switch (value) {
+    case true:
+      return 'ready';
+    default:
+      return 'ready';
+  }
+}
+function switchWithoutEntry(): 'ready' | 'unused' {
+  switch ('ready' as 'ready' | 'unmatched') {
+    case 'unmatched':
+      return 'unused';
+  }
+  return 'ready';
+}
+      `,
+      errors: [
+        { messageId: 'misleadingReturnType' },
+        { messageId: 'misleadingReturnType' },
+      ],
+    },
+    // A completion from finally replaces an earlier return completion.
+    {
+      code: `
+function finallyOverridesReturn(): string | null {
+  try {
+    return null;
+  } finally {
+    return 'ready';
+  }
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    {
+      code: `
+declare function haltOnOtherPath(): never;
+function finallySwitchCanBreak(flag: boolean): string | null {
+  try {
+    return null;
+  } finally {
+    switch (flag) {
+      case true:
+        break;
+      default:
+        haltOnOtherPath();
+    }
+  }
+}
+function finallyLoopCanBreak(): string | null {
+  try {
+    return null;
+  } finally {
+    do {
+      break;
+    } while (false);
+  }
+}
+      `,
+      errors: [
+        { messageId: 'misleadingReturnType' },
+        { messageId: 'misleadingReturnType' },
+      ],
+    },
+    // Tuple spreads exercise distinct fixed-slot and variadic projections.
+    {
+      code: `
+type FixedTupleAfterSpread = readonly [string | null, number | null];
+declare const fixedTuplePrefix: readonly ['ready'];
+function fixedTupleAfterSpread(): FixedTupleAfterSpread {
+  return [...fixedTuplePrefix, 1];
+}
+      `,
+      errors: [
+        {
+          column: 33,
+          data: { annotated: 'FixedTupleAfterSpread', unused: 'null' },
+          endColumn: 56,
+          endLine: 4,
+          line: 4,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+type VariadicTupleSpread = readonly [string, ...(number | null)[]];
+declare const numericTupleTail: readonly number[];
+function variadicTupleSpread(): VariadicTupleSpread {
+  return ['ready', ...numericTupleTail];
+}
+      `,
+      errors: [
+        {
+          column: 31,
+          data: { annotated: 'VariadicTupleSpread', unused: 'null' },
+          endColumn: 52,
+          endLine: 4,
+          line: 4,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    // Declared tuples use the checker's instantiated fixed and variadic slots.
+    {
+      code: `
+type WideDeclaredTuple = readonly [string | null];
+declare const narrowDeclaredTuple: readonly [string];
+function declaredTupleSource(): WideDeclaredTuple {
+  return narrowDeclaredTuple;
+}
+      `,
+      errors: [
+        {
+          column: 31,
+          data: { annotated: 'WideDeclaredTuple', unused: 'null' },
+          endColumn: 50,
+          endLine: 4,
+          line: 4,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+type WideDeclaredVariadicTuple = readonly [string, ...(number | null)[]];
+declare const narrowDeclaredVariadicTuple: readonly [string, ...number[]];
+function declaredVariadicTupleSource(): WideDeclaredVariadicTuple {
+  return narrowDeclaredVariadicTuple;
+}
+      `,
+      errors: [
+        {
+          column: 39,
+          data: {
+            annotated: 'WideDeclaredVariadicTuple',
+            unused: 'null',
+          },
+          endColumn: 66,
+          endLine: 4,
+          line: 4,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    // A type-invalid array source still has usable numeric index information.
+    {
+      code: `
+type WideTupleFromArray = readonly [string | null];
+declare const textArraySource: ReadonlyArray<string>;
+function tupleFromArraySource(): WideTupleFromArray {
+  return textArraySource;
+}
+      `,
+      errors: [
+        {
+          column: 32,
+          data: { annotated: 'WideTupleFromArray', unused: 'null' },
+          endColumn: 52,
+          endLine: 4,
+          line: 4,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    // Recursive structural types terminate without skipping other properties.
+    {
+      code: `
+interface WideRecursiveNode {
+  readonly next: WideRecursiveNode;
+  readonly value: string | null;
+}
+interface NarrowRecursiveNode {
+  readonly next: NarrowRecursiveNode;
+  readonly value: string;
+}
+declare const narrowRecursiveNode: NarrowRecursiveNode;
+function recursiveStructuralProjection(): WideRecursiveNode {
+  return narrowRecursiveNode;
+}
+      `,
+      errors: [
+        {
+          column: 41,
+          data: { annotated: 'WideRecursiveNode', unused: 'null' },
+          endColumn: 60,
+          endLine: 11,
+          line: 11,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    // A later exact write overrides an earlier unknown computed key.
+    {
+      code: `
+type ComputedWriteResult = {
+  readonly unrelated: number;
+  readonly value: string | null;
+};
+declare const earlyComputedKey: string;
+function computedWriteBeforeExactProperty(): ComputedWriteResult {
+  return { [earlyComputedKey]: null, value: 'ready', unrelated: 1 };
+}
+      `,
+      errors: [
+        {
+          column: 44,
+          data: { annotated: 'ComputedWriteResult', unused: 'null' },
+          endColumn: 65,
+          endLine: 7,
+          line: 7,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    // Private fields do not satisfy a public string index signature.
+    {
+      code: `
+type StringIndexResult = { readonly [key: string]: string | null };
+class PrivateIndexSource {
+  #secret: null = null;
+  value = 'ready';
+}
+function privateIndexIgnored(): StringIndexResult {
+  return new PrivateIndexSource();
+}
+      `,
+      errors: [
+        {
+          column: 31,
+          data: { annotated: 'StringIndexResult', unused: 'null' },
+          endColumn: 50,
+          endLine: 7,
+          line: 7,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    // Method declarations expose their callable value through an index.
+    {
+      code: `
+type MethodIndexResult = {
+  readonly [key: string]: (() => string) | null;
+};
+function methodIndexResult(): MethodIndexResult {
+  return {
+    read() {
+      return 'ready';
+    },
+  };
+}
+      `,
+      errors: [
+        {
+          column: 29,
+          data: { annotated: 'MethodIndexResult', unused: 'null' },
+          endColumn: 48,
+          endLine: 5,
+          line: 5,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    // A direct computed literal and its following plain property are the same
+    // runtime key, so the later write wins. Duplicate keys are what these
+    // cases exercise, so the compiler reports on them by construction.
+    {
+      code: `
+type StringIndexResult = { readonly [key: string]: string | null };
+function directComputedOverwrite(): StringIndexResult {
+  return { ['value']: null, value: 'ready' };
+}
+      `,
+      errors: [
+        {
+          column: 35,
+          data: { annotated: 'StringIndexResult', unused: 'null' },
+          endColumn: 54,
+          endLine: 3,
+          line: 3,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    // Type-level exact computed keys participate in last-write semantics.
+    {
+      code: `
+type ExactStringIndexResult = { readonly [key: string]: string | null };
+declare const exactStringIndexKey: 'value';
+function exactStringIndexWrite(): ExactStringIndexResult {
+  return { [exactStringIndexKey]: null, value: 'ready' };
+}
+      `,
+      errors: [
+        {
+          column: 33,
+          data: { annotated: 'ExactStringIndexResult', unused: 'null' },
+          endColumn: 57,
+          endLine: 4,
+          line: 4,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+type ExactNumberIndexResult = { readonly [key: number]: string | null };
+declare const exactNumberIndexKey: 1;
+function exactNumberIndexWrite(): ExactNumberIndexResult {
+  return { [exactNumberIndexKey]: null, 1: 'ready' };
+}
+      `,
+      errors: [
+        {
+          column: 33,
+          data: { annotated: 'ExactNumberIndexResult', unused: 'null' },
+          endColumn: 57,
+          endLine: 4,
+          line: 4,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+declare const exactSymbolIndexKey: unique symbol;
+type ExactSymbolIndexResult = { readonly [key: symbol]: string | null };
+function exactSymbolIndexWrite(): ExactSymbolIndexResult {
+  return { [exactSymbolIndexKey]: null, [exactSymbolIndexKey]: 'ready' };
+}
+      `,
+      errors: [
+        {
+          column: 33,
+          data: { annotated: 'ExactSymbolIndexResult', unused: 'null' },
+          endColumn: 57,
+          endLine: 4,
+          line: 4,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    // A later exact index write suppresses the same key in an earlier spread.
+    {
+      code: `
+type SpreadIndexResult = { readonly [key: string]: string | null };
+function overriddenIndexSpread(): SpreadIndexResult {
+  return { ...{ value: null }, value: 'ready' };
+}
+      `,
+      errors: [
+        {
+          column: 33,
+          data: { annotated: 'SpreadIndexResult', unused: 'null' },
+          endColumn: 52,
+          endLine: 3,
+          line: 3,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    // Array object spreads expose their enumerable indexed properties.
+    {
+      code: `
+type TupleObjectSpreadResult = { readonly 0: string | null };
+function tupleObjectSpread(): TupleObjectSpreadResult {
+  return { ...['ready'] };
+}
+      `,
+      errors: [
+        {
+          column: 29,
+          data: { annotated: 'TupleObjectSpreadResult', unused: 'null' },
+          endColumn: 54,
+          endLine: 3,
+          line: 3,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    // Signature correspondence distributes over either union parameter.
+    {
+      code: `
+interface ExpectedUnionParameter {
+  (value: number | string): 'matched' | 'unused';
+}
+interface SourceAgainstUnionParameter {
+  (value: number | string): 'matched';
+  (value: boolean): 'unused';
+}
+declare const sourceAgainstUnionParameter: SourceAgainstUnionParameter;
+function expectedUnionParameter(): ExpectedUnionParameter {
+  return sourceAgainstUnionParameter;
+}
+      `,
+      errors: [
+        {
+          column: 34,
+          data: {
+            annotated: 'ExpectedUnionParameter',
+            unused: '"unused"',
+          },
+          endColumn: 58,
+          endLine: 10,
+          line: 10,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    // An `any` parameter overlaps the expected string domain, but overload
+    // resolution still selects that first signature's null-only return.
+    {
+      code: `
+interface StringExpectedCallable {
+  (value: string): string | null;
+}
+interface OpaqueParameterCallable {
+  (value: any): null;
+  (value: boolean): string;
+}
+declare const opaqueParameterCallable: OpaqueParameterCallable;
+function opaqueCallableParameter(): StringExpectedCallable {
+  return opaqueParameterCallable;
+}
+      `,
+      errors: [
+        {
+          column: 35,
+          data: {
+            annotated: 'StringExpectedCallable',
+            unused: 'string',
+          },
+          endColumn: 59,
+          endLine: 10,
+          line: 10,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+interface ExpectedStringParameter {
+  (value: string): 'matched' | 'unused';
+}
+interface SourceUnionParameter {
+  (value: number | string): 'matched';
+  (value: boolean): 'unused';
+}
+declare const sourceUnionParameter: SourceUnionParameter;
+function sourceHasUnionParameter(): ExpectedStringParameter {
+  return sourceUnionParameter;
+}
+      `,
+      errors: [
+        {
+          column: 35,
+          data: {
+            annotated: 'ExpectedStringParameter',
+            unused: '"unused"',
+          },
+          endColumn: 60,
+          endLine: 10,
+          line: 10,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    // Iterator yield results may omit their optional `done` property.
+    {
+      code: `
+interface ValueOnlyIterator<T> {
+  next(): { value: T };
+}
+interface ValueOnlyIterable<T> {
+  [Symbol.iterator](): ValueOnlyIterator<T>;
+}
+declare const textValueOnlyIterable: ValueOnlyIterable<string>;
+function valueOnlyIterable(): Iterable<string | null> {
+  return textValueOnlyIterable;
+}
+      `,
+      errors: [
+        {
+          column: 29,
+          data: { annotated: 'Iterable<string | null>', unused: 'null' },
+          endColumn: 54,
+          endLine: 9,
+          line: 9,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    // Never-completing expressions do not make dead returns observable.
+    {
+      code: `
+declare function stopExecution(): never;
+function conditionalNever(branch: boolean, text: boolean): string | null {
+  if (text) return 'ready';
+  return branch ? stopExecution() : stopExecution();
+}
+      `,
+      errors: [
+        {
+          column: 58,
+          data: { annotated: 'string | null', unused: 'null' },
+          endColumn: 73,
+          endLine: 3,
+          line: 3,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+declare function stopExecution(): never;
+function staticConditionalNever(text: boolean): string | null {
+  if (text) return 'ready';
+  return true ? stopExecution() : null;
+}
+      `,
+      errors: [
+        {
+          column: 47,
+          data: { annotated: 'string | null', unused: 'null' },
+          endColumn: 62,
+          endLine: 3,
+          line: 3,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    // The statically selected false branch is analyzed symmetrically.
+    {
+      code: `
+function staticFalseConditional(): string | null {
+  return false ? null : 'ready';
+}
+      `,
+      errors: [
+        {
+          column: 34,
+          data: { annotated: 'string | null', unused: 'null' },
+          endColumn: 49,
+          endLine: 2,
+          line: 2,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    // A test whose type is never truthy makes its then-branch unreachable.
+    {
+      code: `
+declare const featureDisabled: false;
+function typePrunedThenBranch(): string | null {
+  if (featureDisabled) return null;
+  return 'ready';
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    // A test whose type is never falsy makes its else-branch unreachable.
+    {
+      code: `
+declare const alwaysOn: true;
+function typePrunedElseBranch(): 'ready' | 'idle' {
+  if (alwaysOn) {
+    return 'ready';
+  } else {
+    return 'idle';
+  }
+}
+      `,
+      errors: [{ messageId: 'misleadingReturnType' }],
+    },
+    // Static and type-level nullishness both select the fallback value. A
+    // statically nullish or non-nullish operand is reported by the compiler
+    // itself, so this short-circuit can only be expressed as code the checker
+    // rejects; the rule still has to read the surviving operand correctly.
+    {
+      code: `
+function staticNullishReturn(): string | null {
+  return 'ready' ?? null;
+}
+      `,
+      errors: [
+        {
+          column: 31,
+          data: { annotated: 'string | null', unused: 'null' },
+          endColumn: 46,
+          endLine: 2,
+          line: 2,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+declare const typedNull: null;
+function typedNullishReturn(): string | null {
+  return typedNull ?? 'ready';
+}
+      `,
+      errors: [
+        {
+          column: 30,
+          data: { annotated: 'string | null', unused: 'null' },
+          endColumn: 45,
+          endLine: 3,
+          line: 3,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    // Promise settlement without a value exposes only undefined.
+    {
+      code: `
+function resolveWithoutValue(): Promise<string | null | undefined> {
+  return new Promise<undefined>(resolve => {
+    resolve(undefined);
+  });
+}
+      `,
+      errors: [
+        {
+          column: 31,
+          data: {
+            annotated: 'Promise<string | null | undefined>',
+            unused: 'null | string',
+          },
+          endColumn: 67,
+          endLine: 2,
+          line: 2,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+function staticResolveWithoutValue(): Promise<string | null | undefined> {
+  return Promise.resolve(undefined);
+}
+      `,
+      errors: [
+        {
+          column: 37,
+          data: {
+            annotated: 'Promise<string | null | undefined>',
+            unused: 'null | string',
+          },
+          endColumn: 73,
+          endLine: 2,
+          line: 2,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+declare function stopExecution(): never;
+function logicalNever(text: boolean): string | null {
+  if (text) return 'ready';
+  true && stopExecution();
+  return null;
+}
+      `,
+      errors: [
+        {
+          column: 37,
+          data: { annotated: 'string | null', unused: 'null' },
+          endColumn: 52,
+          endLine: 3,
+          line: 3,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    // Type-invalid for the same reason as `staticNullishReturn` above.
+    {
+      code: `
+declare function stopExecution(): never;
+function nullishNever(text: boolean): string | null {
+  if (text) return 'ready';
+  null ?? stopExecution();
+  return null;
+}
+      `,
+      errors: [
+        {
+          column: 37,
+          data: { annotated: 'string | null', unused: 'null' },
+          endColumn: 52,
+          endLine: 3,
+          line: 3,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+declare function stopExecution(): never;
+function computedNameNever(text: boolean): string | null {
+  if (text) return 'ready';
+  ({ [stopExecution()]: 1 });
+  return null;
+}
+      `,
+      errors: [
+        {
+          column: 42,
+          data: { annotated: 'string | null', unused: 'null' },
+          endColumn: 57,
+          endLine: 3,
+          line: 3,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+declare function stopExecution(): never;
+function forOfNever(text: boolean): string | null {
+  if (text) return 'ready';
+  for (const value of stopExecution() as string[]) {
+    void value;
+  }
+  return null;
+}
+      `,
+      errors: [
+        {
+          column: 35,
+          data: { annotated: 'string | null', unused: 'null' },
+          endColumn: 50,
+          endLine: 3,
+          line: 3,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+declare function stopExecution(): never;
+function tryCatchNever(text: boolean): string | null {
+  if (text) return 'ready';
+  try {
+    stopExecution();
+  } catch {
+    stopExecution();
+  }
+  return null;
+}
+      `,
+      errors: [
+        {
+          column: 38,
+          data: { annotated: 'string | null', unused: 'null' },
+          endColumn: 53,
+          endLine: 3,
+          line: 3,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    // Function-expression Promise executors are inspected like arrows.
+    {
+      code: `
+function functionExpressionPromiseExecutor(): Promise<string | null> {
+  return new Promise(function (resolve) {
+    resolve('ready');
+  });
+}
+      `,
+      errors: [
+        {
+          column: 45,
+          data: { annotated: 'Promise<string | null>', unused: 'null' },
+          endColumn: 69,
+          endLine: 2,
+          line: 2,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    // Known element-access keys remain exact under unchecked-index settings.
+    {
+      code: `
+interface ExactStringState {
+  readonly known: string;
+}
+function exactStringElement(value: ExactStringState): string | undefined {
+  return value['known'];
+}
+      `,
+      errors: [
+        {
+          column: 53,
+          data: { annotated: 'string | undefined', unused: 'undefined' },
+          endColumn: 73,
+          endLine: 5,
+          line: 5,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+      languageOptions: {
+        parserOptions: {
+          project: './tsconfig.noUncheckedIndexedAccess.json',
+          projectService: false,
+          tsconfigRootDir: getFixturesRootDir(),
+        },
+      },
+    },
+    {
+      code: `
+declare const exactElementKey: unique symbol;
+interface ExactSymbolState {
+  readonly [exactElementKey]: string;
+}
+function exactSymbolElement(value: ExactSymbolState): string | undefined {
+  return value[exactElementKey];
+}
+      `,
+      errors: [
+        {
+          column: 53,
+          data: { annotated: 'string | undefined', unused: 'undefined' },
+          endColumn: 73,
+          endLine: 6,
+          line: 6,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+      languageOptions: {
+        parserOptions: {
+          project: './tsconfig.noUncheckedIndexedAccess.json',
+          projectService: false,
+          tsconfigRootDir: getFixturesRootDir(),
+        },
+      },
+    },
+    // Repeated exact observations share one constituent entry.
+    {
+      code: `
+const exactReady: 'ready' = 'ready';
+function repeatedExactObservation(flag: boolean): 'idle' | 'ready' {
+  if (flag) return exactReady;
+  return exactReady;
+}
+      `,
+      errors: [
+        {
+          column: 49,
+          data: {
+            annotated: '"idle" | "ready"',
+            unused: '"idle"',
+          },
+          endColumn: 67,
+          endLine: 3,
+          line: 3,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    // A tuple assembled by spread still exposes its numeric property when the
+    // tuple itself is object-spread.
+    {
+      code: `
+type NestedTupleObjectSpreadResult = { readonly 0: string | null };
+declare const nestedTupleSource: readonly ['ready'];
+function nestedTupleObjectSpread(): NestedTupleObjectSpreadResult {
+  return { ...[...nestedTupleSource] };
+}
+      `,
+      errors: [
+        {
+          column: 35,
+          data: {
+            annotated: 'NestedTupleObjectSpreadResult',
+            unused: 'null',
+          },
+          endColumn: 66,
+          endLine: 4,
+          line: 4,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    // Statically unreachable loop bodies cannot contribute yielded values.
+    {
+      code: `
+type TextGenerator = Generator<string | null, void, unknown>;
+function* unreachableForYield(): TextGenerator {
+  for (; false;) {
+    yield null;
+  }
+  yield 'ready';
+}
+      `,
+      errors: [
+        {
+          column: 32,
+          data: { annotated: 'TextGenerator', unused: 'null' },
+          endColumn: 47,
+          endLine: 3,
+          line: 3,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+type TextGenerator = Generator<string | null, void, unknown>;
+function* unreachableWhileYield(): TextGenerator {
+  while (false) {
+    yield null;
+  }
+  yield 'ready';
+}
+      `,
+      errors: [
+        {
+          column: 34,
+          data: { annotated: 'TextGenerator', unused: 'null' },
+          endColumn: 49,
+          endLine: 3,
+          line: 3,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    // Each short-circuiting operator can make a yield unreachable.
+    {
+      code: `
+type TextGenerator = Generator<string | null, void, unknown>;
+function* shortCircuitedOrYield(): TextGenerator {
+  true || (yield null);
+  yield 'ready';
+}
+      `,
+      errors: [
+        {
+          column: 34,
+          data: { annotated: 'TextGenerator', unused: 'null' },
+          endColumn: 49,
+          endLine: 3,
+          line: 3,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    // Type-invalid for the same reason as `staticNullishReturn` above.
+    {
+      code: `
+type TextGenerator = Generator<string | null, void, unknown>;
+function* shortCircuitedNullishYield(): TextGenerator {
+  'present' ?? (yield null);
+  yield 'ready';
+}
+      `,
+      errors: [
+        {
+          column: 39,
+          data: { annotated: 'TextGenerator', unused: 'null' },
+          endColumn: 54,
+          endLine: 3,
+          line: 3,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    // Spread arguments are evaluated before constructor invocation.
+    {
+      code: `
+declare function stopExecution(): never;
+declare const ResultBox: new (...values: never[]) => object;
+function constructorSpreadNever(text: boolean): string | null {
+  if (text) return 'ready';
+  new ResultBox(...(stopExecution() as never[]));
+  return null;
+}
+      `,
+      errors: [
+        {
+          column: 47,
+          data: { annotated: 'string | null', unused: 'null' },
+          endColumn: 62,
+          endLine: 4,
+          line: 4,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    // Overloaded local wrappers are one reachable Promise settlement source.
+    {
+      code: `
+function overloadedResolverWrapper(): Promise<string | null> {
+  return new Promise(resolve => {
+    function settle(value: 'ready'): void;
+    function settle(value: string): void;
+    function settle(value: string): void {
+      resolve(value);
+    }
+    settle('ready');
+  });
+}
+      `,
+      errors: [
+        {
+          column: 37,
+          data: { annotated: 'Promise<string | null>', unused: 'null' },
+          endColumn: 61,
+          endLine: 2,
+          line: 2,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    // A never-typed observation contributes no reachable constituent.
+    {
+      code: `
+declare const impossibleValue: never;
+function neverObservation(flag: boolean): string | null {
+  if (flag) return impossibleValue;
+  return 'ready';
+}
+      `,
+      errors: [
+        {
+          column: 41,
+          data: { annotated: 'string | null', unused: 'null' },
+          endColumn: 56,
+          endLine: 3,
+          line: 3,
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+    // Diagnostic payloads stay bounded for large unions.
+    {
+      code: `
+function largeUnion():
+  | 'returned'
+  | 'unused-constituent-one'
+  | 'unused-constituent-two'
+  | 'unused-constituent-three'
+  | 'unused-constituent-four'
+  | 'unused-constituent-five' {
+  return 'returned';
+}
+      `,
+      errors: [
+        {
+          data: {
+            annotated:
+              '"returned" | "unused-constituent-one" | "unused-constituent-two" | "unused-const...',
+            unused:
+              '"unused-constituent-one" | "unused-constituent-two" | "unused-constituent-three"',
+          },
+          messageId: 'misleadingReturnType',
+        },
+      ],
+    },
+  ],
+});
+
+const unstrictRuleTester = createRuleTesterWithTypes({
+  project: './tsconfig.json',
+  tsconfigRootDir: path.join(getFixturesRootDir(), 'unstrict'),
+});
+
+unstrictRuleTester.run('no-misleading-return-type without strict nulls', rule, {
+  valid: [
+    `
+function nullIsNotASeparateType(): string | null {
+  return 'ready';
+}
+    `,
+  ],
+  invalid: [],
+});

--- a/packages/eslint-plugin/tests/rules/strict-void-return.test.ts
+++ b/packages/eslint-plugin/tests/rules/strict-void-return.test.ts
@@ -2790,5 +2790,18 @@ async function* cb() {
       `,
       errors: [{ column: 10, line: 5, messageId: 'nonVoidFunc' }],
     },
+    {
+      code: `
+class Base {
+  static run(): void {}
+}
+class Child extends Base {
+  static run() {
+    return 1;
+  }
+}
+      `,
+      errors: [{ column: 5, line: 7, messageId: 'nonVoidReturn' }],
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/schema-snapshots/no-misleading-return-type.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-misleading-return-type.shot
@@ -1,0 +1,10 @@
+
+# SCHEMA:
+
+[]
+
+
+# TYPES:
+
+/** No options declared */
+type Options = [];


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: closes #6442
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

Adds `no-misleading-return-type`, the rule proposed in #6442. It reports return type annotations containing union constituents the function never returns — the `function f(): string | null { return 'x'; }` case from the issue.

I maintain the same rule as a [standalone plugin](https://github.com/minseong0324/eslint-plugin-no-misleading-return-type) and in Biome as [`noMisleadingReturnType`](https://github.com/biomejs/biome/pull/9799). The boundaries here come from false-positive cases found while maintaining those.

What it checks:

- written unions at every observable position: the annotation itself, awaited `Promise`/thenable results, object properties, index signatures, tuples, arrays, `Map`/`Set`/`WeakRef` and other built-in containers, and returned call/construct signatures
- reachability: only returns and yields that can actually execute count, using ESLint's code path analysis plus static branch, `switch`, `try`/`finally`, and `never`-completion evaluation
- generators: the yielded-value channel for sync and async generators, including resolvable `yield*` delegation
- `undefined`/`void` constituents when both `strictNullChecks` and `noUncheckedIndexedAccess` are enabled; with either disabled they are exempt, since unchecked index access can produce `undefined` the checker does not surface

Deliberately not reported, to avoid false positives:

- generator `TReturn`/`TNext`: callers can inject those through `generator.return(value)` and `generator.next(value)`
- overload implementation signatures, annotations mirroring an inherited or contextual contract, and members of decorator-affected classes
- generic conditional/mapped/index/indexed-access types that are still uninstantiated, `any`/`unknown`/error types, and anything past the rule's bounded work limits

Design choices:

- report-only: no autofix and no suggestions. Narrowing a nested constituent cannot be expressed as a safe text edit; a conservative remove-annotation suggestion could be a follow-up
- no options, and not enabled in any shared config (`all`/`disable-type-checked` entries are generated)