### PR TITLE
docs(eslint-plugin): fix typos in three rule docs

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
@@ -213,7 +213,7 @@ If for some reason you cannot turn on `strictNullChecks`, but still want to use 
 
 ## Limitations
 
-This rule is powered by TypeScript types, therefore, if the types do not match match the runtime behavior, the rule may report inaccurately.
+This rule is powered by TypeScript types, therefore, if the types do not match the runtime behavior, the rule may report inaccurately.
 This can happen in several commonplace scenarios.
 
 ### Possibly-undefined indexed access

--- a/packages/eslint-plugin/docs/rules/no-unnecessary-type-parameters.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-type-parameters.mdx
@@ -112,7 +112,7 @@ declare function length(array: ReadonlyArray<unknown>): number;
 ### The return type is only used as an input, so why isn't the rule reporting?
 
 One common reason that this might be the case is when the return type is not specified explicitly.
-The rule uses uses type information to count implicit usages of the type parameter in the function signature, including in the inferred return type.
+The rule uses type information to count implicit usages of the type parameter in the function signature, including in the inferred return type.
 For example, the following function...
 
 ```ts

--- a/packages/eslint-plugin/docs/rules/no-unsafe-call.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unsafe-call.mdx
@@ -88,7 +88,7 @@ function callUnsafe(maybeFunction: unknown): string {
 ```
 
 In this sort of situation, beware that there is no way to guarantee with runtime checks that a value is safe to call.
-If you _really_ want to call a value whose type you don't know, your best best is to use a `try`/`catch` and suppress any TypeScript or linter errors that get in your way.
+If you _really_ want to call a value whose type you don't know, your best bet is to use a `try`/`catch` and suppress any TypeScript or linter errors that get in your way.
 
 ```ts
 function callSafe(maybeFunction: unknown): void {


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

> No linked issue: these are extremely minor documentation typos, which [Pull Requests](https://typescript-eslint.io/contributing/pull-requests) lists as an exception.

## Overview

Three typos I ran into while reading rule docs:

- `no-unnecessary-condition`: `if the types do not match match the runtime behavior` → `do not match`
- `no-unnecessary-type-parameters`: `The rule uses uses type information` → `The rule uses`
- `no-unsafe-call`: `your best best is to use a try/catch` → `your best bet` (this one reads like it was meant to be "bet" rather than a repeated word)
