### PR TITLE
docs: fix typed linting wording

### DIFF
--- a/docs/developers/ESLint_Plugins.mdx
+++ b/docs/developers/ESLint_Plugins.mdx
@@ -75,7 +75,7 @@ export const createRule = ESLintUtils.RuleCreator<ExamplePluginDocs>(
 Most ESLint plugins export a _"`recommended`"_ [ESLint shared config](https://eslint.org/docs/latest/extend/shareable-configs).
 Many ESLint users assume enabling a plugin's `recommended` config is enough to enable all its relevant rules.
 
-However, at the same time, not all users want to or are able to enabled typed linting.
+However, at the same time, not all users want to or are able to enable typed linting.
 If your plugin's rules heavily use type information, it might be difficult to enable those in a `recommended` config.
 
 You have roughly two options:


### PR DESCRIPTION
Corrects a grammar error in the plugin documentation so the sentence accurately describes enabling typed linting.

Assisted-by: OpenAI GPT-5