### PR TITLE
fix(eslint-plugin): [no-unnecessary-type-assertion] prevent autofix from weakening types in double assertions

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -480,7 +480,8 @@ export default createRule<Options, MessageIds>({
 
       if (
         isTypeUnchanged(node, innerExpression, originalType, castType) &&
-        !isTypeFlagSet(castType, ts.TypeFlags.Any)
+        !isTypeFlagSet(castType, ts.TypeFlags.Any) &&
+        wouldSameTypeBeInferred(node, castType)
       ) {
         return 'unnecessaryAssertion';
       }

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -920,6 +920,15 @@ export default createRule<Options, MessageIds>({
       }
     }
 
+    function wouldSameTypeBeInferred(
+      node: TSESTree.TSAsExpression | TSESTree.TSTypeAssertion,
+      castType: ts.Type,
+    ): boolean {
+      return isTypeLiteral(castType)
+        ? isImplicitlyNarrowedLiteralDeclaration(node)
+        : !isConstAssertion(node.typeAnnotation);
+    }
+
     return {
       'TSAsExpression, TSTypeAssertion'(
         node: TSESTree.TSAsExpression | TSESTree.TSTypeAssertion,
@@ -953,11 +962,8 @@ export default createRule<Options, MessageIds>({
           uncastType,
           castType,
         );
-        const wouldSameTypeBeInferred = castTypeIsLiteral
-          ? isImplicitlyNarrowedLiteralDeclaration(node)
-          : !typeAnnotationIsConstAssertion;
 
-        if (typeIsUnchanged && wouldSameTypeBeInferred) {
+        if (typeIsUnchanged && wouldSameTypeBeInferred(node, castType)) {
           context.report({
             node,
             messageId: 'unnecessaryAssertion',

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -57,6 +57,7 @@ let x: Array<[number, string]> = [1, 2, 3, 4, 5].map(
 );
     `,
     'let y = 1 as 1;',
+    'let y = 1 as any as 1;',
     'const foo = 3 as number;',
     'const foo = <number>3;',
     `


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #12713
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

TODO