### PR TITLE
fix(type-utils): match packages at path boundaries

### DIFF
--- a/docs/packages/type-utils/TypeOrValueSpecifier.mdx
+++ b/docs/packages/type-utils/TypeOrValueSpecifier.mdx
@@ -108,6 +108,14 @@ Describes specific types or values imported from packages.
 
 `package` must be used to specify the package name.
 
+A `package` matches at path boundaries: the package itself, and anything published under it.
+Naming a scope therefore matches every package in that scope — `@angular` matches `@angular/common`
+and `@angular/core`. Partial names do not match: `@angular/comm` matches nothing.
+
+Types that ship through DefinitelyTyped can be named either way. `semver` and `@types/semver` both
+match the types from `@types/semver`, as do `@babel/code-frame` and `@types/babel__code-frame` for a
+scoped package.
+
 ### PackageSpecifier Examples
 
 Matching the `SafePromise` type from `@reduxjs/toolkit`:

--- a/packages/type-utils/src/typeOrValueSpecifiers/typeDeclaredInPackageDeclarationFile.ts
+++ b/packages/type-utils/src/typeOrValueSpecifiers/typeDeclaredInPackageDeclarationFile.ts
@@ -1,5 +1,30 @@
 import * as ts from 'typescript';
 
+function getCanonicalPackageName(packageName: string): string {
+  if (!packageName.startsWith('@types/')) {
+    return packageName;
+  }
+
+  const typesPackageName = packageName.slice('@types/'.length);
+  const scopeSeparatorIndex = typesPackageName.indexOf('__');
+  if (scopeSeparatorIndex === -1) {
+    return typesPackageName;
+  }
+
+  return `@${typesPackageName.slice(0, scopeSeparatorIndex)}/${typesPackageName.slice(scopeSeparatorIndex + 2)}`;
+}
+
+function packageNameMatches(
+  expectedPackageName: string,
+  actualPackageName: string,
+): boolean {
+  const canonicalPackageName = getCanonicalPackageName(actualPackageName);
+  return (
+    canonicalPackageName === expectedPackageName ||
+    canonicalPackageName.startsWith(`${expectedPackageName}/`)
+  );
+}
+
 function findParentModuleDeclaration(
   node: ts.Node,
 ): ts.ModuleDeclaration | undefined {
@@ -33,15 +58,11 @@ function typeDeclaredInDeclarationFile(
   declarationFiles: ts.SourceFile[],
   program: ts.Program,
 ): boolean {
-  // Handle scoped packages: if the name starts with @, remove it and replace / with __
-  const typesPackageName = packageName.replace(/^@([^/]+)\//, '$1__');
-
-  const matcher = new RegExp(`${packageName}|${typesPackageName}`);
   return declarationFiles.some(declaration => {
     const packageIdName = program.sourceFileToPackageName.get(declaration.path);
     return (
       packageIdName != null &&
-      matcher.test(packageIdName) &&
+      packageNameMatches(packageName, packageIdName) &&
       program.isSourceFileFromExternalLibrary(declaration)
     );
   });

--- a/packages/type-utils/src/typeOrValueSpecifiers/typeDeclaredInPackageDeclarationFile.ts
+++ b/packages/type-utils/src/typeOrValueSpecifiers/typeDeclaredInPackageDeclarationFile.ts
@@ -18,10 +18,14 @@ function packageNameMatches(
   expectedPackageName: string,
   actualPackageName: string,
 ): boolean {
-  const canonicalPackageName = getCanonicalPackageName(actualPackageName);
+  // Both sides are canonicalized so that a specifier keeps matching whether it
+  // names the package (`semver`) or its DefinitelyTyped wrapper
+  // (`@types/semver`), which is the form the declaration file reports.
+  const canonicalExpectedName = getCanonicalPackageName(expectedPackageName);
+  const canonicalActualName = getCanonicalPackageName(actualPackageName);
   return (
-    canonicalPackageName === expectedPackageName ||
-    canonicalPackageName.startsWith(`${expectedPackageName}/`)
+    canonicalActualName === canonicalExpectedName ||
+    canonicalActualName.startsWith(`${canonicalExpectedName}/`)
   );
 }
 

--- a/packages/type-utils/src/typeOrValueSpecifiers/typeDeclaredInPackageDeclarationFile.ts
+++ b/packages/type-utils/src/typeOrValueSpecifiers/typeDeclaredInPackageDeclarationFile.ts
@@ -5,13 +5,8 @@ function getCanonicalPackageName(packageName: string): string {
     return packageName;
   }
 
-  const typesPackageName = packageName.slice('@types/'.length);
-  const scopeSeparatorIndex = typesPackageName.indexOf('__');
-  if (scopeSeparatorIndex === -1) {
-    return typesPackageName;
-  }
-
-  return `@${typesPackageName.slice(0, scopeSeparatorIndex)}/${typesPackageName.slice(scopeSeparatorIndex + 2)}`;
+  // Handle scoped packages: if the name contains __, add a leading @ and replace __ with /
+  return packageName.slice('@types/'.length).replace(/([^_]+)__/, '@$1/');
 }
 
 function packageNameMatches(

--- a/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
+++ b/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
@@ -396,7 +396,9 @@ describe('TypeOrValueSpecifier', () => {
           package: '@babel/code-frame',
         },
       ],
-      // Package scopes and package names match their subpaths.
+      // A specifier matches whole path components only, so a scope matches every
+      // package inside it: `@babel` matches `@babel/code-frame`, just as
+      // `@angular` matches `@angular/foo` and `@angular/foo/bar`.
       [
         'import {BabelCodeFrameOptions} from "@babel/code-frame"; type Test = BabelCodeFrameOptions;',
         {
@@ -598,6 +600,9 @@ describe('TypeOrValueSpecifier', () => {
         'import type {Node as TsNode} from "typescript"; type Test = TsNode;',
         { from: 'package', name: 'TsNode', package: 'typescript' },
       ],
+      // A prefix that stops mid-component is not a match: `typescript` is not
+      // matched by `type`, the same way `@angular/foo` does not match
+      // `@angular/foobar`.
       [
         'import type {Node} from "typescript"; type Test = Node;',
         { from: 'package', name: 'Node', package: 'type' },
@@ -609,6 +614,39 @@ describe('TypeOrValueSpecifier', () => {
           name: 'BabelCodeFrameOptions',
           package: '@babel/code',
         },
+      ],
+      // ...and neither is a partial scope, the `@angular` / `@angularlol` case.
+      [
+        'import {BabelCodeFrameOptions} from "@babel/code-frame"; type Test = BabelCodeFrameOptions;',
+        {
+          from: 'package',
+          name: 'BabelCodeFrameOptions',
+          package: '@babe',
+        },
+      ],
+      // A sibling package in the same scope is not a match either
+      // (`@angular/foo` vs. `@angular/bar`).
+      [
+        'import {BabelCodeFrameOptions} from "@babel/code-frame"; type Test = BabelCodeFrameOptions;',
+        {
+          from: 'package',
+          name: 'BabelCodeFrameOptions',
+          package: '@babel/other',
+        },
+      ],
+      // The boundary applies to the canonicalized name, so the DefinitelyTyped
+      // spelling of a mid-component prefix does not match either.
+      [
+        'import {BabelCodeFrameOptions} from "@babel/code-frame"; type Test = BabelCodeFrameOptions;',
+        {
+          from: 'package',
+          name: 'BabelCodeFrameOptions',
+          package: '@types/babel__code',
+        },
+      ],
+      [
+        'import {SemVer} from "semver"; type Test = SemVer;',
+        { from: 'package', name: 'SemVer', package: '@types/semve' },
       ],
     ] as const satisfies [string, TypeOrValueSpecifier][])(
       "doesn't match a mismatched package specifier: %s\n\t%s",

--- a/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
+++ b/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
@@ -396,6 +396,15 @@ describe('TypeOrValueSpecifier', () => {
           package: '@babel/code-frame',
         },
       ],
+      // Package scopes and package names match their subpaths.
+      [
+        'import {BabelCodeFrameOptions} from "@babel/code-frame"; type Test = BabelCodeFrameOptions;',
+        {
+          from: 'package',
+          name: 'BabelCodeFrameOptions',
+          package: '@babel',
+        },
+      ],
       // TODO: Skipped pending resolution of https://github.com/typescript-eslint/typescript-eslint/issues/11504
       //
       // The following type is available from the multi-file @types/node package.
@@ -575,6 +584,18 @@ describe('TypeOrValueSpecifier', () => {
       [
         'import type {Node as TsNode} from "typescript"; type Test = TsNode;',
         { from: 'package', name: 'TsNode', package: 'typescript' },
+      ],
+      [
+        'import type {Node} from "typescript"; type Test = Node;',
+        { from: 'package', name: 'Node', package: 'type' },
+      ],
+      [
+        'import {BabelCodeFrameOptions} from "@babel/code-frame"; type Test = BabelCodeFrameOptions;',
+        {
+          from: 'package',
+          name: 'BabelCodeFrameOptions',
+          package: '@babel/code',
+        },
       ],
     ] as const satisfies [string, TypeOrValueSpecifier][])(
       "doesn't match a mismatched package specifier: %s\n\t%s",

--- a/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
+++ b/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
@@ -405,6 +405,19 @@ describe('TypeOrValueSpecifier', () => {
           package: '@babel',
         },
       ],
+      // A package may also be named by its DefinitelyTyped wrapper.
+      [
+        'import {SemVer} from "semver"; type Test = SemVer;',
+        { from: 'package', name: 'SemVer', package: '@types/semver' },
+      ],
+      [
+        'import {BabelCodeFrameOptions} from "@babel/code-frame"; type Test = BabelCodeFrameOptions;',
+        {
+          from: 'package',
+          name: 'BabelCodeFrameOptions',
+          package: '@types/babel__code-frame',
+        },
+      ],
       // TODO: Skipped pending resolution of https://github.com/typescript-eslint/typescript-eslint/issues/11504
       //
       // The following type is available from the multi-file @types/node package.


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #~11946~
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

Package specifiers were matched with an unanchored regular expression, so a value such as `@angular/com` could accidentally match `@angular/common/http`.

This change normalizes `@types` package names and then accepts only an exact package name or a `/`-delimited subpath. The tests cover retained scoped `@types` matching, scope-level matching, and rejected partial names for both scoped and unscoped packages.

Validation:

- `nx test type-utils` (345 passed, 1 skipped)
- `nx typecheck type-utils`
- ESLint and Prettier checks for the changed files

AI assistance disclosure: I used Codex to help investigate and implement this change. I reviewed the code, tests, and validation results before opening the PR.

💖