### PR TITLE
docs: fix duplicated word in no-restricted-types docs

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-restricted-types.mdx
+++ b/packages/eslint-plugin/docs/rules/no-restricted-types.mdx
@@ -21,7 +21,7 @@ Note that it does not ban the corresponding runtime objects from being used.
 
 {/* insert option description */}
 
-The type can either be a type name literal (`OldType`) or a a type name with generic parameter instantiation(s) (`OldType<MyArgument>`).
+The type can either be a type name literal (`OldType`) or a type name with generic parameter instantiation(s) (`OldType<MyArgument>`).
 
 The values can be:
 


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

> Note: No linked issue — this is an extremely minor documentation typo, which the [Pull Request guidelines](https://typescript-eslint.io/contributing/pull-requests) list as an exception to the "must address an open issue" rule.

## Overview

Removes a repeated word in the `no-restricted-types` rule docs: `a a type name` → `a type name`.

🤓