### PR TITLE
chore: [ci] use windows-2022 runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,9 +398,9 @@ jobs:
       fail-fast: false
       matrix:
         exclude:
-          - os: windows-latest
+          - os: windows-2022
             node-version: 18
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-2022]
         # just run on the oldest and latest supported versions and assume the intermediate versions are good
         node-version: [18, 24]
         package:
@@ -454,7 +454,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-2022]
         # note: do not run these packages on the oldest supported node versions -- we assume that the plugin tests have enough e2e coverage to prove everything works on the lowest node version
         node-version: [24]
         package: ${{ fromJson(needs['affected-for-tests'].outputs.unit_tests_packages) }}
@@ -462,22 +462,22 @@ jobs:
         # Packages that have no (or we don't care about their) platform-specific,
         # runtime behavior, so skipping them on Windows to have less jobs to run.
         exclude:
-          - os: windows-latest
+          - os: windows-2022
             package: ast-spec
 
-          - os: windows-latest
+          - os: windows-2022
             package: eslint-plugin-internal
 
-          - os: windows-latest
+          - os: windows-2022
             package: rule-schema-to-typescript-types
 
-          - os: windows-latest
+          - os: windows-2022
             package: scope-manager
 
-          - os: windows-latest
+          - os: windows-2022
             package: utils
 
-          - os: windows-latest
+          - os: windows-2022
             package: visitor-keys
     env:
       NX_CI_EXECUTION_ENV: '${{ matrix.os }} - Node ${{ matrix.node-version }}'


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [X] Addresses an existing open issue: Related to #11204
- [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [X] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

Trying https://github.com/actions/runner-images/issues/12647
