### PR TITLE
fix(type-utils): match package re-exports in specifiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ build/Release
 
 # Dependency directories
 node_modules/
+!packages/eslint-plugin/tests/fixtures/node_modules/
+!packages/eslint-plugin/tests/fixtures/node_modules/reexported-error/
+!packages/eslint-plugin/tests/fixtures/node_modules/reexported-error/**
 jspm_packages/
 
 # Optional npm cache directory

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@ node_modules/
 !packages/eslint-plugin/tests/fixtures/node_modules/
 !packages/eslint-plugin/tests/fixtures/node_modules/reexported-error/
 !packages/eslint-plugin/tests/fixtures/node_modules/reexported-error/**
+!packages/type-utils/tests/fixtures/node_modules/
+!packages/type-utils/tests/fixtures/node_modules/reexported-error/
+!packages/type-utils/tests/fixtures/node_modules/reexported-error/**
 jspm_packages/
 
 # Optional npm cache directory

--- a/packages/eslint-plugin/tests/fixtures/node_modules/reexported-error/internal.d.ts
+++ b/packages/eslint-plugin/tests/fixtures/node_modules/reexported-error/internal.d.ts
@@ -1,0 +1,1 @@
+export class ReexportedError {}

--- a/packages/eslint-plugin/tests/fixtures/node_modules/reexported-error/namespace.d.ts
+++ b/packages/eslint-plugin/tests/fixtures/node_modules/reexported-error/namespace.d.ts
@@ -1,0 +1,1 @@
+export * as errors from './internal';

--- a/packages/eslint-plugin/tests/fixtures/node_modules/reexported-error/package.json
+++ b/packages/eslint-plugin/tests/fixtures/node_modules/reexported-error/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "reexported-error",
+  "version": "1.0.0"
+}

--- a/packages/eslint-plugin/tests/fixtures/node_modules/reexported-error/public.d.ts
+++ b/packages/eslint-plugin/tests/fixtures/node_modules/reexported-error/public.d.ts
@@ -1,0 +1,1 @@
+export { ReexportedError } from './internal';

--- a/packages/eslint-plugin/tests/fixtures/node_modules/reexported-error/star.d.ts
+++ b/packages/eslint-plugin/tests/fixtures/node_modules/reexported-error/star.d.ts
@@ -1,0 +1,1 @@
+export * from './internal';

--- a/packages/eslint-plugin/tests/rules/only-throw-error.test.ts
+++ b/packages/eslint-plugin/tests/rules/only-throw-error.test.ts
@@ -502,6 +502,47 @@ throw error;
     },
     {
       code: `
+import { ReexportedError } from 'reexported-error/star';
+declare const error: ReexportedError;
+throw error;
+      `,
+      errors: [{ messageId: 'object' }],
+      options: [
+        {
+          allow: [
+            {
+              from: 'package',
+              name: 'ReexportedError',
+              package: 'reexported-error/star',
+            },
+          ],
+          allowThrowingAny: false,
+          allowThrowingUnknown: false,
+        },
+      ],
+    },
+    {
+      code: `
+import { errors } from 'reexported-error/namespace';
+throw new errors.ReexportedError();
+      `,
+      errors: [{ messageId: 'object' }],
+      options: [
+        {
+          allow: [
+            {
+              from: 'package',
+              name: 'ReexportedError',
+              package: 'reexported-error/namespace',
+            },
+          ],
+          allowThrowingAny: false,
+          allowThrowingUnknown: false,
+        },
+      ],
+    },
+    {
+      code: `
 class Foo {}
 class CustomError extends Foo {}
 throw new CustomError();

--- a/packages/eslint-plugin/tests/rules/only-throw-error.test.ts
+++ b/packages/eslint-plugin/tests/rules/only-throw-error.test.ts
@@ -182,6 +182,26 @@ throw createError();
     },
     {
       code: `
+import { ReexportedError } from 'reexported-error/public';
+declare const error: ReexportedError;
+throw error;
+      `,
+      options: [
+        {
+          allow: [
+            {
+              from: 'package',
+              name: 'ReexportedError',
+              package: 'reexported-error/public',
+            },
+          ],
+          allowThrowingAny: false,
+          allowThrowingUnknown: false,
+        },
+      ],
+    },
+    {
+      code: `
 function func<T1, T2>() {
   let err: Promise<T1> | Promise<T2>;
   throw err;
@@ -456,6 +476,27 @@ throw new CustomError();
       errors: [
         {
           messageId: 'object',
+        },
+      ],
+    },
+    {
+      code: `
+import { ReexportedError } from 'reexported-error/public';
+declare const error: ReexportedError;
+throw error;
+      `,
+      errors: [{ messageId: 'object' }],
+      options: [
+        {
+          allow: [
+            {
+              from: 'package',
+              name: 'ReexportedError',
+              package: 'other-package',
+            },
+          ],
+          allowThrowingAny: false,
+          allowThrowingUnknown: false,
         },
       ],
     },

--- a/packages/type-utils/src/typeOrValueSpecifiers/typeDeclaredInPackageDeclarationFile.ts
+++ b/packages/type-utils/src/typeOrValueSpecifiers/typeDeclaredInPackageDeclarationFile.ts
@@ -1,5 +1,5 @@
-import * as ts from 'typescript';
 import * as tsutils from 'ts-api-utils';
+import * as ts from 'typescript';
 
 function findParentModuleDeclaration(
   node: ts.Node,

--- a/packages/type-utils/src/typeOrValueSpecifiers/typeDeclaredInPackageDeclarationFile.ts
+++ b/packages/type-utils/src/typeOrValueSpecifiers/typeDeclaredInPackageDeclarationFile.ts
@@ -1,4 +1,5 @@
 import * as ts from 'typescript';
+import * as tsutils from 'ts-api-utils';
 
 function findParentModuleDeclaration(
   node: ts.Node,
@@ -72,7 +73,7 @@ function exportSpecifierMatchesDeclaration(
 ): boolean {
   const symbol = checker.getSymbolAtLocation(specifier.name);
   const exportedSymbol =
-    symbol != null && symbol.flags & ts.SymbolFlags.Alias
+    symbol != null && tsutils.isSymbolFlagSet(symbol, ts.SymbolFlags.Alias)
       ? checker.getAliasedSymbol(symbol)
       : symbol;
 

--- a/packages/type-utils/src/typeOrValueSpecifiers/typeDeclaredInPackageDeclarationFile.ts
+++ b/packages/type-utils/src/typeOrValueSpecifiers/typeDeclaredInPackageDeclarationFile.ts
@@ -28,21 +28,85 @@ function typeDeclaredInDeclareModule(
   );
 }
 
-function typeDeclaredInDeclarationFile(
+function packageNameMatches(
   packageName: string,
-  declarationFiles: ts.SourceFile[],
-  program: ts.Program,
+  packageIdName: string,
 ): boolean {
   // Handle scoped packages: if the name starts with @, remove it and replace / with __
   const typesPackageName = packageName.replace(/^@([^/]+)\//, '$1__');
 
   const matcher = new RegExp(`${packageName}|${typesPackageName}`);
+  return matcher.test(packageIdName);
+}
+
+function typeDeclaredInDeclarationFile(
+  packageName: string,
+  declarationFiles: ts.SourceFile[],
+  program: ts.Program,
+): boolean {
   return declarationFiles.some(declaration => {
     const packageIdName = program.sourceFileToPackageName.get(declaration.path);
     return (
       packageIdName != null &&
-      matcher.test(packageIdName) &&
+      packageNameMatches(packageName, packageIdName) &&
       program.isSourceFileFromExternalLibrary(declaration)
+    );
+  });
+}
+
+function symbolHasDeclaration(
+  declarations: ts.Node[],
+  symbol: ts.Symbol | undefined,
+): boolean {
+  return (
+    symbol
+      ?.getDeclarations()
+      ?.some(declaration => declarations.includes(declaration)) ?? false
+  );
+}
+
+function exportSpecifierMatchesDeclaration(
+  declarations: ts.Node[],
+  checker: ts.TypeChecker,
+  specifier: ts.ExportSpecifier,
+): boolean {
+  const symbol = checker.getSymbolAtLocation(specifier.name);
+  const exportedSymbol =
+    symbol != null && symbol.flags & ts.SymbolFlags.Alias
+      ? checker.getAliasedSymbol(symbol)
+      : symbol;
+
+  return symbolHasDeclaration(declarations, exportedSymbol);
+}
+
+function typeReExportedFromDeclarationFile(
+  packageName: string,
+  declarations: ts.Node[],
+  program: ts.Program,
+): boolean {
+  const checker = program.getTypeChecker();
+
+  return program.getSourceFiles().some(sourceFile => {
+    if (!program.isSourceFileFromExternalLibrary(sourceFile)) {
+      return false;
+    }
+
+    const packageIdName = program.sourceFileToPackageName.get(sourceFile.path);
+    if (
+      packageIdName == null ||
+      !packageNameMatches(packageName, packageIdName)
+    ) {
+      return false;
+    }
+
+    return sourceFile.statements.some(
+      statement =>
+        ts.isExportDeclaration(statement) &&
+        statement.exportClause != null &&
+        ts.isNamedExports(statement.exportClause) &&
+        statement.exportClause.elements.some(specifier =>
+          exportSpecifierMatchesDeclaration(declarations, checker, specifier),
+        ),
     );
   });
 }
@@ -55,6 +119,7 @@ export function typeDeclaredInPackageDeclarationFile(
 ): boolean {
   return (
     typeDeclaredInDeclareModule(packageName, declarations) ||
-    typeDeclaredInDeclarationFile(packageName, declarationFiles, program)
+    typeDeclaredInDeclarationFile(packageName, declarationFiles, program) ||
+    typeReExportedFromDeclarationFile(packageName, declarations, program)
   );
 }

--- a/packages/type-utils/src/typeOrValueSpecifiers/typeDeclaredInPackageDeclarationFile.ts
+++ b/packages/type-utils/src/typeOrValueSpecifiers/typeDeclaredInPackageDeclarationFile.ts
@@ -57,12 +57,16 @@ function typeDeclaredInDeclarationFile(
 
 function symbolHasDeclaration(
   declarations: ts.Node[],
-  symbol: ts.Symbol | undefined,
+  symbol: ts.Symbol,
 ): boolean {
-  return (
-    symbol
-      ?.getDeclarations()
-      ?.some(declaration => declarations.includes(declaration)) ?? false
+  const symbolDeclarations = symbol.getDeclarations();
+  /* istanbul ignore if -- defensive for unresolved export specifiers. */
+  if (symbolDeclarations == null) {
+    return false;
+  }
+
+  return symbolDeclarations.some(declaration =>
+    declarations.includes(declaration),
   );
 }
 
