### PR TITLE
test: improve vitest performance with `isolate: false`

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -69,6 +69,7 @@
       "options": {
         "config": "vitest.config.mts"
       },
+      "inputs": ["default", "{workspaceRoot}/vitest.config.base.mts"],
       "outputs": ["{projectRoot}/coverage"]
     },
     "attw-check": {

--- a/packages/eslint-plugin/vitest.config.mts
+++ b/packages/eslint-plugin/vitest.config.mts
@@ -12,7 +12,6 @@ const vitestConfig = mergeConfig(
 
     test: {
       dir: path.join(import.meta.dirname, 'tests'),
-      isolate: false,
       name: packageJson.name.replace('@typescript-eslint/', ''),
       root: import.meta.dirname,
 

--- a/packages/integration-tests/tools/integration-test-base.ts
+++ b/packages/integration-tests/tools/integration-test-base.ts
@@ -3,9 +3,6 @@ import * as path from 'node:path';
 
 import { execFile, FIXTURES_DESTINATION_DIR } from './pack-packages.js';
 
-// make sure that vitest doesn't timeout the test
-vi.setConfig({ testTimeout: 60_000 });
-
 function integrationTest(
   testName: string,
   testFilename: string,

--- a/packages/integration-tests/vitest.config.mts
+++ b/packages/integration-tests/vitest.config.mts
@@ -15,6 +15,7 @@ const vitestConfig = mergeConfig(
       globalSetup: ['./tools/pack-packages.ts'],
       name: packageJson.name.replace('@typescript-eslint/', ''),
       root: import.meta.dirname,
+      testTimeout: 60_000,
     },
   }),
 );

--- a/packages/typescript-estree/vitest.config.mts
+++ b/packages/typescript-estree/vitest.config.mts
@@ -17,6 +17,7 @@ const vitestConfig = mergeConfig(
         ? [...defaultExclude, 'parse.project-true.test.ts']
         : [...defaultExclude],
 
+      isolate: true,
       name: packageJson.name.replace('@typescript-eslint/', ''),
       root: import.meta.dirname,
       setupFiles: ['./tests/test-utils/custom-matchers/custom-matchers.ts'],

--- a/vitest.config.base.mts
+++ b/vitest.config.base.mts
@@ -15,6 +15,7 @@ export const vitestBaseConfig = {
 
     globals: true,
     include: ['**/*.test.?(c|m)ts?(x)'],
+    isolate: false,
 
     reporters: process.env.GITHUB_ACTIONS
       ? [['default', { summary: false }], ['github-actions']]


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [X] Addresses an existing open issue: Related #11204
- [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [X] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

Basically continuing on #11754. Most of them are within the margin of error, but the top 2 are showing nice gains (M4 Pro, 24GB). typescript-estree is the only one that's failing without isolation:

<details>
<summary>scope-manager (+96%)</summary>

```text
$ hyperfine "CI=true pnpm vitest" "CI=true FAST=true pnpm vitest"
Benchmark 1: CI=true pnpm vitest
  Time (mean ± σ):      5.563 s ±  0.904 s    [User: 15.220 s, System: 3.618 s]
  Range (min … max):    4.696 s …  7.583 s    10 runs
 
Benchmark 2: CI=true FAST=true pnpm vitest
  Time (mean ± σ):      2.842 s ±  0.458 s    [User: 6.137 s, System: 1.485 s]
  Range (min … max):    2.319 s …  3.475 s    10 runs
 
Summary
  CI=true FAST=true pnpm vitest ran
    1.96 ± 0.45 times faster than CI=true pnpm vitest
```

</details>

<details>
<summary>type-utils (+8%)</summary>

```text
$ hyperfine "CI=true pnpm vitest" "CI=true FAST=true pnpm vitest"
Benchmark 1: CI=true pnpm vitest
  Time (mean ± σ):      4.866 s ±  1.051 s    [User: 16.001 s, System: 3.041 s]
  Range (min … max):    3.965 s …  7.029 s    10 runs
 
Benchmark 2: CI=true FAST=true pnpm vitest
  Time (mean ± σ):      4.507 s ±  0.502 s    [User: 15.774 s, System: 2.694 s]
  Range (min … max):    3.981 s …  5.521 s    10 runs
 
Summary
  CI=true FAST=true pnpm vitest ran
    1.08 ± 0.26 times faster than CI=true pnpm vitest
```

</details>

<details>
<summary>project-service (+4%, margin of error)</summary>

```text
$ hyperfine "CI=true pnpm vitest" "CI=true FAST=true pnpm vitest"
Benchmark 1: CI=true pnpm vitest
  Time (mean ± σ):     863.1 ms ± 119.1 ms    [User: 877.7 ms, System: 167.6 ms]
  Range (min … max):   780.1 ms … 1160.4 ms    10 runs
 
Benchmark 2: CI=true FAST=true pnpm vitest
  Time (mean ± σ):     832.9 ms ±  51.9 ms    [User: 857.7 ms, System: 161.1 ms]
  Range (min … max):   783.8 ms … 963.1 ms    10 runs
 
Summary
  CI=true FAST=true pnpm vitest ran
    1.04 ± 0.16 times faster than CI=true pnpm vitest
```

</details>

<details>
<summary>rule-schema-to-typescript-types (+4%, margin of error)</summary>

```text
$ hyperfine "CI=true pnpm vitest" "CI=true FAST=true pnpm vitest"
Benchmark 1: CI=true pnpm vitest
  Time (mean ± σ):      1.008 s ±  0.078 s    [User: 0.946 s, System: 0.195 s]
  Range (min … max):    0.924 s …  1.160 s    10 runs

Benchmark 2: CI=true FAST=true pnpm vitest
  Time (mean ± σ):     971.4 ms ± 115.0 ms    [User: 926.2 ms, System: 184.0 ms]
  Range (min … max):   896.1 ms … 1285.5 ms    10 runs

Summary
  CI=true FAST=true pnpm vitest ran
    1.04 ± 0.15 times faster than CI=true pnpm vitest
```

</details>

<details>
<summary>parser (+2%, margin of error)</summary>

```text
$ hyperfine "CI=true pnpm vitest" "CI=true FAST=true pnpm vitest"
Benchmark 1: CI=true pnpm vitest
  Time (mean ± σ):      1.729 s ±  0.148 s    [User: 4.073 s, System: 0.581 s]
  Range (min … max):    1.577 s …  1.998 s    10 runs
 
Benchmark 2: CI=true FAST=true pnpm vitest
  Time (mean ± σ):      1.701 s ±  0.139 s    [User: 4.074 s, System: 0.571 s]
  Range (min … max):    1.587 s …  1.969 s    10 runs
 
Summary
  CI=true FAST=true pnpm vitest ran
    1.02 ± 0.12 times faster than CI=true pnpm vitest
```

</details>

<details>
<summary>utils (+2%, margin of error)</summary>

```text
$ hyperfine "CI=true pnpm vitest" "CI=true FAST=true pnpm vitest"
Benchmark 1: CI=true pnpm vitest
  Time (mean ± σ):      1.249 s ±  0.146 s    [User: 2.206 s, System: 0.629 s]
  Range (min … max):    1.096 s …  1.497 s    10 runs
 
Benchmark 2: CI=true FAST=true pnpm vitest
  Time (mean ± σ):      1.229 s ±  0.122 s    [User: 2.238 s, System: 0.634 s]
  Range (min … max):    1.108 s …  1.463 s    10 runs
 
Summary
  CI=true FAST=true pnpm vitest ran
    1.02 ± 0.16 times faster than CI=true pnpm vitest
```

</details>

<details>
<summary>rule-tester (+1%, margin of error)</summary>

```text
$ hyperfine "CI=true pnpm vitest" "CI=true FAST=true pnpm vitest"
Benchmark 1: CI=true pnpm vitest
  Time (mean ± σ):      1.202 s ±  0.130 s    [User: 1.800 s, System: 0.357 s]
  Range (min … max):    1.051 s …  1.410 s    10 runs
 
Benchmark 2: CI=true FAST=true pnpm vitest
  Time (mean ± σ):      1.188 s ±  0.109 s    [User: 1.801 s, System: 0.357 s]
  Range (min … max):    1.052 s …  1.364 s    10 runs
 
Summary
  CI=true FAST=true pnpm vitest ran
    1.01 ± 0.14 times faster than CI=true pnpm vitest
```

</details>

<details>
<summary>tsconfig-utils (+1%, margin of error)</summary>

```text
$ hyperfine "CI=true pnpm vitest" "CI=true FAST=true pnpm vitest"
Benchmark 1: CI=true pnpm vitest
  Time (mean ± σ):     841.2 ms ±  74.9 ms    [User: 734.5 ms, System: 137.1 ms]
  Range (min … max):   766.8 ms … 1025.4 ms    10 runs
 
Benchmark 2: CI=true FAST=true pnpm vitest
  Time (mean ± σ):     831.0 ms ±  57.6 ms    [User: 728.3 ms, System: 131.2 ms]
  Range (min … max):   778.5 ms … 933.1 ms    10 runs
 
Summary
  CI=true FAST=true pnpm vitest ran
    1.01 ± 0.11 times faster than CI=true pnpm vitest
```

</details>

<details>
<summary>typescript-eslint (+1%, margin of error)</summary>

```text
$ hyperfine "CI=true pnpm vitest" "CI=true FAST=true pnpm vitest"
Benchmark 1: CI=true pnpm vitest
  Time (mean ± σ):      1.505 s ±  0.179 s    [User: 2.841 s, System: 0.658 s]
  Range (min … max):    1.355 s …  1.882 s    10 runs
 
Benchmark 2: CI=true FAST=true pnpm vitest
  Time (mean ± σ):      1.488 s ±  0.133 s    [User: 2.959 s, System: 0.668 s]
  Range (min … max):    1.357 s …  1.708 s    10 runs
 
Summary
  CI=true FAST=true pnpm vitest ran
    1.01 ± 0.15 times faster than CI=true pnpm vitest
```

</details>

<details>
<summary>visitor-keys (+1%, margin of error)</summary>

```text
$ hyperfine "CI=true pnpm vitest" "CI=true FAST=true pnpm vitest"
Benchmark 1: CI=true pnpm vitest
  Time (mean ± σ):     782.8 ms ± 115.9 ms    [User: 719.5 ms, System: 141.6 ms]
  Range (min … max):   689.6 ms … 1057.0 ms    10 runs
 
Benchmark 2: CI=true FAST=true pnpm vitest
  Time (mean ± σ):     776.2 ms ± 120.5 ms    [User: 733.6 ms, System: 137.8 ms]
  Range (min … max):   676.5 ms … 1046.8 ms    10 runs
 
Summary
  CI=true FAST=true pnpm vitest ran
    1.01 ± 0.22 times faster than CI=true pnpm vitest
```

</details>

<details>
<summary>ast-spec (-2%, margin of error)</summary>

```text
$ hyperfine "CI=true pnpm vitest" "CI=true FAST=true pnpm vitest"
Benchmark 1: CI=true pnpm vitest
  Time (mean ± σ):      3.851 s ±  0.411 s    [User: 4.282 s, System: 1.426 s]
  Range (min … max):    3.394 s …  4.503 s    10 runs
 
Benchmark 2: CI=true FAST=true pnpm vitest
  Time (mean ± σ):      3.941 s ±  0.385 s    [User: 4.364 s, System: 1.440 s]
  Range (min … max):    3.382 s …  4.386 s    10 runs
 
Summary
  CI=true pnpm vitest ran
    1.02 ± 0.15 times faster than CI=true FAST=true pnpm vitest
```

</details>

<details>
<summary>integration-tests (-3%, margin of error)</summary>

```text
$ hyperfine "CI=true pnpm vitest" "CI=true FAST=true pnpm vitest" --runs=3
Benchmark 1: CI=true pnpm vitest
  Time (mean ± σ):     37.114 s ±  2.457 s    [User: 84.069 s, System: 40.876 s]
  Range (min … max):   35.390 s … 39.927 s    3 runs
 
Benchmark 2: CI=true FAST=true pnpm vitest
  Time (mean ± σ):     38.358 s ±  3.666 s    [User: 83.407 s, System: 41.612 s]
  Range (min … max):   35.940 s … 42.576 s    3 runs
 
Summary
  CI=true pnpm vitest ran
    1.03 ± 0.12 times faster than CI=true FAST=true pnpm vitest
```

</details>

<details>
<summary>eslint-plugin-internal (-4%, margin of error)</summary>

```text
$ hyperfine "CI=true pnpm vitest" "CI=true FAST=true pnpm vitest"
Benchmark 1: CI=true pnpm vitest
  Time (mean ± σ):      2.945 s ±  0.139 s    [User: 8.212 s, System: 1.596 s]
  Range (min … max):    2.749 s …  3.162 s    10 runs
 
Benchmark 2: CI=true FAST=true pnpm vitest
  Time (mean ± σ):      3.060 s ±  0.466 s    [User: 8.302 s, System: 1.619 s]
  Range (min … max):    2.634 s …  3.959 s    10 runs
 
Summary
  CI=true pnpm vitest ran
    1.04 ± 0.17 times faster than CI=true FAST=true pnpm vitest
```

</details>