### PR TITLE
docs: fix duplicated word in Releases docs

### DIFF
--- a/docs/users/Releases.mdx
+++ b/docs/users/Releases.mdx
@@ -120,7 +120,7 @@ npm i typescript-eslint@canary --save-dev --force
 We currently do not have a set schedule around when major releases shall be performed; instead they are done as the need arises.
 
 We keep a backlog of breaking issues as a milestone on GitHub that is named in the form `${major}.0.0`.
-When we do do a major release, we release a release candidate version to the `rc-v${major}` tag on npm for each commit to the major branch.
+When we do a major release, we release a release candidate version to the `rc-v${major}` tag on npm for each commit to the major branch.
 
 See [Maintenance > Releases](../maintenance/Releases.mdx#major-releases) for steps to perform a major release.
 


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

> Note: No linked issue — this is an extremely minor documentation typo, which the [Pull Request guidelines](https://typescript-eslint.io/contributing/pull-requests) list as an exception to the "must address an open issue" rule.

## Overview

Removes a repeated word in the Releases docs (`docs/users/Releases.mdx`): `When we do do a major release` → `When we do a major release`.

🤓
