### PR TITLE
docs: fix incorrect package name in custom rules docs

### DIFF
--- a/docs/developers/Custom_Rules.mdx
+++ b/docs/developers/Custom_Rules.mdx
@@ -202,7 +202,7 @@ When reading the options, use the second parameter of the `create` function, not
 
 ## AST Extensions
 
-`@typescript-eslint/estree` creates AST nodes for TypeScript syntax with names that begin with `TS`, such as `TSInterfaceDeclaration` and `TSTypeAnnotation`.
+`@typescript-eslint/typescript-estree` creates AST nodes for TypeScript syntax with names that begin with `TS`, such as `TSInterfaceDeclaration` and `TSTypeAnnotation`.
 These nodes are treated just like any other AST node.
 You can query for them in your rule selectors.
 
@@ -291,8 +291,8 @@ The biggest addition typescript-eslint brings to ESLint rules is the ability to 
 That `services` object contains:
 
 - `program`: A full TypeScript `ts.Program` object if type checking is enabled, or `null` otherwise
-- `esTreeNodeToTSNodeMap`: Map of `@typescript-eslint/estree` `TSESTree.Node` nodes to their TypeScript `ts.Node` equivalents
-- `tsNodeToESTreeNodeMap`: Map of TypeScript `ts.Node` nodes to their `@typescript-eslint/estree` `TSESTree.Node` equivalents
+- `esTreeNodeToTSNodeMap`: Map of `TSESTree.Node` nodes to their TypeScript `ts.Node` equivalents
+- `tsNodeToESTreeNodeMap`: Map of TypeScript `ts.Node` nodes to their `TSESTree.Node` equivalents
 
 If type checking is enabled, that `services` object additionally contains:
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

<!-- Description of what is changed and how the code change does that. -->
@typescript-eslint/estree doesn't exist. The package is @typescript-eslint/typescript-estree. Fixed the name on line 205. On lines 294-295 I removed the prefix instead of renaming it, because TSESTree comes from @typescript-eslint/utils (line 230) and lines 299-300 in the same list already write TSESTree.Node bare.

```md
Disclosure: I'm a participant of [open source contribution program OSSCA](https://github.com/eslint-ossca)
```