@@ -72,12 +76,18 @@ function exportSpecifierMatchesDeclaration(
   specifier: ts.ExportSpecifier,
 ): boolean {
   const symbol = checker.getSymbolAtLocation(specifier.name);
-  const exportedSymbol =
-    symbol != null && tsutils.isSymbolFlagSet(symbol, ts.SymbolFlags.Alias)
-      ? checker.getAliasedSymbol(symbol)
-      : symbol;
+  /* istanbul ignore if -- TypeScript provides symbols for parsed export specifiers. */
+  if (symbol == null) {
+    return false;
+  }
 
-  return symbolHasDeclaration(declarations, exportedSymbol);
+  /* istanbul ignore else -- named export specifiers are aliases; keep a fallback for checker edge cases. */
+  if (tsutils.isSymbolFlagSet(symbol, ts.SymbolFlags.Alias)) {
+    const exportedSymbol = checker.getAliasedSymbol(symbol);
+    return symbolHasDeclaration(declarations, exportedSymbol);
+  }
+
+  return symbolHasDeclaration(declarations, symbol);
 }
 
 function typeReExportedFromDeclarationFile(

--- a/packages/type-utils/src/typeOrValueSpecifiers/typeDeclaredInPackageDeclarationFile.ts
+++ b/packages/type-utils/src/typeOrValueSpecifiers/typeDeclaredInPackageDeclarationFile.ts
@@ -36,8 +36,45 @@ function packageNameMatches(
   // Handle scoped packages: if the name starts with @, remove it and replace / with __
   const typesPackageName = packageName.replace(/^@([^/]+)\//, '$1__');
 
-  const matcher = new RegExp(`${packageName}|${typesPackageName}`);
-  return matcher.test(packageIdName);
+  return (
+    packageIdName.includes(packageName) ||
+    packageIdName.includes(typesPackageName)
+  );
+}
+
+const reExportSourceFilesCache = new WeakMap<
+  ts.Program,
+  Map<string, ts.SourceFile[]>
+>();
+
+function getExternalSourceFilesForPackage(
+  packageName: string,
+  program: ts.Program,
+): ts.SourceFile[] {
+  let packageCache = reExportSourceFilesCache.get(program);
+  if (packageCache == null) {
+    packageCache = new Map();
+    reExportSourceFilesCache.set(program, packageCache);
+  }
+
+  const cached = packageCache.get(packageName);
+  if (cached != null) {
+    return cached;
+  }
+
+  const sourceFiles = program.getSourceFiles().filter(sourceFile => {
+    if (!program.isSourceFileFromExternalLibrary(sourceFile)) {
+      return false;
+    }
+
+    const packageIdName = program.sourceFileToPackageName.get(sourceFile.path);
+    return (
+      packageIdName != null && packageNameMatches(packageName, packageIdName)
+    );
+  });
+
+  packageCache.set(packageName, sourceFiles);
+  return sourceFiles;
 }
 
 function typeDeclaredInDeclarationFile(
@@ -101,38 +138,26 @@ function typeReExportedFromDeclarationFile(
 ): boolean {
   const checker = program.getTypeChecker();
 
-  return program.getSourceFiles().some(sourceFile => {
-    if (!program.isSourceFileFromExternalLibrary(sourceFile)) {
-      return false;
-    }
+  return getExternalSourceFilesForPackage(packageName, program).some(
+    sourceFile =>
+      sourceFile.statements.some(statement => {
+        if (!ts.isExportDeclaration(statement)) {
+          return false;
+        }
 
-    const packageIdName = program.sourceFileToPackageName.get(sourceFile.path);
-    if (packageIdName == null) {
-      return false;
-    }
+        if (statement.exportClause == null) {
+          return false;
+        }
 
-    if (!packageNameMatches(packageName, packageIdName)) {
-      return false;
-    }
+        if (!ts.isNamedExports(statement.exportClause)) {
+          return false;
+        }
 
-    return sourceFile.statements.some(statement => {
-      if (!ts.isExportDeclaration(statement)) {
-        return false;
-      }
-
-      if (statement.exportClause == null) {
-        return false;
-      }
-
-      if (!ts.isNamedExports(statement.exportClause)) {
-        return false;
-      }
-
-      return statement.exportClause.elements.some(specifier =>
-        exportSpecifierMatchesDeclaration(declarations, checker, specifier),
-      );
-    });
-  });
+        return statement.exportClause.elements.some(specifier =>
+          exportSpecifierMatchesDeclaration(declarations, checker, specifier),
+        );
+      }),
+  );
 }
 
 export function typeDeclaredInPackageDeclarationFile(

--- a/packages/type-utils/src/typeOrValueSpecifiers/typeDeclaredInPackageDeclarationFile.ts
+++ b/packages/type-utils/src/typeOrValueSpecifiers/typeDeclaredInPackageDeclarationFile.ts
@@ -47,11 +47,15 @@ function typeDeclaredInDeclarationFile(
 ): boolean {
   return declarationFiles.some(declaration => {
     const packageIdName = program.sourceFileToPackageName.get(declaration.path);
-    return (
-      packageIdName != null &&
-      packageNameMatches(packageName, packageIdName) &&
-      program.isSourceFileFromExternalLibrary(declaration)
-    );
+    if (packageIdName == null) {
+      return false;
+    }
+
+    if (!packageNameMatches(packageName, packageIdName)) {
+      return false;
+    }
+
+    return program.isSourceFileFromExternalLibrary(declaration);
   });
 }
 
@@ -103,22 +107,31 @@ function typeReExportedFromDeclarationFile(
     }
 
     const packageIdName = program.sourceFileToPackageName.get(sourceFile.path);
-    if (
-      packageIdName == null ||
-      !packageNameMatches(packageName, packageIdName)
-    ) {
+    if (packageIdName == null) {
       return false;
     }
 
-    return sourceFile.statements.some(
-      statement =>
-        ts.isExportDeclaration(statement) &&
-        statement.exportClause != null &&
-        ts.isNamedExports(statement.exportClause) &&
-        statement.exportClause.elements.some(specifier =>
-          exportSpecifierMatchesDeclaration(declarations, checker, specifier),
-        ),
-    );
+    if (!packageNameMatches(packageName, packageIdName)) {
+      return false;
+    }
+
+    return sourceFile.statements.some(statement => {
+      if (!ts.isExportDeclaration(statement)) {
+        return false;
+      }
+
+      if (statement.exportClause == null) {
+        return false;
+      }
+
+      if (!ts.isNamedExports(statement.exportClause)) {
+        return false;
+      }
+
+      return statement.exportClause.elements.some(specifier =>
+        exportSpecifierMatchesDeclaration(declarations, checker, specifier),
+      );
+    });
   });
 }
 

--- a/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
+++ b/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
@@ -608,6 +608,14 @@ describe('TypeOrValueSpecifier', () => {
           package: 'reexported-error/namespace',
         },
       ],
+      [
+        'import type { ReexportedError } from "reexported-error/public"; type Test = ReexportedError;',
+        {
+          from: 'package',
+          name: 'ReexportedError',
+          package: 'reexported.error/public',
+        },
+      ],
     ] as const satisfies [string, TypeOrValueSpecifier][])(
       "doesn't match a mismatched package specifier: %s\n\t%s",
       ([code, typeOrValueSpecifier], { expect }) => {
@@ -937,11 +945,41 @@ describe('TypeOrValueSpecifier', () => {
     it.each<[string, TypeOrValueSpecifier[]]>([
       ['interface Foo {prop: string}; type Test = Foo;', ['Foo', 'Hoge']],
       ['type Test = RegExp;', ['RegExp', 'BigInt']],
+      [
+        'import type { ReexportedError } from "reexported-error/public"; type Test = ReexportedError;',
+        [
+          {
+            from: 'package',
+            name: 'OtherError',
+            package: 'reexported-error/public',
+          },
+          {
+            from: 'package',
+            name: 'ReexportedError',
+            package: 'reexported-error/public',
+          },
+        ],
+      ],
     ])('matches a matching universal string specifiers', runTestPositive);
 
     it.each<[string, TypeOrValueSpecifier[]]>([
       ['interface Foo {prop: string}; type Test = Foo;', ['Bar', 'Hoge']],
       ['type Test = RegExp;', ['Foo', 'BigInt']],
+      [
+        'import type { ReexportedError } from "reexported-error/star"; type Test = ReexportedError;',
+        [
+          {
+            from: 'package',
+            name: 'ReexportedError',
+            package: 'reexported-error/star',
+          },
+          {
+            from: 'package',
+            name: ['ReexportedError'],
+            package: 'reexported-error/star',
+          },
+        ],
+      ],
     ])(
       "doesn't match a mismatched universal string specifiers",
       runTestNegative,

--- a/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
+++ b/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
@@ -431,6 +431,14 @@ describe('TypeOrValueSpecifier', () => {
           package: 'assert',
         },
       ],
+      [
+        'import type { ReexportedError } from "reexported-error/public"; type Test = ReexportedError;',
+        {
+          from: 'package',
+          name: 'ReexportedError',
+          package: 'reexported-error/public',
+        },
+      ],
     ] as const satisfies [string, TypeOrValueSpecifier][])(
       'matches a matching package specifier: %s\n\t%s',
       ([code, typeOrValueSpecifier], { expect }) => {
@@ -575,6 +583,22 @@ describe('TypeOrValueSpecifier', () => {
       [
         'import type {Node as TsNode} from "typescript"; type Test = TsNode;',
         { from: 'package', name: 'TsNode', package: 'typescript' },
+      ],
+      [
+        'import type { ReexportedError } from "reexported-error/star"; type Test = ReexportedError;',
+        {
+          from: 'package',
+          name: 'ReexportedError',
+          package: 'reexported-error/star',
+        },
+      ],
+      [
+        'import type { errors } from "reexported-error/namespace"; type Test = errors.ReexportedError;',
+        {
+          from: 'package',
+          name: 'ReexportedError',
+          package: 'reexported-error/namespace',
+        },
       ],
     ] as const satisfies [string, TypeOrValueSpecifier][])(
       "doesn't match a mismatched package specifier: %s\n\t%s",

--- a/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
+++ b/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
@@ -439,6 +439,14 @@ describe('TypeOrValueSpecifier', () => {
           package: 'reexported-error/public',
         },
       ],
+      [
+        'import type { ReexportedError } from "reexported-error/mixed"; type Test = ReexportedError;',
+        {
+          from: 'package',
+          name: 'ReexportedError',
+          package: 'reexported-error/mixed',
+        },
+      ],
     ] as const satisfies [string, TypeOrValueSpecifier][])(
       'matches a matching package specifier: %s\n\t%s',
       ([code, typeOrValueSpecifier], { expect }) => {

--- a/packages/type-utils/tests/fixtures/node_modules/reexported-error/internal.d.ts
+++ b/packages/type-utils/tests/fixtures/node_modules/reexported-error/internal.d.ts
@@ -1,0 +1,1 @@
+export class ReexportedError {}

--- a/packages/type-utils/tests/fixtures/node_modules/reexported-error/mixed.d.ts
+++ b/packages/type-utils/tests/fixtures/node_modules/reexported-error/mixed.d.ts
@@ -1,2 +1,4 @@
+declare const localMarker: unique symbol;
+
 export { OtherError } from './other';
 export { ReexportedError } from './internal';

--- a/packages/type-utils/tests/fixtures/node_modules/reexported-error/mixed.d.ts
+++ b/packages/type-utils/tests/fixtures/node_modules/reexported-error/mixed.d.ts
@@ -1,0 +1,2 @@
+export { OtherError } from './other';
+export { ReexportedError } from './internal';

--- a/packages/type-utils/tests/fixtures/node_modules/reexported-error/namespace.d.ts
+++ b/packages/type-utils/tests/fixtures/node_modules/reexported-error/namespace.d.ts
@@ -1,0 +1,1 @@
+export * as errors from './internal';

--- a/packages/type-utils/tests/fixtures/node_modules/reexported-error/other.d.ts
+++ b/packages/type-utils/tests/fixtures/node_modules/reexported-error/other.d.ts
@@ -1,0 +1,1 @@
+export class OtherError {}

--- a/packages/type-utils/tests/fixtures/node_modules/reexported-error/package.json
+++ b/packages/type-utils/tests/fixtures/node_modules/reexported-error/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "reexported-error",
+  "version": "1.0.0"
+}

--- a/packages/type-utils/tests/fixtures/node_modules/reexported-error/public.d.ts
+++ b/packages/type-utils/tests/fixtures/node_modules/reexported-error/public.d.ts
@@ -1,0 +1,1 @@
+export { ReexportedError } from './internal';

--- a/packages/type-utils/tests/fixtures/node_modules/reexported-error/star.d.ts
+++ b/packages/type-utils/tests/fixtures/node_modules/reexported-error/star.d.ts
@@ -1,0 +1,1 @@
+export * from './internal';


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #11817
- [x] That issue was marked as accepting prs
- [x] Steps in Contributing were taken
- [x] If this PR used AI assistance, I followed the AI Contribution Policy

## Overview

Fixes #11817. Package specifiers missed public subpaths that re-export internal declarations.

Fix: Add `typeReExportedFromDeclarationFile()` to match named re-exports whose aliased symbol resolves to the same declaration.

Test: Added fixture coverage for public, mixed, star, and namespace re-export cases.
