### PR TITLE
chore: [ci] remove eslint-plugin test sharding in Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,10 +397,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        exclude:
-          - os: windows-latest
-            node-version: 18
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
         # just run on the oldest and latest supported versions and assume the intermediate versions are good
         node-version: [18, 24]
         package:
@@ -410,6 +407,12 @@ jobs:
             { name: 'eslint-plugin', params: '--shard=3/4' },
             { name: 'eslint-plugin', params: '--shard=4/4' },
           ]
+        # Windows CI skips the rules tests (see the package's vitest config), so there
+        # isn't enough left to be worth sharding -- run it as a single unsharded job.
+        include:
+          - os: windows-latest
+            node-version: 24
+            package: { name: 'eslint-plugin', params: '' }
     steps:
       - name: Checkout
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -407,8 +407,7 @@ jobs:
             { name: 'eslint-plugin', params: '--shard=3/4' },
             { name: 'eslint-plugin', params: '--shard=4/4' },
           ]
-        # Windows CI skips the rules tests (see the package's vitest config), so there
-        # isn't enough left to be worth sharding -- run it as a single unsharded job.
+        # Windows CI skips the rules tests so there isn't enough left to be worth sharding.
         include:
           - os: windows-latest
             node-version: 24


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [X] Addresses an existing open issue: Related #11204
- [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [X] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

We're sharding in Windows for no reason. It's running a very small amount of tests thanks to:
 https://github.com/typescript-eslint/typescript-eslint/blob/b3f0cceee7b1d68f967253abc317f1b1b28fe4c8/packages/eslint-plugin/vitest.config.mts#L20-L22

So we're essentially spinning up 4 runners to run 2-3 tests each...

So from 4 runners taking almost ~7m, we're down to 1 runner taking ~2m
