### PR TITLE
chore: [ci] use minimal test reporter in Windows CI

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -69,6 +69,7 @@
       "options": {
         "config": "vitest.config.mts"
       },
+      "inputs": ["default", "{workspaceRoot}/vitest.config.base.mts"],
       "outputs": ["{projectRoot}/coverage"]
     },
     "attw-check": {

--- a/vitest.config.base.mts
+++ b/vitest.config.base.mts
@@ -17,7 +17,7 @@ export const vitestBaseConfig = {
     include: ['**/*.test.?(c|m)ts?(x)'],
 
     reporters: isWindowsCI()
-      ? ['minimal']
+      ? ['dot']
       : process.env.GITHUB_ACTIONS
         ? [['default', { summary: false }], ['github-actions']]
         : [['default']],

--- a/vitest.config.base.mts
+++ b/vitest.config.base.mts
@@ -16,9 +16,11 @@ export const vitestBaseConfig = {
     globals: true,
     include: ['**/*.test.?(c|m)ts?(x)'],
 
-    reporters: process.env.GITHUB_ACTIONS
-      ? [['default', { summary: false }], ['github-actions']]
-      : [['default']],
+    reporters: isWindowsCI()
+      ? ['minimal']
+      : process.env.GITHUB_ACTIONS
+        ? [['default', { summary: false }], ['github-actions']]
+        : [['default']],
 
     setupFiles: ['console-fail-test/setup'],
 
@@ -31,3 +33,7 @@ export const vitestBaseConfig = {
     watch: false,
   },
 } as const satisfies ViteUserConfig;
+
+function isWindowsCI() {
+  return process.platform === 'win32' && Boolean(process.env.CI);
+}


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [X] Addresses an existing open issue: Related #11204
- [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [X] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

~Outputting in Windows might be too slow, let's see if this helps~

So, I'm not sure how to consistently measure that, but looking at other PR runs, there's no definitive answer. It's about the same. Tried also with `dot` reporter, same.
