### PR TITLE
chore: [ci] run deduplicate check without build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,9 @@ jobs:
             run: pnpm run stylelint
             working-directory: packages/website
 
+          - name: Run Deduplicate Check
+            run: pnpm run deduplicate
+
   lint_with_build:
     name: Lint with build
     environment: ${{ (github.repository == 'typescript-eslint/typescript-eslint' && github.ref == 'refs/heads/main') && 'main' || '' }} # Have to specify per job
@@ -194,7 +197,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        lint-task: ['deduplicate', 'typecheck', 'typecheck:tsgo', 'knip']
+        lint-task: ['typecheck', 'typecheck:tsgo', 'knip']
     env:
       NX_CI_EXECUTION_ENV: 'ubuntu-latest'
     steps:


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [X] Addresses an existing open issue: related #11204
- [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [X] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

There is no need to build before deduplicating dependencies AFAIK, this is wasting too much time

Correct me if I'm wrong
