### PR TITLE
fix(eslint-plugin): [no-deprecated] report deprecated properties in object literals

### DIFF
--- a/packages/eslint-plugin/src/rules/no-deprecated.ts
+++ b/packages/eslint-plugin/src/rules/no-deprecated.ts
@@ -333,6 +333,22 @@ export default createRule<Options, MessageIds>({
       return getJsDocDeprecation(symbol);
     }
 
+    function getObjectLiteralPropertyDeprecation(
+      node: TSESTree.Identifier,
+    ): string | undefined {
+      if (node.parent.parent?.type !== AST_NODE_TYPES.ObjectExpression) {
+        return;
+      }
+      const contextualType = services.getContextualType(node.parent.parent);
+      if (!contextualType) {
+        return;
+      }
+
+      const symbol = contextualType.getProperty(node.name);
+
+      return getJsDocDeprecation(symbol);
+    }
+
     function getDeprecationReason(node: IdentifierLike): string | undefined {
       const callLikeNode = getCallLikeNode(node);
       if (callLikeNode) {
@@ -344,6 +360,10 @@ export default createRule<Options, MessageIds>({
         node.type !== AST_NODE_TYPES.Super
       ) {
         return getJSXAttributeDeprecation(node.parent.parent, node.name);
+      }
+
+      if (isObjectLiteralPropertyKey(node)) {
+        return getObjectLiteralPropertyDeprecation(node);
       }
 
       if (
@@ -372,7 +392,10 @@ export default createRule<Options, MessageIds>({
     }
 
     function checkIdentifier(node: IdentifierLike): void {
-      if (isDeclaration(node) || isInsideImport(node)) {
+      if (
+        (isDeclaration(node) && !isObjectLiteralPropertyKey(node)) ||
+        isInsideImport(node)
+      ) {
         return;
       }
 
@@ -506,4 +529,16 @@ function getReportedNodeName(node: IdentifierLike): string {
   }
 
   return node.name;
+}
+
+function isObjectLiteralPropertyKey(
+  node: TSESTree.Node,
+): node is TSESTree.Identifier {
+  return (
+    node.type === AST_NODE_TYPES.Identifier &&
+    node.parent.type === AST_NODE_TYPES.Property &&
+    node.parent.key === node &&
+    !node.parent.computed &&
+    node.parent.parent.type === AST_NODE_TYPES.ObjectExpression
+  );
 }

--- a/packages/eslint-plugin/src/rules/no-deprecated.ts
+++ b/packages/eslint-plugin/src/rules/no-deprecated.ts
@@ -334,17 +334,15 @@ export default createRule<Options, MessageIds>({
     }
 
     function getObjectLiteralPropertyDeprecation(
-      node: TSESTree.Identifier,
+      objectExpression: TSESTree.ObjectExpression,
+      propertyName: string,
     ): string | undefined {
-      if (node.parent.parent?.type !== AST_NODE_TYPES.ObjectExpression) {
-        return;
-      }
-      const contextualType = services.getContextualType(node.parent.parent);
+      const contextualType = services.getContextualType(objectExpression);
       if (!contextualType) {
         return;
       }
 
-      const symbol = contextualType.getProperty(node.name);
+      const symbol = contextualType.getProperty(propertyName);
 
       return getJsDocDeprecation(symbol);
     }
@@ -363,7 +361,10 @@ export default createRule<Options, MessageIds>({
       }
 
       if (isObjectLiteralPropertyKey(node)) {
-        return getObjectLiteralPropertyDeprecation(node);
+        return getObjectLiteralPropertyDeprecation(
+          node.parent.parent,
+          node.name,
+        );
       }
 
       if (
@@ -545,7 +546,9 @@ function getReportedNodeName(node: IdentifierLike): string {
  */
 function isObjectLiteralPropertyKey(
   node: TSESTree.Node,
-): node is TSESTree.Identifier {
+): node is TSESTree.Identifier & {
+  parent: TSESTree.Property & { parent: TSESTree.ObjectExpression };
+} {
   return (
     node.type === AST_NODE_TYPES.Identifier &&
     node.parent.type === AST_NODE_TYPES.Property &&
@@ -567,13 +570,11 @@ function isObjectExpressionAssignedToVariable(
       return node.parent.right === node;
 
     case AST_NODE_TYPES.Property:
-      if (
+      return (
         node.parent.value === node &&
-        node.parent.parent.type === AST_NODE_TYPES.ObjectExpression
-      ) {
-        return isObjectExpressionAssignedToVariable(node.parent.parent);
-      }
-      return false;
+        node.parent.parent.type === AST_NODE_TYPES.ObjectExpression &&
+        isObjectExpressionAssignedToVariable(node.parent.parent)
+      );
 
     default:
       return false;

--- a/packages/eslint-plugin/src/rules/no-deprecated.ts
+++ b/packages/eslint-plugin/src/rules/no-deprecated.ts
@@ -531,6 +531,18 @@ function getReportedNodeName(node: IdentifierLike): string {
   return node.name;
 }
 
+/**
+ * Whether the node is the key of a non-computed property in an object literal
+ * that is assigned to a variable, such as `const x: Foo = { key: 1 }`.
+ *
+ * Such a key refers to a property of the object literal's contextual type,
+ * rather than declaring a new property of its own.
+ *
+ * Object literals in other positions also have a contextual type (call
+ * arguments, `return` statements, array elements), but they are deliberately
+ * left out of scope: covering all of them produces a very large number of new
+ * reports.
+ */
 function isObjectLiteralPropertyKey(
   node: TSESTree.Node,
 ): node is TSESTree.Identifier {
@@ -539,6 +551,31 @@ function isObjectLiteralPropertyKey(
     node.parent.type === AST_NODE_TYPES.Property &&
     node.parent.key === node &&
     !node.parent.computed &&
-    node.parent.parent.type === AST_NODE_TYPES.ObjectExpression
+    node.parent.parent.type === AST_NODE_TYPES.ObjectExpression &&
+    isObjectExpressionAssignedToVariable(node.parent.parent)
   );
+}
+
+function isObjectExpressionAssignedToVariable(
+  node: TSESTree.ObjectExpression,
+): boolean {
+  switch (node.parent.type) {
+    case AST_NODE_TYPES.VariableDeclarator:
+      return node.parent.init === node;
+
+    case AST_NODE_TYPES.AssignmentExpression:
+      return node.parent.right === node;
+
+    case AST_NODE_TYPES.Property:
+      if (
+        node.parent.value === node &&
+        node.parent.parent.type === AST_NODE_TYPES.ObjectExpression
+      ) {
+        return isObjectExpressionAssignedToVariable(node.parent.parent);
+      }
+      return false;
+
+    default:
+      return false;
+  }
 }

--- a/packages/eslint-plugin/src/rules/no-restricted-imports.ts
+++ b/packages/eslint-plugin/src/rules/no-restricted-imports.ts
@@ -369,6 +369,7 @@ export default createRule<Options, MessageIds>({
           const synthesizedImport: TSESTree.ImportDeclaration = {
             ...node,
             type: AST_NODE_TYPES.ImportDeclaration,
+            // eslint-disable-next-line @typescript-eslint/no-deprecated -- `assertions` is a required property of `ImportDeclaration` until it is removed
             assertions: [],
             attributes: [],
             source: node.moduleReference.expression,

--- a/packages/eslint-plugin/tests/rules/no-deprecated.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-deprecated.test.ts
@@ -3783,6 +3783,45 @@ class A {
     },
     {
       code: `
+interface A {
+  /** @deprecated */
+  deprecatedField: string;
+}
+const x: A = { deprecatedField: 'string' };
+      `,
+      errors: [
+        {
+          column: 16,
+          data: { name: 'deprecatedField' },
+          endColumn: 31,
+          endLine: 6,
+          line: 6,
+          messageId: 'deprecated',
+        },
+      ],
+    },
+    {
+      code: `
+interface A {
+  /** @deprecated */
+  deprecatedField: string;
+}
+declare function func(x: A): void;
+func({ deprecatedField: 'string' });
+      `,
+      errors: [
+        {
+          column: 8,
+          data: { name: 'deprecatedField' },
+          endColumn: 23,
+          endLine: 7,
+          line: 7,
+          messageId: 'deprecated',
+        },
+      ],
+    },
+    {
+      code: `
 const a = {
   /** @deprecated */
   b: 'string',

--- a/packages/eslint-plugin/tests/rules/no-deprecated.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-deprecated.test.ts
@@ -732,6 +732,14 @@ const {
   foo: { notDeprecatedProperty: deprecatedProperty },
 } = a;
     `,
+    `
+interface A {
+  /** @deprecated */
+  deprecatedField: string;
+}
+declare function func(x: A): void;
+func({ deprecatedField: 'string' });
+    `,
   ],
   invalid: [
     {
@@ -3796,26 +3804,6 @@ const x: A = { deprecatedField: 'string' };
           endColumn: 31,
           endLine: 6,
           line: 6,
-          messageId: 'deprecated',
-        },
-      ],
-    },
-    {
-      code: `
-interface A {
-  /** @deprecated */
-  deprecatedField: string;
-}
-declare function func(x: A): void;
-func({ deprecatedField: 'string' });
-      `,
-      errors: [
-        {
-          column: 8,
-          data: { name: 'deprecatedField' },
-          endColumn: 23,
-          endLine: 7,
-          line: 7,
           messageId: 'deprecated',
         },
       ],

--- a/packages/eslint-plugin/tests/rules/no-deprecated.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-deprecated.test.ts
@@ -3810,6 +3810,48 @@ const x: A = { deprecatedField: 'string' };
     },
     {
       code: `
+interface A {
+  /** @deprecated */
+  deprecatedField: string;
+}
+let x: A;
+x = { deprecatedField: 'string' };
+      `,
+      errors: [
+        {
+          column: 7,
+          data: { name: 'deprecatedField' },
+          endColumn: 22,
+          endLine: 7,
+          line: 7,
+          messageId: 'deprecated',
+        },
+      ],
+    },
+    {
+      code: `
+interface A {
+  /** @deprecated */
+  deprecatedField: string;
+}
+interface B {
+  nested: A;
+}
+const y: B = { nested: { deprecatedField: 'string' } };
+      `,
+      errors: [
+        {
+          column: 26,
+          data: { name: 'deprecatedField' },
+          endColumn: 41,
+          endLine: 9,
+          line: 9,
+          messageId: 'deprecated',
+        },
+      ],
+    },
+    {
+      code: `
 const a = {
   /** @deprecated */
   b: 'string',

--- a/packages/rule-tester/tests/RuleTester.test.ts
+++ b/packages/rule-tester/tests/RuleTester.test.ts
@@ -86,7 +86,6 @@ const NOOP_RULE: RuleModule<'error'> = {
   create() {
     return {};
   },
-  defaultOptions: [],
   meta: {
     messages: {
       error: 'error',
@@ -2180,7 +2179,6 @@ describe('RuleTester - hooks', () => {
         },
       };
     },
-    defaultOptions: [],
     meta: {
       messages: {
         error: 'error',
@@ -2403,7 +2401,6 @@ describe('RuleTester - multipass fixer', () => {
           },
         };
       },
-      defaultOptions: [],
       meta: {
         messages: {
           error: 'error',
@@ -2487,7 +2484,6 @@ describe('RuleTester - multipass fixer', () => {
           },
         };
       },
-      defaultOptions: [],
       meta: {
         fixable: 'code',
         messages: {
@@ -2609,7 +2605,6 @@ describe('RuleTester - multipass fixer', () => {
           },
         };
       },
-      defaultOptions: [],
       meta: {
         fixable: 'code',
         messages: {
@@ -2707,7 +2702,6 @@ describe('RuleTester - run types', () => {
         },
       };
     },
-    defaultOptions: [],
     meta: {
       messages: {
         customErrorBar: 'Error custom Bar',

--- a/packages/scope-manager/src/analyze.ts
+++ b/packages/scope-manager/src/analyze.ts
@@ -68,6 +68,7 @@ export interface AnalyzeOptions {
 
 const DEFAULT_OPTIONS: Required<AnalyzeOptions> = {
   childVisitorKeys: visitorKeys,
+  // eslint-disable-next-line @typescript-eslint/no-deprecated -- -- `Required<AnalyzeOptions>` makes this mandatory until it is removed in v10
   emitDecoratorMetadata: false,
   globalReturn: false,
   impliedStrict: false,
@@ -87,6 +88,7 @@ export function analyze(
   const options: Required<AnalyzeOptions> = {
     childVisitorKeys:
       providedOptions?.childVisitorKeys ?? DEFAULT_OPTIONS.childVisitorKeys,
+    // eslint-disable-next-line @typescript-eslint/no-deprecated -- -- `Required<AnalyzeOptions>` makes this mandatory until it is removed in v10
     emitDecoratorMetadata: false,
     globalReturn: providedOptions?.globalReturn ?? DEFAULT_OPTIONS.globalReturn,
     impliedStrict:


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10643
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

<!-- Description of what is changed and how the code change does that. -->

### What this fixes

Fix the rule does not report a deprecated property when it is written as a key of an object literal. This is the case reported in #10643.

```typescript
interface GridOptions {
  /** @deprecated use newApi instead */
  a?: string;
}

// not reported before this change
const x: GridOptions = {
  a: 'foo', // `a` is deprecated. use newApi instead
};
```

### Cause
- The object literal's contextual type was not checked.
- `isDeclaration` treats an object literal key as a declaration of a new property, so it returns before the report is made.
- `getJSXAttributeDeprecation` already uses getContextualType for JSX attributes, so I followed the same flow.

### Changes in other packages
- scope-manager, `emitDecoratorMetadata`
    - It is a required property, so there was no choice but to disable the rule.
- no-restricted-imports, `assertions`
    - It is a required property, so there was no choice but to disable the rule.
- rule-tester, `defaultOptions`
    - It is optional and resolves to [], so I removed those lines.


### Why the scope is limited to assignments to a variable

If every object literal with a contextual type is checked, this repository alone gets 175 reports. 166 of them are call arguments or return statements, and only 9 are assignments to a variable.
I expect the same to happen in an average codebase, so this PR only covers assignments to a variable.

### Question and background
I would like deprecated properties to be reported for call arguments as well, not only for assignments. I am happy to extend this PR, or to open a separate issue, whichever you prefer.

Some background on why I opened this PR: I work on server side development in another language. We add `@deprecated` to request parameters in our OpenAPI schema, and I was looking for a way to surface that as a lint error in the clients, which are written in TypeScript. That is how I found this issue.

The case I actually care about is a call to a generated API client, which is a call argument, so it is out of scope in this PR for the reason above. That is why I would like call arguments to be covered eventually.

I have written very little TypeScript, so please point out anything that does not follow your conventions.

💖