### PR TITLE
docs: use https instead of http for external links

### DIFF
--- a/packages/eslint-plugin/docs/rules/prefer-for-of.mdx
+++ b/packages/eslint-plugin/docs/rules/prefer-for-of.mdx
@@ -51,7 +51,7 @@ for (let i = 0; i < array.length; i++) {
 
 By default, TypeScript's type checking only allows `for-of` loops over DOM iterables such as `HTMLCollectionOf` when the `dom.iterable` `lib` option is enabled.
 If you are using this rule in a project that works with DOM elements, be sure to enable `dom.iterable` in your TSConfig `lib`.
-See [aka.ms/tsconfig#lib](http://aka.ms/tsconfig#lib) for more information.
+See [aka.ms/tsconfig#lib](https://aka.ms/tsconfig#lib) for more information.
 
 ```json
 {

--- a/packages/website/blog/2026-01-05-revamping-the-ban-types-rule.mdx
+++ b/packages/website/blog/2026-01-05-revamping-the-ban-types-rule.mdx
@@ -36,7 +36,7 @@ This post will explain how `@typescript-eslint/ban-types` came to be, its benefi
 ## A Brief History of `ban-types`
 
 The first version of a _"ban types"_ lint rule came from [TSLint](https://palantir.github.io/tslint), a now-deprecated TypeScript-only linter predating typescript-eslint.
-[TSLint's `ban-type` rule](http://palantir.github.io/tslint/rules/ban-types) didn't ban any types by default.
+[TSLint's `ban-type` rule](https://palantir.github.io/tslint/rules/ban-types) didn't ban any types by default.
 It would only ban types explicitly declared in a project's linting config.
 
 When the rule was ported to `@typescript-eslint/ban-types`, it was changed to additionally lint against known dangerous built-in types by default.


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [ ] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

<!-- Description of what is changed and how the code change does that. -->

Updated the protocol from http to https for two external links in the docs.

- The `aka.ms/tsconfig#lib` link in `packages/eslint-plugin/docs/rules/prefer-for-of.mdx`
- The `palantir.github.io/tslint/rules/ban-types` link in `packages/website/blog/2026-01-05-revamping-the-ban-types-rule.mdx`

I updated them to https directly (avoiding the http→https redirect) and confirmed both links still work.

💖