### PR TITLE
fix(eslint-plugin): handle union-keyed nullish assignments

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -50,6 +50,12 @@ function isPossiblyNullish(type: ts.Type): boolean {
     .some(t => isNullishType(t) || isTypeFlagSet(t, ts.TypeFlags.Void));
 }
 
+function isPossiblyNonNullish(type: ts.Type): boolean {
+  return tsutils
+    .unionConstituents(type)
+    .some(t => !isNullishType(t) && !isTypeFlagSet(t, ts.TypeFlags.Void));
+}
+
 function toStaticValue(
   type: ts.Type,
 ):
@@ -342,6 +348,55 @@ export default createRule<Options, MessageId>({
       return false;
     }
 
+    function getComputedMemberPropertyTypes(
+      node: TSESTree.MemberExpression,
+    ): ts.Type[] | undefined {
+      if (!node.computed) {
+        return undefined;
+      }
+
+      const objectType = getConstrainedTypeAtLocation(services, node.object);
+      const propertyType = getConstrainedTypeAtLocation(
+        services,
+        node.property,
+      );
+      const propertyTypes: ts.Type[] = [];
+
+      for (const keyType of tsutils.unionConstituents(propertyType)) {
+        if (!keyType.isStringLiteral() && !keyType.isNumberLiteral()) {
+          return undefined;
+        }
+
+        const selectedType = getTypeOfPropertyOfName(
+          checker,
+          objectType,
+          String(keyType.value),
+        );
+        if (!selectedType) {
+          return undefined;
+        }
+
+        propertyTypes.push(selectedType);
+      }
+
+      return propertyTypes;
+    }
+
+    function hasPossiblyNonNullishComputedMemberProperty(
+      node: TSESTree.Expression,
+    ): boolean {
+      if (node.type !== AST_NODE_TYPES.MemberExpression) {
+        return false;
+      }
+
+      // Computed assignment targets can be typed as a write-side intersection.
+      // Inspect the selected property read types before reporting `??=` as always nullish.
+      return (
+        getComputedMemberPropertyTypes(node)?.some(isPossiblyNonNullish) ??
+        false
+      );
+    }
+
     /**
      * Checks if a conditional node is necessary:
      * if the type of the node is always true or always false, it's not necessary.
@@ -439,7 +494,10 @@ export default createRule<Options, MessageId>({
         ) {
           messageId = 'neverNullish';
         }
-      } else if (isAlwaysNullish(type)) {
+      } else if (
+        isAlwaysNullish(type) &&
+        !hasPossiblyNonNullishComputedMemberProperty(node)
+      ) {
         messageId = 'alwaysNullish';
       }
 

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -3455,6 +3455,37 @@ foo ??= null;
     },
     {
       code: `
+declare const foo: { bar: null };
+foo.bar ??= null;
+      `,
+      errors: [
+        {
+          column: 1,
+          endColumn: 8,
+          endLine: 3,
+          line: 3,
+          messageId: 'alwaysNullish',
+        },
+      ],
+    },
+    {
+      code: `
+declare const foo: Record<string, undefined>;
+declare const key: string;
+foo[key] ??= undefined;
+      `,
+      errors: [
+        {
+          column: 1,
+          endColumn: 9,
+          endLine: 4,
+          line: 4,
+          messageId: 'alwaysNullish',
+        },
+      ],
+    },
+    {
+      code: `
 type Fields = {
   hello?: undefined;
   world?: null;

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -1025,6 +1025,18 @@ declare const key: Key;
 foo.bar[key] ??= 1;
     `,
     `
+type Fields = {
+  hello?: number;
+  world?: boolean;
+};
+
+let fields: Fields = {};
+
+for (const key of ['hello', 'world'] as const) {
+  fields[key] ??= undefined;
+}
+    `,
+    `
 enum Keys {
   A = 'A',
   B = 'B',
@@ -3437,6 +3449,29 @@ foo ??= null;
           endColumn: 4,
           endLine: 3,
           line: 3,
+          messageId: 'alwaysNullish',
+        },
+      ],
+    },
+    {
+      code: `
+type Fields = {
+  hello?: undefined;
+  world?: null;
+};
+
+let fields: Fields = {};
+
+for (const key of ['hello', 'world'] as const) {
+  fields[key] ??= undefined;
+}
+      `,
+      errors: [
+        {
+          column: 3,
+          endColumn: 14,
+          endLine: 10,
+          line: 10,
           messageId: 'alwaysNullish',
         },
       ],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #12556
- [x] That issue was marked as accepting prs
- [x] Steps in Contributing were taken
- [x] If this PR used AI assistance, I followed the AI Contribution Policy

## Overview

Fixes #12556. `no-unnecessary-condition` misreported union-keyed `??=` as always nullish.

Fix: Check selected computed property read types before reporting, so mixed optional fields are not treated as nullish-only.

Test: Added union-keyed `??=` regression coverage and nullish-only control cases.
