### PR TITLE
feat(eslint-plugin): [no-unsafe-enum-assignment] add rule

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-unsafe-enum-assignment.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unsafe-enum-assignment.mdx
@@ -1,0 +1,129 @@
+---
+description: 'Disallow assigning non-enum values to enum typed locations.'
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+> 🛑 This file is source code, not the primary documentation location! 🛑
+>
+> See **https://typescript-eslint.io/rules/no-unsafe-enum-assignment** for documentation.
+
+TypeScript is deliberately lenient about assigning plain numbers into numeric enums.
+That leniency supports bit flag enums, whose combinations produce a plain `number` rather than an enum member:
+
+```ts
+enum Flags {
+  Read = 1 << 0,
+  Write = 1 << 1,
+}
+
+const readWrite: Flags = Flags.Read | Flags.Write;
+```
+
+The cost is that _any_ number may be assigned into a numeric enum type, including one that matches no member at all:
+
+```ts
+enum Fruit {
+  Apple,
+}
+
+declare const someNumber: number;
+
+const fruit: Fruit = someNumber; // No error
+```
+
+TypeScript also permits numeric literals that happen to coincide with a member's value, which makes code depend on what an enum's members are set to rather than what they are called.
+Incrementing or otherwise doing arithmetic on an enum-typed value has the same effect, since the result is a plain number that need not match any member.
+String enums are checked more strictly, but a type assertion still bypasses those checks.
+
+Requiring enum members to be referred to by name:
+
+- makes a codebase more resilient to enum members changing values.
+- allows code IDEs to use the "Rename Symbol" feature to quickly rename an enum member.
+- aligns code to the proper enum semantics of referring to members by name and treating their values as implementation details.
+
+## Examples
+
+<Tabs>
+<TabItem value="❌ Incorrect">
+
+```ts
+enum Fruit {
+  Apple,
+}
+
+declare const someNumber: number;
+
+// Fruit.Apple is set to 0, so TypeScript allows this literal.
+const fruit: Fruit = 0;
+
+function takesFruit(value: Fruit) {}
+takesFruit(someNumber);
+
+function getFruit(): Fruit {
+  return someNumber;
+}
+
+let mutated: Fruit = Fruit.Apple;
+mutated++;
+mutated += 1;
+
+enum Vegetable {
+  Asparagus = 'asparagus',
+}
+
+// A type assertion bypasses TypeScript's stricter string enum checks.
+const vegetable = 'asparagus' as Vegetable;
+```
+
+</TabItem>
+<TabItem value="✅ Correct">
+
+```ts
+enum Fruit {
+  Apple,
+}
+
+const fruit: Fruit = Fruit.Apple;
+
+function takesFruit(value: Fruit) {}
+takesFruit(Fruit.Apple);
+
+function getFruit(): Fruit {
+  return Fruit.Apple;
+}
+
+let reassigned: Fruit = Fruit.Apple;
+reassigned = Fruit.Apple;
+
+enum Vegetable {
+  Asparagus = 'asparagus',
+}
+
+const vegetable: Vegetable = Vegetable.Asparagus;
+```
+
+</TabItem>
+</Tabs>
+
+## When Not To Use It
+
+Combining enum members with bitwise operators is allowed by this rule, including with `|=`, `&=`, and `^=`.
+Computing flag values with other arithmetic is not.
+If your codebase derives enum values that way, this rule will be difficult to adhere to.
+
+Sometimes, you may want to ingest a value from an API or user input, then use it as an enum throughout your application.
+While validating the input, it may be appropriate to disable the rule.
+Alternately, you might consider making use of a validation library like [Zod](https://zod.dev/?id=native-enums).
+See further discussion of treating enums as opaque in [#8557](https://github.com/typescript-eslint/typescript-eslint/issues/8557).
+
+In the case of relying on third party enums that are only imported as `type`s, their members aren't available to refer to by name.
+You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) for those specific situations instead of completely disabling this rule.
+
+More generally, if you don't mind enums being treated as a namespaced bag of values rather than opaque identifiers, you likely don't need this rule.
+In that case, you might consider declaring a `const` object and a union of its values instead of an enum.
+
+## Related To
+
+- [`no-unsafe-enum-comparison`](./no-unsafe-enum-comparison.mdx)

--- a/packages/eslint-plugin/src/configs/eslintrc/all.ts
+++ b/packages/eslint-plugin/src/configs/eslintrc/all.ts
@@ -100,6 +100,7 @@ export = {
     '@typescript-eslint/no-unsafe-assignment': 'error',
     '@typescript-eslint/no-unsafe-call': 'error',
     '@typescript-eslint/no-unsafe-declaration-merging': 'error',
+    '@typescript-eslint/no-unsafe-enum-assignment': 'error',
     '@typescript-eslint/no-unsafe-enum-comparison': 'error',
     '@typescript-eslint/no-unsafe-function-type': 'error',
     '@typescript-eslint/no-unsafe-member-access': 'error',

--- a/packages/eslint-plugin/src/configs/eslintrc/disable-type-checked.ts
+++ b/packages/eslint-plugin/src/configs/eslintrc/disable-type-checked.ts
@@ -39,6 +39,7 @@ export = {
     '@typescript-eslint/no-unsafe-argument': 'off',
     '@typescript-eslint/no-unsafe-assignment': 'off',
     '@typescript-eslint/no-unsafe-call': 'off',
+    '@typescript-eslint/no-unsafe-enum-assignment': 'off',
     '@typescript-eslint/no-unsafe-enum-comparison': 'off',
     '@typescript-eslint/no-unsafe-member-access': 'off',
     '@typescript-eslint/no-unsafe-return': 'off',

--- a/packages/eslint-plugin/src/configs/eslintrc/strict-type-checked-only.ts
+++ b/packages/eslint-plugin/src/configs/eslintrc/strict-type-checked-only.ts
@@ -35,6 +35,7 @@ export = {
     '@typescript-eslint/no-unsafe-argument': 'error',
     '@typescript-eslint/no-unsafe-assignment': 'error',
     '@typescript-eslint/no-unsafe-call': 'error',
+    '@typescript-eslint/no-unsafe-enum-assignment': 'error',
     '@typescript-eslint/no-unsafe-enum-comparison': 'error',
     '@typescript-eslint/no-unsafe-member-access': 'error',
     '@typescript-eslint/no-unsafe-return': 'error',

--- a/packages/eslint-plugin/src/configs/eslintrc/strict-type-checked.ts
+++ b/packages/eslint-plugin/src/configs/eslintrc/strict-type-checked.ts
@@ -57,6 +57,7 @@ export = {
     '@typescript-eslint/no-unsafe-assignment': 'error',
     '@typescript-eslint/no-unsafe-call': 'error',
     '@typescript-eslint/no-unsafe-declaration-merging': 'error',
+    '@typescript-eslint/no-unsafe-enum-assignment': 'error',
     '@typescript-eslint/no-unsafe-enum-comparison': 'error',
     '@typescript-eslint/no-unsafe-function-type': 'error',
     '@typescript-eslint/no-unsafe-member-access': 'error',

--- a/packages/eslint-plugin/src/configs/flat/all.ts
+++ b/packages/eslint-plugin/src/configs/flat/all.ts
@@ -114,6 +114,7 @@ export default (
       '@typescript-eslint/no-unsafe-assignment': 'error',
       '@typescript-eslint/no-unsafe-call': 'error',
       '@typescript-eslint/no-unsafe-declaration-merging': 'error',
+      '@typescript-eslint/no-unsafe-enum-assignment': 'error',
       '@typescript-eslint/no-unsafe-enum-comparison': 'error',
       '@typescript-eslint/no-unsafe-function-type': 'error',
       '@typescript-eslint/no-unsafe-member-access': 'error',

--- a/packages/eslint-plugin/src/configs/flat/disable-type-checked.ts
+++ b/packages/eslint-plugin/src/configs/flat/disable-type-checked.ts
@@ -46,6 +46,7 @@ export default (
     '@typescript-eslint/no-unsafe-argument': 'off',
     '@typescript-eslint/no-unsafe-assignment': 'off',
     '@typescript-eslint/no-unsafe-call': 'off',
+    '@typescript-eslint/no-unsafe-enum-assignment': 'off',
     '@typescript-eslint/no-unsafe-enum-comparison': 'off',
     '@typescript-eslint/no-unsafe-member-access': 'off',
     '@typescript-eslint/no-unsafe-return': 'off',

--- a/packages/eslint-plugin/src/configs/flat/strict-type-checked-only.ts
+++ b/packages/eslint-plugin/src/configs/flat/strict-type-checked-only.ts
@@ -48,6 +48,7 @@ export default (
       '@typescript-eslint/no-unsafe-argument': 'error',
       '@typescript-eslint/no-unsafe-assignment': 'error',
       '@typescript-eslint/no-unsafe-call': 'error',
+      '@typescript-eslint/no-unsafe-enum-assignment': 'error',
       '@typescript-eslint/no-unsafe-enum-comparison': 'error',
       '@typescript-eslint/no-unsafe-member-access': 'error',
       '@typescript-eslint/no-unsafe-return': 'error',

--- a/packages/eslint-plugin/src/configs/flat/strict-type-checked.ts
+++ b/packages/eslint-plugin/src/configs/flat/strict-type-checked.ts
@@ -70,6 +70,7 @@ export default (
       '@typescript-eslint/no-unsafe-assignment': 'error',
       '@typescript-eslint/no-unsafe-call': 'error',
       '@typescript-eslint/no-unsafe-declaration-merging': 'error',
+      '@typescript-eslint/no-unsafe-enum-assignment': 'error',
       '@typescript-eslint/no-unsafe-enum-comparison': 'error',
       '@typescript-eslint/no-unsafe-function-type': 'error',
       '@typescript-eslint/no-unsafe-member-access': 'error',

--- a/packages/eslint-plugin/src/rules/enum-utils/shared.ts
+++ b/packages/eslint-plugin/src/rules/enum-utils/shared.ts
@@ -116,6 +116,56 @@ export function isMismatchedEnumComparisonTypes(
 }
 
 /**
+ * @returns Whether assigning a sender type to a receiver type is unsafe because
+ * the receiver expects an enum value but the sender only provides non-enum
+ * values of the same primitive kind.
+ */
+export function isMismatchedEnumAssignmentTypes(
+  typeChecker: ts.TypeChecker,
+  senderType: ts.Type,
+  receiverType: ts.Type,
+): boolean {
+  const receiverEnumTypes = getEnumTypes(typeChecker, receiverType);
+  if (receiverEnumTypes.length === 0) {
+    return false;
+  }
+
+  const receiverTypeParts = tsutils.unionConstituents(receiverType);
+  const receiverNonEnumParts = receiverTypeParts.filter(
+    receiverTypePart =>
+      getEnumTypes(typeChecker, receiverTypePart).length === 0,
+  );
+  const receiverEnumValueTypes = new Set(
+    receiverTypeParts.map(getEnumValueType),
+  );
+
+  for (const senderTypePart of tsutils.unionConstituents(senderType)) {
+    if (hasSharedEnumType(typeChecker, senderTypePart, receiverEnumTypes)) {
+      continue;
+    }
+
+    if (
+      receiverNonEnumParts.some(receiverTypePart =>
+        typeChecker.isTypeAssignableTo(senderTypePart, receiverTypePart),
+      )
+    ) {
+      continue;
+    }
+
+    if (
+      (receiverEnumValueTypes.has(ts.TypeFlags.Number) &&
+        isNumberLike(senderTypePart)) ||
+      (receiverEnumValueTypes.has(ts.TypeFlags.String) &&
+        isStringLike(senderTypePart))
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
  * @returns Whether the right type is an unsafe comparison against any left type.
  */
 function typeViolates(leftTypeParts: ts.Type[], rightType: ts.Type): boolean {
@@ -125,6 +175,22 @@ function typeViolates(leftTypeParts: ts.Type[], rightType: ts.Type): boolean {
     (leftEnumValueTypes.has(ts.TypeFlags.Number) && isNumberLike(rightType)) ||
     (leftEnumValueTypes.has(ts.TypeFlags.String) && isStringLike(rightType))
   );
+}
+
+function hasSharedEnumType(
+  typeChecker: ts.TypeChecker,
+  type: ts.Type,
+  expectedEnumTypes: readonly ts.Type[],
+): boolean {
+  const typeEnumTypes = new Set(getEnumTypes(typeChecker, type));
+
+  for (const expectedEnumType of expectedEnumTypes) {
+    if (typeEnumTypes.has(expectedEnumType)) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 function isNumberLike(type: ts.Type): boolean {

--- a/packages/eslint-plugin/src/rules/index.ts
+++ b/packages/eslint-plugin/src/rules/index.ts
@@ -81,6 +81,7 @@ import noUnsafeArgument from './no-unsafe-argument';
 import noUnsafeAssignment from './no-unsafe-assignment';
 import noUnsafeCall from './no-unsafe-call';
 import noUnsafeDeclarationMerging from './no-unsafe-declaration-merging';
+import noUnsafeEnumAssignment from './no-unsafe-enum-assignment';
 import noUnsafeEnumComparison from './no-unsafe-enum-comparison';
 import noUnsafeFunctionType from './no-unsafe-function-type';
 import noUnsafeMemberAccess from './no-unsafe-member-access';
@@ -218,6 +219,7 @@ const rules = {
   'no-unsafe-assignment': noUnsafeAssignment,
   'no-unsafe-call': noUnsafeCall,
   'no-unsafe-declaration-merging': noUnsafeDeclarationMerging,
+  'no-unsafe-enum-assignment': noUnsafeEnumAssignment,
   'no-unsafe-enum-comparison': noUnsafeEnumComparison,
   'no-unsafe-function-type': noUnsafeFunctionType,
   'no-unsafe-member-access': noUnsafeMemberAccess,

--- a/packages/eslint-plugin/src/rules/no-redundant-type-constituents.ts
+++ b/packages/eslint-plugin/src/rules/no-redundant-type-constituents.ts
@@ -375,6 +375,7 @@ export default createRule({
                   literal: typeValues.map(name => name.typeName).join(' | '),
                   primitive:
                     primitiveTypeFlagNames[
+                      // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-assignment -- narrowing a ts.TypeFlags value to its name lookup key
                       primitive as keyof typeof primitiveTypeFlagNames
                     ],
                 },

--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -30,7 +30,7 @@ import {
 
 // #region
 
-const nullishFlag = ts.TypeFlags.Undefined | ts.TypeFlags.Null;
+const nullishFlag: ts.TypeFlags = ts.TypeFlags.Undefined | ts.TypeFlags.Null;
 
 function isNullishType(type: ts.Type): boolean {
   return tsutils.isTypeFlagSet(type, nullishFlag);

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-constraint.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-constraint.ts
@@ -43,6 +43,7 @@ export default createRule({
     function checkRequiresGenericDeclarationDisambiguation(
       filename: string,
     ): boolean {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-assignment -- narrowing a file extension string to ts.Extension at a parse boundary
       const pathExt = extname(filename).toLocaleLowerCase() as ts.Extension;
       switch (pathExt) {
         case ts.Extension.Cts:

--- a/packages/eslint-plugin/src/rules/no-unsafe-enum-assignment.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-enum-assignment.ts
@@ -1,0 +1,1032 @@
+import type { TSESTree } from '@typescript-eslint/utils';
+
+import { AST_NODE_TYPES } from '@typescript-eslint/utils';
+import * as tsutils from 'ts-api-utils';
+import * as ts from 'typescript';
+
+import type { MakeRequired } from '../util';
+
+import {
+  createRule,
+  FunctionSignature,
+  getContextualType,
+  getParserServices,
+  getStaticMemberAccessValue,
+} from '../util';
+import { getParentFunctionNode } from '../util/getParentFunctionNode';
+import {
+  getEnumTypes,
+  isMismatchedEnumAssignmentTypes,
+} from './enum-utils/shared';
+
+const bitwiseBinaryOperators = new Set(['&', '<<', '>>', '>>>', '^', '|']);
+
+// These assign their right side through, so they are checked like a plain `=`.
+// Every other compound operator computes a new number from the enum value.
+const valueAssigningOperators = new Set([
+  '&&=',
+  '&=',
+  '??=',
+  '^=',
+  '|=',
+  '||=',
+]);
+
+export default createRule({
+  name: 'no-unsafe-enum-assignment',
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow assigning non-enum values to enum typed locations',
+      recommended: 'strict',
+      requiresTypeChecking: true,
+    },
+    messages: {
+      unsafeEnumAccess:
+        'The computed key used here does not have a shared enum type with the expected enum {{enumNames}}.',
+      unsafeEnumArgument:
+        'The argument passed here does not have a shared enum type with the expected enum {{enumNames}}.',
+      unsafeEnumAssertion:
+        'The value asserted here does not have a shared enum type with the expected enum {{enumNames}}.',
+      unsafeEnumAssignment:
+        'The value assigned here does not have a shared enum type with the expected enum {{enumNames}}.',
+      unsafeEnumMutation:
+        'This mutation can produce a value outside of the expected enum {{enumNames}}.',
+      unsafeEnumReturn:
+        'The value returned here does not have a shared enum type with the expected enum {{enumNames}}.',
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    const services = getParserServices(context);
+    const checker = services.program.getTypeChecker();
+    const suppressedNestedReportRoots = new WeakSet<TSESTree.Node>();
+
+    function hasSharedEnumType(
+      type: ts.Type,
+      expectedEnumTypes: readonly ts.Type[],
+    ) {
+      const typeEnumTypes = new Set(getEnumTypes(checker, type));
+
+      for (const expectedEnumType of expectedEnumTypes) {
+        if (typeEnumTypes.has(expectedEnumType)) {
+          return true;
+        }
+      }
+
+      return false;
+    }
+
+    function getTsExpression(node: TSESTree.Expression): ts.Expression {
+      return services.esTreeNodeToTSNodeMap.get(node) as ts.Expression;
+    }
+
+    function getContextualTypeForExpression(node: TSESTree.Expression) {
+      return getContextualType(checker, getTsExpression(node));
+    }
+
+    function getTypeArguments(type: ts.Type): readonly ts.Type[] {
+      if (!tsutils.isTypeReference(type)) {
+        return [];
+      }
+
+      return checker.getTypeArguments(type);
+    }
+
+    function isSafeEnumBitwiseExpression(
+      expression: TSESTree.Expression,
+      receiverType: ts.Type,
+    ) {
+      const receiverEnumTypes = getEnumTypes(checker, receiverType);
+      if (receiverEnumTypes.length === 0) {
+        return false;
+      }
+
+      function unwrapTsExpression(node: ts.Expression) {
+        if (ts.isParenthesizedExpression(node)) {
+          return unwrapTsExpression(node.expression);
+        }
+
+        if (ts.isAsExpression(node) || ts.isTypeAssertionExpression(node)) {
+          return unwrapTsExpression(node.expression);
+        }
+
+        return node;
+      }
+
+      function isBitwiseOperand(node: ts.Expression): boolean {
+        const unwrappedNode = unwrapTsExpression(node);
+        if (ts.isBinaryExpression(unwrappedNode)) {
+          const operator = ts.tokenToString(unwrappedNode.operatorToken.kind);
+          if (!operator || !bitwiseBinaryOperators.has(operator)) {
+            return false;
+          }
+
+          return (
+            isBitwiseOperand(unwrappedNode.left) &&
+            isBitwiseOperand(unwrappedNode.right)
+          );
+        }
+
+        return hasSharedEnumType(
+          checker.getTypeAtLocation(unwrappedNode),
+          receiverEnumTypes,
+        );
+      }
+
+      const unwrappedExpression = unwrapTsExpression(
+        getTsExpression(expression),
+      );
+      if (!ts.isBinaryExpression(unwrappedExpression)) {
+        return false;
+      }
+
+      const operator = ts.tokenToString(unwrappedExpression.operatorToken.kind);
+      if (!operator || !bitwiseBinaryOperators.has(operator)) {
+        return false;
+      }
+
+      return (
+        isBitwiseOperand(unwrappedExpression.left) &&
+        isBitwiseOperand(unwrappedExpression.right)
+      );
+    }
+
+    function getImplementedMemberTypes(
+      node: TSESTree.AccessorProperty | TSESTree.PropertyDefinition,
+    ) {
+      const memberName = getStaticMemberAccessValue(node, context);
+      if (typeof memberName !== 'string') {
+        return [];
+      }
+
+      const tsMemberNode = services.esTreeNodeToTSNodeMap.get(node);
+      const classNode = tsMemberNode.parent;
+
+      const implementedTypes = [];
+      for (const heritageClause of classNode.heritageClauses ?? []) {
+        for (const heritageType of heritageClause.types) {
+          const implementedType = checker.getTypeAtLocation(heritageType);
+          const memberSymbol = implementedType.getProperty(memberName);
+          if (!memberSymbol) {
+            continue;
+          }
+
+          implementedTypes.push(checker.getTypeOfSymbol(memberSymbol));
+        }
+      }
+
+      return implementedTypes;
+    }
+
+    function hasSuppressedNestedReportAncestor(node: TSESTree.Node) {
+      let current: TSESTree.Node | undefined = node;
+
+      while (current) {
+        if (suppressedNestedReportRoots.has(current)) {
+          return true;
+        }
+
+        current = current.parent;
+      }
+
+      return false;
+    }
+
+    function formatEnumNames(enumNames: readonly string[]) {
+      return enumNames.map(enumName => `'${enumName}'`).join(', ');
+    }
+
+    function getExpectedEnumNames(type: ts.Type) {
+      const visited = new Set<ts.Type>();
+      const enumNames = new Set<string>();
+
+      function visit(currentType: ts.Type) {
+        const constrainedType = getConstraintType(currentType);
+
+        for (const enumType of getEnumTypes(checker, constrainedType)) {
+          enumNames.add(checker.typeToString(enumType));
+        }
+
+        if (visited.has(constrainedType)) {
+          return;
+        }
+        visited.add(constrainedType);
+
+        for (const typeArgument of getTypeArguments(constrainedType)) {
+          visit(typeArgument);
+        }
+
+        const indexType = checker.getIndexTypeOfType(
+          constrainedType,
+          ts.IndexKind.Number,
+        );
+        if (indexType) {
+          visit(indexType);
+        }
+
+        for (const property of constrainedType.getProperties()) {
+          visit(checker.getTypeOfSymbol(property));
+        }
+      }
+
+      visit(type);
+
+      return [...enumNames].sort();
+    }
+
+    function getReportDataForTypes(types: readonly ts.Type[]) {
+      const enumNames = new Set<string>();
+
+      for (const type of types) {
+        for (const enumName of getExpectedEnumNames(type)) {
+          enumNames.add(enumName);
+        }
+      }
+
+      return {
+        enumNames: formatEnumNames([...enumNames].sort()),
+      };
+    }
+
+    function reportWithSuppressedNestedRoots(
+      nodeToSuppress: TSESTree.Node,
+      reportingNode: TSESTree.Node,
+      messageId:
+        | 'unsafeEnumAccess'
+        | 'unsafeEnumArgument'
+        | 'unsafeEnumAssertion'
+        | 'unsafeEnumAssignment'
+        | 'unsafeEnumMutation'
+        | 'unsafeEnumReturn',
+      receiverTypes: readonly ts.Type[],
+    ) {
+      suppressedNestedReportRoots.add(nodeToSuppress);
+      context.report({
+        node: reportingNode,
+        messageId,
+        data: getReportDataForTypes(receiverTypes),
+      });
+    }
+
+    function checkImplementedMemberAssignment(
+      node: TSESTree.AccessorProperty | TSESTree.PropertyDefinition,
+      valueNode: TSESTree.Expression,
+      reportingNode: TSESTree.Node,
+    ) {
+      const implementedMemberTypes = getImplementedMemberTypes(node);
+      if (implementedMemberTypes.length === 0) {
+        return false;
+      }
+
+      const senderType = services.getTypeAtLocation(valueNode);
+
+      for (const receiverType of implementedMemberTypes) {
+        if (
+          !hasDeepEnumAssignmentMismatch(senderType, receiverType) ||
+          isSafeEnumBitwiseExpression(valueNode, receiverType)
+        ) {
+          return false;
+        }
+      }
+
+      reportWithSuppressedNestedRoots(
+        valueNode,
+        reportingNode,
+        'unsafeEnumAssignment',
+        implementedMemberTypes,
+      );
+
+      return true;
+    }
+
+    function checkAssignmentWithReceiverType(
+      receiverType: ts.Type,
+      senderNode: TSESTree.Expression,
+      reportingNode: TSESTree.Node,
+    ) {
+      const senderType = services.getTypeAtLocation(senderNode);
+
+      if (senderNode.type === AST_NODE_TYPES.ObjectExpression) {
+        return false;
+      }
+
+      if (senderNode.type === AST_NODE_TYPES.ArrayExpression) {
+        const constrainedReceiverType = getConstraintType(receiverType);
+
+        if (
+          !isTypeParameterType(receiverType) &&
+          (checker.isArrayType(constrainedReceiverType) ||
+            checker.isTupleType(constrainedReceiverType))
+        ) {
+          return false;
+        }
+      }
+
+      if (hasDeepEnumAssignmentMismatch(senderType, receiverType)) {
+        if (isSafeEnumBitwiseExpression(senderNode, receiverType)) {
+          return false;
+        }
+
+        reportWithSuppressedNestedRoots(
+          senderNode,
+          reportingNode,
+          'unsafeEnumAssignment',
+          [receiverType],
+        );
+        return true;
+      }
+
+      return false;
+    }
+
+    function checkAssignment(
+      receiverNode: TSESTree.Node,
+      senderNode: TSESTree.Expression,
+      reportingNode: TSESTree.Node,
+    ) {
+      return checkAssignmentWithReceiverType(
+        services.getTypeAtLocation(receiverNode),
+        senderNode,
+        reportingNode,
+      );
+    }
+
+    function checkContextualAssignment(
+      receiverNode: TSESTree.Node,
+      senderNode: TSESTree.Expression,
+      reportingNode: TSESTree.Node,
+      contextualReceiverNode: TSESTree.Expression,
+    ) {
+      return checkAssignmentWithReceiverType(
+        getContextualTypeForExpression(contextualReceiverNode) ??
+          services.getTypeAtLocation(receiverNode),
+        senderNode,
+        reportingNode,
+      );
+    }
+
+    function getConstraintType(type: ts.Type) {
+      return checker.getBaseConstraintOfType(type) ?? type;
+    }
+
+    function isTypeParameterType(type: ts.Type) {
+      return tsutils.isTypeFlagSet(type, ts.TypeFlags.TypeParameter);
+    }
+
+    function getEffectiveArgumentReceiverType(
+      _argument: TSESTree.Expression,
+      parameterType: ts.Type,
+    ) {
+      return parameterType;
+    }
+
+    function hasDeepEnumAssignmentMismatch(
+      senderType: ts.Type,
+      receiverType: ts.Type,
+      visited = new Map<ts.Type, Set<ts.Type>>(),
+    ) {
+      const constrainedSenderType = getConstraintType(senderType);
+      const constrainedReceiverType = getConstraintType(receiverType);
+
+      let visitedReceiverTypes = visited.get(constrainedSenderType);
+      if (visitedReceiverTypes == null) {
+        visitedReceiverTypes = new Set();
+        visited.set(constrainedSenderType, visitedReceiverTypes);
+      } else if (visitedReceiverTypes.has(constrainedReceiverType)) {
+        return false;
+      }
+      visitedReceiverTypes.add(constrainedReceiverType);
+
+      if (
+        isMismatchedEnumAssignmentTypes(
+          checker,
+          constrainedSenderType,
+          constrainedReceiverType,
+        )
+      ) {
+        return true;
+      }
+
+      const senderTypeArguments = getTypeArguments(constrainedSenderType);
+      const receiverTypeArguments = getTypeArguments(constrainedReceiverType);
+      if (
+        senderTypeArguments.length > 0 &&
+        senderTypeArguments.length === receiverTypeArguments.length
+      ) {
+        for (let index = 0; index < receiverTypeArguments.length; index += 1) {
+          if (
+            hasDeepEnumAssignmentMismatch(
+              senderTypeArguments[index],
+              receiverTypeArguments[index],
+              visited,
+            )
+          ) {
+            return true;
+          }
+        }
+      }
+
+      const receiverElementType = checker.getIndexTypeOfType(
+        constrainedReceiverType,
+        ts.IndexKind.Number,
+      );
+      if (
+        receiverElementType &&
+        checker.isTupleType(constrainedSenderType) &&
+        checker
+          .getTypeArguments(constrainedSenderType)
+          .some(elementType =>
+            hasDeepEnumAssignmentMismatch(
+              elementType,
+              receiverElementType,
+              visited,
+            ),
+          )
+      ) {
+        return true;
+      }
+
+      for (const receiverProperty of constrainedReceiverType.getProperties()) {
+        const senderProperty = constrainedSenderType.getProperty(
+          receiverProperty.name,
+        );
+        if (!senderProperty) {
+          continue;
+        }
+
+        if (
+          hasDeepEnumAssignmentMismatch(
+            checker.getTypeOfSymbol(senderProperty),
+            checker.getTypeOfSymbol(receiverProperty),
+            visited,
+          )
+        ) {
+          return true;
+        }
+      }
+
+      return false;
+    }
+
+    function checkArrayDestructurePattern(
+      receiverNode: TSESTree.ArrayPattern,
+      senderNode: TSESTree.Expression,
+    ) {
+      const receiverType = services.getTypeAtLocation(receiverNode);
+      if (
+        !checker.isTupleType(receiverType) &&
+        !checker.isArrayType(receiverType)
+      ) {
+        return false;
+      }
+
+      const senderType = services.getTypeAtLocation(senderNode);
+      const senderElementTypes = checker.isTupleType(senderType)
+        ? checker.getTypeArguments(senderType)
+        : [];
+      const receiverElementTypes = checker.isTupleType(receiverType)
+        ? checker.getTypeArguments(receiverType)
+        : [];
+      const receiverArrayElementType = checker.getIndexTypeOfType(
+        receiverType,
+        ts.IndexKind.Number,
+      );
+
+      let foundMismatch = false;
+      for (let index = 0; index < receiverNode.elements.length; index += 1) {
+        const receiverElement = receiverNode.elements[index];
+        if (
+          !receiverElement ||
+          receiverElement.type === AST_NODE_TYPES.RestElement
+        ) {
+          continue;
+        }
+
+        const receiverElementType =
+          receiverElementTypes[index] ?? receiverArrayElementType;
+
+        const senderElementType =
+          senderElementTypes[index] ??
+          checker.getIndexTypeOfType(senderType, ts.IndexKind.Number);
+
+        if (
+          !hasDeepEnumAssignmentMismatch(senderElementType, receiverElementType)
+        ) {
+          continue;
+        }
+
+        context.report({
+          node: receiverElement,
+          messageId: 'unsafeEnumAssignment',
+          data: getReportDataForTypes([receiverElementType]),
+        });
+        foundMismatch = true;
+      }
+
+      return foundMismatch;
+    }
+
+    function checkObjectDestructurePattern(
+      receiverNode: TSESTree.ObjectPattern,
+      senderNode: TSESTree.Expression,
+    ) {
+      const receiverType = services.getTypeAtLocation(receiverNode);
+      const senderType = services.getTypeAtLocation(senderNode);
+
+      let foundMismatch = false;
+      for (const property of receiverNode.properties) {
+        if (
+          property.type !== AST_NODE_TYPES.Property ||
+          property.value.type === AST_NODE_TYPES.AssignmentPattern
+        ) {
+          continue;
+        }
+
+        const key = getStaticMemberAccessValue(property, context);
+        if (typeof key !== 'string') {
+          continue;
+        }
+
+        const senderProperty = senderType.getProperty(key);
+        const receiverProperty = receiverType.getProperty(key);
+        if (!senderProperty || !receiverProperty) {
+          continue;
+        }
+
+        const senderPropertyType = checker.getTypeOfSymbol(senderProperty);
+        const receiverPropertyType = checker.getTypeOfSymbol(receiverProperty);
+
+        if (
+          !hasDeepEnumAssignmentMismatch(
+            senderPropertyType,
+            receiverPropertyType,
+          )
+        ) {
+          continue;
+        }
+
+        context.report({
+          node: property.value,
+          messageId: 'unsafeEnumAssignment',
+          data: getReportDataForTypes([receiverPropertyType]),
+        });
+        foundMismatch = true;
+      }
+
+      return foundMismatch;
+    }
+
+    function checkArguments(
+      args: TSESTree.CallExpressionArgument[] | TSESTree.Expression[],
+      node:
+        | TSESTree.CallExpression
+        | TSESTree.NewExpression
+        | TSESTree.TaggedTemplateExpression,
+    ) {
+      if (args.length === 0) {
+        return;
+      }
+
+      const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+      const signature = FunctionSignature.create(checker, tsNode, {
+        useDeclaredParameterTypes: true,
+      });
+
+      if (node.type === AST_NODE_TYPES.TaggedTemplateExpression) {
+        signature.getNextParameterType();
+      }
+
+      for (const argument of args) {
+        if (argument.type === AST_NODE_TYPES.SpreadElement) {
+          const spreadArgType = services.getTypeAtLocation(argument.argument);
+          if (checker.isTupleType(spreadArgType)) {
+            const spreadTypeArguments = checker.getTypeArguments(spreadArgType);
+            for (const tupleType of spreadTypeArguments) {
+              const parameterType = signature.getNextParameterType();
+              if (parameterType == null) {
+                continue;
+              }
+
+              if (hasDeepEnumAssignmentMismatch(tupleType, parameterType)) {
+                reportWithSuppressedNestedRoots(
+                  argument,
+                  argument,
+                  'unsafeEnumArgument',
+                  [parameterType],
+                );
+              }
+            }
+
+            if (spreadArgType.target.combinedFlags & ts.ElementFlags.Variable) {
+              signature.consumeRemainingArguments();
+            }
+          }
+
+          continue;
+        }
+
+        const parameterType = signature.getNextParameterType();
+        if (parameterType == null) {
+          continue;
+        }
+
+        if (argument.type === AST_NODE_TYPES.ArrayExpression) {
+          const constrainedParameterType = getConstraintType(parameterType);
+
+          if (
+            !isTypeParameterType(parameterType) &&
+            (checker.isArrayType(constrainedParameterType) ||
+              checker.isTupleType(constrainedParameterType))
+          ) {
+            continue;
+          }
+        }
+
+        const receiverType = getEffectiveArgumentReceiverType(
+          argument,
+          parameterType,
+        );
+
+        const argumentType = services.getTypeAtLocation(argument);
+        if (
+          hasDeepEnumAssignmentMismatch(argumentType, receiverType) &&
+          !isSafeEnumBitwiseExpression(argument, receiverType)
+        ) {
+          reportWithSuppressedNestedRoots(
+            argument,
+            argument,
+            'unsafeEnumArgument',
+            [receiverType],
+          );
+        }
+      }
+    }
+
+    function checkAssigningVariable(
+      node: TSESTree.Node,
+      assignee: TSESTree.Node,
+      value: TSESTree.Expression,
+    ) {
+      switch (assignee.type) {
+        case AST_NODE_TYPES.ArrayPattern:
+          checkArrayDestructurePattern(assignee, value);
+          return;
+        case AST_NODE_TYPES.ObjectPattern:
+          checkObjectDestructurePattern(assignee, value);
+          return;
+        default:
+          checkAssignment(assignee, value, node);
+          return;
+      }
+    }
+
+    function checkMutation(
+      targetNode: TSESTree.Expression,
+      reportingNode: TSESTree.Node,
+    ) {
+      const targetType = services.getTypeAtLocation(targetNode);
+      if (getEnumTypes(checker, getConstraintType(targetType)).length === 0) {
+        return;
+      }
+
+      reportWithSuppressedNestedRoots(
+        targetNode,
+        reportingNode,
+        'unsafeEnumMutation',
+        [targetType],
+      );
+    }
+
+    function checkReturn(
+      returnNode: TSESTree.Expression,
+      reportingNode: TSESTree.Node = returnNode,
+    ) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const functionNode = getParentFunctionNode(returnNode)!;
+
+      const functionTsNode = services.esTreeNodeToTSNodeMap.get(functionNode);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const signature = checker.getSignatureFromDeclaration(functionTsNode)!;
+
+      const returnNodeType = services.getTypeAtLocation(returnNode);
+      const senderType = functionNode.async
+        ? checker.getAwaitedType(returnNodeType)
+        : returnNodeType;
+      if (!senderType) {
+        return;
+      }
+
+      const signatureReturnType = signature.getReturnType();
+      const receiverType = functionNode.async
+        ? checker.getAwaitedType(signatureReturnType)
+        : signatureReturnType;
+      if (!receiverType) {
+        return;
+      }
+
+      if (
+        hasDeepEnumAssignmentMismatch(senderType, receiverType) &&
+        !isSafeEnumBitwiseExpression(returnNode, receiverType)
+      ) {
+        reportWithSuppressedNestedRoots(
+          returnNode,
+          reportingNode,
+          'unsafeEnumReturn',
+          [receiverType],
+        );
+      }
+    }
+
+    function checkTypeAssertion(
+      node: TSESTree.TSAsExpression | TSESTree.TSTypeAssertion,
+    ) {
+      const expressionType = services.getTypeAtLocation(node.expression);
+      const assertedType = services.getTypeAtLocation(node.typeAnnotation);
+
+      if (
+        hasDeepEnumAssignmentMismatch(expressionType, assertedType) &&
+        !isSafeEnumBitwiseExpression(node.expression, assertedType)
+      ) {
+        reportWithSuppressedNestedRoots(node, node, 'unsafeEnumAssertion', [
+          assertedType,
+        ]);
+      }
+    }
+
+    function addMappedKeyConstraintTypesFromDeclarations(
+      declaration: ts.Declaration,
+    ): ts.Type[] {
+      if (
+        !ts.isParameter(declaration) &&
+        !ts.isPropertyDeclaration(declaration) &&
+        !ts.isPropertySignature(declaration) &&
+        !ts.isVariableDeclaration(declaration)
+      ) {
+        return [];
+      }
+
+      if (!declaration.type) {
+        return [];
+      }
+
+      if (ts.isMappedTypeNode(declaration.type)) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const constraint = declaration.type.typeParameter.constraint!;
+        return [checker.getTypeFromTypeNode(constraint)];
+      }
+
+      if (ts.isTypeLiteralNode(declaration.type)) {
+        const receiverTypes: ts.Type[] = [];
+        for (const member of declaration.type.members) {
+          if (
+            ts.isPropertySignature(member) &&
+            ts.isComputedPropertyName(member.name)
+          ) {
+            receiverTypes.push(
+              checker.getTypeAtLocation(member.name.expression),
+            );
+          }
+        }
+
+        return receiverTypes;
+      }
+
+      return [];
+    }
+
+    function isObjectPatternDestructureSource(
+      objectExpression: TSESTree.ObjectExpression,
+    ) {
+      const objectExpressionParent = objectExpression.parent;
+
+      return (
+        (objectExpressionParent.type === AST_NODE_TYPES.VariableDeclarator &&
+          objectExpressionParent.id.type === AST_NODE_TYPES.ObjectPattern &&
+          objectExpressionParent.init === objectExpression) ||
+        (objectExpressionParent.type === AST_NODE_TYPES.AssignmentExpression &&
+          objectExpressionParent.left.type === AST_NODE_TYPES.ObjectPattern &&
+          objectExpressionParent.right === objectExpression) ||
+        (objectExpressionParent.type === AST_NODE_TYPES.AssignmentPattern &&
+          objectExpressionParent.left.type === AST_NODE_TYPES.ObjectPattern &&
+          objectExpressionParent.right === objectExpression)
+      );
+    }
+
+    function isArrayPatternDestructureSource(node: TSESTree.ArrayExpression) {
+      const parent = node.parent;
+
+      return (
+        (parent.type === AST_NODE_TYPES.VariableDeclarator &&
+          parent.id.type === AST_NODE_TYPES.ArrayPattern &&
+          parent.init === node) ||
+        (parent.type === AST_NODE_TYPES.AssignmentExpression &&
+          parent.left.type === AST_NODE_TYPES.ArrayPattern &&
+          parent.right === node) ||
+        (parent.type === AST_NODE_TYPES.AssignmentPattern &&
+          parent.left.type === AST_NODE_TYPES.ArrayPattern &&
+          parent.right === node)
+      );
+    }
+
+    return {
+      ':not(ObjectPattern) > Property'(
+        node: TSESTree.Property & {
+          parent: TSESTree.ObjectExpression;
+          value: TSESTree.Expression;
+        },
+      ) {
+        if (
+          hasSuppressedNestedReportAncestor(node) ||
+          isObjectPatternDestructureSource(node.parent)
+        ) {
+          return;
+        }
+
+        checkContextualAssignment(
+          node.computed ? node.value : node.key,
+          node.value,
+          node,
+          node.computed ? node.value : node.key,
+        );
+      },
+      'AccessorProperty[value != null]'(
+        node: { value: NonNullable<unknown> } & TSESTree.AccessorProperty,
+      ) {
+        if (checkImplementedMemberAssignment(node, node.value, node)) {
+          return;
+        }
+
+        checkAssignment(node, node.value, node);
+      },
+      ArrayExpression(node) {
+        if (
+          hasSuppressedNestedReportAncestor(node) ||
+          isArrayPatternDestructureSource(node)
+        ) {
+          return;
+        }
+
+        const contextualType = getContextualTypeForExpression(node);
+        const constrainedContextualType = contextualType
+          ? getConstraintType(contextualType)
+          : undefined;
+        if (
+          !constrainedContextualType ||
+          (!checker.isArrayType(constrainedContextualType) &&
+            !checker.isTupleType(constrainedContextualType))
+        ) {
+          return;
+        }
+
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const arrayElementType = checker.getIndexTypeOfType(
+          constrainedContextualType,
+          ts.IndexKind.Number,
+        )!;
+        if (getEnumTypes(checker, arrayElementType).length === 0) {
+          return;
+        }
+
+        for (const element of node.elements.filter(
+          arrayElement =>
+            arrayElement != null &&
+            arrayElement.type !== AST_NODE_TYPES.SpreadElement,
+        )) {
+          const elementType = services.getTypeAtLocation(element);
+          if (
+            isMismatchedEnumAssignmentTypes(
+              checker,
+              elementType,
+              arrayElementType,
+            )
+          ) {
+            context.report({
+              node: element,
+              messageId: 'unsafeEnumAssignment',
+              data: getReportDataForTypes([arrayElementType]),
+            });
+          }
+        }
+      },
+      ArrowFunctionExpression(node) {
+        if (node.body.type !== AST_NODE_TYPES.BlockStatement) {
+          checkReturn(node.body, node.body);
+        }
+      },
+      AssignmentExpression(node) {
+        if (node.operator === '=') {
+          checkAssigningVariable(node, node.left, node.right);
+          return;
+        }
+
+        if (valueAssigningOperators.has(node.operator)) {
+          checkAssignment(node.left, node.right, node);
+          return;
+        }
+
+        checkMutation(node.left, node);
+      },
+      AssignmentPattern(node) {
+        checkAssigningVariable(node, node.left, node.right);
+      },
+      'CallExpression, NewExpression'(
+        node: TSESTree.CallExpression | TSESTree.NewExpression,
+      ) {
+        checkArguments(node.arguments, node);
+      },
+      'JSXAttribute[value != null]'(
+        node: MakeRequired<TSESTree.JSXAttribute, 'value'>,
+      ) {
+        if (
+          node.value.type !== AST_NODE_TYPES.JSXExpressionContainer ||
+          node.value.expression.type === AST_NODE_TYPES.JSXEmptyExpression
+        ) {
+          return;
+        }
+
+        const receiverType = getContextualTypeForExpression(
+          node.value.expression,
+        );
+        if (!receiverType) {
+          return;
+        }
+        const senderType = services.getTypeAtLocation(node.value.expression);
+
+        if (
+          hasDeepEnumAssignmentMismatch(senderType, receiverType) &&
+          !isSafeEnumBitwiseExpression(node.value.expression, receiverType)
+        ) {
+          reportWithSuppressedNestedRoots(
+            node.value.expression,
+            node.value.expression,
+            'unsafeEnumAssignment',
+            [receiverType],
+          );
+        }
+      },
+      'MemberExpression[computed = true]'(
+        node: TSESTree.MemberExpression & { property: TSESTree.Expression },
+      ) {
+        const receiverTypes = [
+          getContextualTypeForExpression(node.property),
+        ].filter(type => type != null);
+
+        const memberTsNode = services.esTreeNodeToTSNodeMap.get(node);
+        for (const declaration of checker.getSymbolAtLocation(
+          memberTsNode.expression,
+        )?.declarations ?? []) {
+          receiverTypes.push(
+            ...addMappedKeyConstraintTypesFromDeclarations(declaration),
+          );
+        }
+
+        if (receiverTypes.length === 0) {
+          return;
+        }
+
+        const senderType = services.getTypeAtLocation(node.property);
+
+        for (const receiverType of receiverTypes) {
+          if (!hasDeepEnumAssignmentMismatch(senderType, receiverType)) {
+            return;
+          }
+        }
+
+        context.report({
+          node: node.property,
+          messageId: 'unsafeEnumAccess',
+          data: getReportDataForTypes(receiverTypes),
+        });
+      },
+      'PropertyDefinition[value != null]'(
+        node: TSESTree.PropertyDefinition & { value: NonNullable<unknown> },
+      ) {
+        if (!checkImplementedMemberAssignment(node, node.value, node)) {
+          checkAssignment(node, node.value, node);
+        }
+      },
+      ReturnStatement(node) {
+        if (node.argument) {
+          checkReturn(node.argument, node);
+        }
+      },
+      TaggedTemplateExpression(node: TSESTree.TaggedTemplateExpression) {
+        checkArguments(node.quasi.expressions, node);
+      },
+      TSAsExpression: checkTypeAssertion,
+      TSTypeAssertion: checkTypeAssertion,
+      UpdateExpression(node) {
+        checkMutation(node.argument, node);
+      },
+      'VariableDeclarator[init != null]'(
+        node: TSESTree.VariableDeclarator & {
+          init: NonNullable<TSESTree.VariableDeclarator['init']>;
+        },
+      ) {
+        checkAssigningVariable(node, node.id, node.init);
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin/src/rules/prefer-nullish-coalescing.ts
+++ b/packages/eslint-plugin/src/rules/prefer-nullish-coalescing.ts
@@ -259,13 +259,12 @@ export default createRule<Options, MessageIds>({
       }
 
       if (
-        tsutils
-          .typeConstituents(type)
-          .some(t =>
-            tsutils
-              .intersectionConstituents(t)
-              .some(t => tsutils.isTypeFlagSet(t, ignorableFlags)),
-          )
+        tsutils.typeConstituents(type).some(t =>
+          tsutils
+            .intersectionConstituents(t)
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-assignment -- ignorableFlags is a computed flags mask
+            .some(t => tsutils.isTypeFlagSet(t, ignorableFlags)),
+        )
       ) {
         return false;
       }

--- a/packages/eslint-plugin/src/rules/prefer-optional-chain-utils/analyzeChain.ts
+++ b/packages/eslint-plugin/src/rules/prefer-optional-chain-utils/analyzeChain.ts
@@ -46,7 +46,8 @@ function includesType(
   node: TSESTree.Node,
   typeFlagIn: ts.TypeFlags,
 ): boolean {
-  const typeFlag = typeFlagIn | ts.TypeFlags.Any | ts.TypeFlags.Unknown;
+  const typeFlag: ts.TypeFlags =
+    typeFlagIn | ts.TypeFlags.Any | ts.TypeFlags.Unknown;
   const types = unionConstituents(parserServices.getTypeAtLocation(node));
   for (const type of types) {
     if (isTypeFlagSet(type, typeFlag)) {
@@ -62,7 +63,8 @@ function isValidAndLastChainOperand(
   parserServices: ParserServicesWithTypeInformation,
 ) {
   const type = parserServices.getTypeAtLocation(ComparisonValueType);
-  const ANY_UNKNOWN_FLAGS = ts.TypeFlags.Any | ts.TypeFlags.Unknown;
+  const ANY_UNKNOWN_FLAGS: ts.TypeFlags =
+    ts.TypeFlags.Any | ts.TypeFlags.Unknown;
 
   const types = unionConstituents(type);
   switch (comparisonType) {
@@ -97,7 +99,8 @@ function isValidOrLastChainOperand(
   parserServices: ParserServicesWithTypeInformation,
 ) {
   const type = parserServices.getTypeAtLocation(ComparisonValueType);
-  const ANY_UNKNOWN_FLAGS = ts.TypeFlags.Any | ts.TypeFlags.Unknown;
+  const ANY_UNKNOWN_FLAGS: ts.TypeFlags =
+    ts.TypeFlags.Any | ts.TypeFlags.Unknown;
 
   const types = unionConstituents(type);
   switch (comparisonType) {

--- a/packages/eslint-plugin/src/rules/prefer-optional-chain-utils/gatherLogicalOperands.ts
+++ b/packages/eslint-plugin/src/rules/prefer-optional-chain-utils/gatherLogicalOperands.ts
@@ -81,7 +81,7 @@ export interface InvalidOperand {
 }
 type Operand = InvalidOperand | LastChainOperand | ValidOperand;
 
-const NULLISH_FLAGS = ts.TypeFlags.Null | ts.TypeFlags.Undefined;
+const NULLISH_FLAGS: ts.TypeFlags = ts.TypeFlags.Null | ts.TypeFlags.Undefined;
 function isValidFalseBooleanCheckType(
   node: TSESTree.Node,
   disallowFalseyLiteral: boolean,
@@ -122,7 +122,7 @@ function isValidFalseBooleanCheckType(
     return false;
   }
 
-  let allowedFlags = NULLISH_FLAGS | ts.TypeFlags.Object;
+  let allowedFlags: ts.TypeFlags = NULLISH_FLAGS | ts.TypeFlags.Object;
   if (options.checkAny === true) {
     allowedFlags |= ts.TypeFlags.Any;
   }

--- a/packages/eslint-plugin/src/rules/strict-void-return.ts
+++ b/packages/eslint-plugin/src/rules/strict-void-return.ts
@@ -356,6 +356,7 @@ export default util.createRule<Options, MessageId>({
           .getCallSignaturesOfType(actualType)
           .map(signature => signature.getReturnType())
           .flatMap(returnType => tsutils.unionConstituents(returnType))
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-assignment -- allowedReturnType is a computed flags mask
           .every(type => tsutils.isTypeFlagSet(type, allowedReturnType))
       ) {
         // The function is already void.
@@ -430,6 +431,7 @@ export default util.createRule<Options, MessageId>({
         const returnType = checker.getTypeAtLocation(
           parserServices.esTreeNodeToTSNodeMap.get(statement.argument),
         );
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-assignment -- allowedReturnType is a computed flags mask
         if (tsutils.isTypeFlagSet(returnType, allowedReturnType)) {
           // Only visit return statements with invalid type.
           continue;

--- a/packages/eslint-plugin/src/util/FunctionSignature.ts
+++ b/packages/eslint-plugin/src/util/FunctionSignature.ts
@@ -41,6 +41,9 @@ export class FunctionSignature {
   public static create(
     checker: ts.TypeChecker,
     tsNode: ts.CallLikeExpression,
+    options?: {
+      useDeclaredParameterTypes?: boolean;
+    },
   ): FunctionSignature {
     // getResolvedSignature only returns undefined for nodes outside the parse
     // tree, and tsNode always comes from the AST node map.
@@ -56,7 +59,13 @@ export class FunctionSignature {
     for (let index = 0; index < parameters.length; index += 1) {
       const param = parameters[index];
       const declaration = param.getDeclarations()?.[0];
-      const type = checker.getTypeOfSymbolAtLocation(param, tsNode);
+      const type =
+        options?.useDeclaredParameterTypes &&
+        declaration != null &&
+        ts.isParameter(declaration) &&
+        declaration.type != null
+          ? checker.getTypeFromTypeNode(declaration.type)
+          : checker.getTypeOfSymbolAtLocation(param, tsNode);
       const constrainedType = checker.getBaseConstraintOfType(type) ?? type;
 
       if (declaration && isRestParameterDeclaration(declaration)) {

--- a/packages/eslint-plugin/src/util/getOperatorPrecedence.ts
+++ b/packages/eslint-plugin/src/util/getOperatorPrecedence.ts
@@ -494,5 +494,6 @@ export function getBinaryOperatorPrecedence(
 
   // -1 is lower than all other precedences.  Returning it will cause binary expression
   // parsing to stop.
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-assignment -- -1 is a sentinel below every real precedence
   return -1;
 }

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unsafe-enum-assignment.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unsafe-enum-assignment.shot
@@ -1,0 +1,58 @@
+Incorrect
+
+enum Fruit {
+  Apple,
+}
+
+declare const someNumber: number;
+
+// Fruit.Apple is set to 0, so TypeScript allows this literal.
+const fruit: Fruit = 0;
+      ~~~~~~~~~~~~~~~~ The value assigned here does not have a shared enum type with the expected enum 'Fruit'.
+
+function takesFruit(value: Fruit) {}
+takesFruit(someNumber);
+           ~~~~~~~~~~ The argument passed here does not have a shared enum type with the expected enum 'Fruit'.
+
+function getFruit(): Fruit {
+  return someNumber;
+  ~~~~~~~~~~~~~~~~~~ The value returned here does not have a shared enum type with the expected enum 'Fruit'.
+}
+
+let mutated: Fruit = Fruit.Apple;
+mutated++;
+~~~~~~~~~ This mutation can produce a value outside of the expected enum 'Fruit'.
+mutated += 1;
+~~~~~~~~~~~~ This mutation can produce a value outside of the expected enum 'Fruit'.
+
+enum Vegetable {
+  Asparagus = 'asparagus',
+}
+
+// A type assertion bypasses TypeScript's stricter string enum checks.
+const vegetable = 'asparagus' as Vegetable;
+                  ~~~~~~~~~~~~~~~~~~~~~~~~ The value asserted here does not have a shared enum type with the expected enum 'Vegetable'.
+
+Correct
+
+enum Fruit {
+  Apple,
+}
+
+const fruit: Fruit = Fruit.Apple;
+
+function takesFruit(value: Fruit) {}
+takesFruit(Fruit.Apple);
+
+function getFruit(): Fruit {
+  return Fruit.Apple;
+}
+
+let reassigned: Fruit = Fruit.Apple;
+reassigned = Fruit.Apple;
+
+enum Vegetable {
+  Asparagus = 'asparagus',
+}
+
+const vegetable: Vegetable = Vegetable.Asparagus;

--- a/packages/eslint-plugin/tests/rules/no-unsafe-enum-assignment.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unsafe-enum-assignment.test.ts
@@ -1,0 +1,3188 @@
+import rule from '../../src/rules/no-unsafe-enum-assignment';
+import { createRuleTesterWithTypes } from '../RuleTester';
+
+const ruleTester = createRuleTesterWithTypes();
+
+ruleTester.run('no-unsafe-enum-assignment', rule, {
+  valid: [
+    `
+enum Fruit {
+  Apple,
+}
+
+const fruit: Fruit = Fruit.Apple;
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+const getFruit = (): Fruit => Fruit.Apple;
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+class Basket {
+  fruit: Fruit = Fruit.Apple;
+}
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+const box: { fruit: Fruit } = { fruit: Fruit.Apple };
+    `,
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+declare function Basket(props: { fruit: Fruit }): JSX.Element;
+
+<Basket fruit={Fruit.Apple} />;
+      `,
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          },
+        },
+      },
+    },
+    `
+({ fruit: 1 });
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+const fruits: [Fruit] = [Fruit.Apple];
+void fruits;
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+const [fruit]: Fruit[] = [Fruit.Apple];
+void fruit;
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+const [fruit]: [Fruit] = [Fruit.Apple] as Fruit[];
+void fruit;
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+let fruit: Fruit;
+[fruit] = [Fruit.Apple];
+void fruit;
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+function takeFruit([fruit]: Fruit[] = [Fruit.Apple]): void {
+  void fruit;
+}
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+const getFruit = (): Fruit => {
+  return Fruit.Apple;
+};
+
+void getFruit;
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+function takesFruits(...fruits: Fruit[]): void {}
+
+const fruits: Fruit[] = [Fruit.Apple];
+takesFruits(...fruits);
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+declare const foo: { plain: string };
+
+foo[0];
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+({})[0];
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+const [fruit]: [Fruit] = [Fruit.Apple];
+void fruit;
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+const { fruit }: { fruit: Fruit } = {} as {};
+void fruit;
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+declare const fruitKey: unique symbol;
+
+type Basket = { [fruitKey]: Fruit };
+
+const { [fruitKey]: fruit }: Basket = { [fruitKey]: Fruit.Apple };
+void fruit;
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+declare const fruitKey: unique symbol;
+
+interface Basket {
+  [fruitKey]: Fruit;
+}
+
+class TestBasket implements Basket {
+  [fruitKey] = Fruit.Apple;
+}
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+const fruit = Fruit.Apple as Fruit;
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+class Basket {
+  fruit = Fruit.Apple;
+}
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+interface Basket {
+  fruit: Fruit;
+}
+
+class TestBasket implements Basket {
+  fruit = Fruit.Apple;
+}
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+declare const foo: { [key in Fruit]: string };
+
+foo[Fruit.Apple];
+foo?.[Fruit.Apple];
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+declare const foo: { [key in Fruit | number]: string };
+
+foo[0];
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+declare const something: any;
+
+const fruit: Fruit = something;
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+declare const something: any;
+
+function takesFruit(fruit: Fruit): void {}
+
+takesFruit(something);
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+declare const something: unknown;
+
+const fruit: Fruit = something as Fruit;
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+function takesFruitOrNull(fruit: Fruit | null): void {}
+
+takesFruitOrNull(null);
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+function takesFruitOrUndefined(fruit: Fruit | undefined): void {}
+
+takesFruitOrUndefined(undefined);
+    `,
+    `
+enum Fruit {
+  Apple,
+  Banana,
+}
+
+declare const apple: Fruit;
+
+const fruit: Fruit = apple;
+    `,
+    `
+const enum Direction {
+  Up,
+  Down,
+}
+
+const dir: Direction = Direction.Up;
+    `,
+    `
+enum Flags {
+  Read = 1 << 0,
+  Write = 1 << 1,
+}
+
+const combined: Flags = Flags.Read | Flags.Write;
+    `,
+    `
+enum Flags {
+  Read = 1 << 0,
+  Write = 1 << 1,
+}
+
+let flags: Flags = Flags.Read;
+flags |= Flags.Write;
+flags &= Flags.Read;
+flags ^= Flags.Write;
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+let fruit: Fruit | undefined;
+fruit ??= Fruit.Apple;
+fruit ||= Fruit.Apple;
+fruit &&= Fruit.Apple;
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+let count = 1;
+count++;
+count += 1;
+void Fruit;
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+declare const fruits: Record<Fruit, string>;
+
+const hasApple = 0 in fruits;
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+type Mapped<T> = { [K in keyof T]: T[K] };
+
+declare const source: Mapped<{ fruit: Fruit }>;
+
+const target: { fruit: Fruit } = source;
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+interface Api<T> {
+  extend<U>(value: U): Api<T & U>;
+  fruit: T;
+}
+
+declare const api: Api<Fruit>;
+
+const extended: Api<Fruit> = api;
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+enum Vegetable {
+  Asparagus = 'asparagus',
+}
+
+function takesEither(val: Fruit | Vegetable): void {}
+
+takesEither(Fruit.Apple);
+takesEither(Vegetable.Asparagus);
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+async function getFruit(): Promise<Fruit> {
+  return Fruit.Apple;
+}
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+function getFruitOrNull(): Fruit | null {
+  return null;
+}
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+declare function tag(strings: TemplateStringsArray, fruit: Fruit): string;
+
+tag\`\${Fruit.Apple}\`;
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+class Basket {
+  constructor(public fruit: Fruit) {}
+}
+
+new Basket(Fruit.Apple);
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+const fruit = Fruit.Apple;
+const box: { fruit: Fruit } = { fruit };
+    `,
+    `
+enum Mixed {
+  A = 'a',
+  B = 1,
+}
+
+const val: Mixed = Mixed.A;
+const val2: Mixed = Mixed.B;
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+interface HasFruit {
+  fruit: Fruit;
+}
+
+interface HasNumber {
+  fruit: number;
+}
+
+class TestBasket implements HasFruit, HasNumber {
+  fruit = 1;
+}
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+function takesFruit(fruit: Fruit): void {}
+
+takesFruit(...[Fruit.Apple]);
+    `,
+    `
+enum Fruit {
+  Apple,
+  Banana,
+}
+
+const fruits: Fruit[] = [Fruit.Apple, Fruit.Banana];
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+const fruits: Array<Fruit | number> = [1, Fruit.Apple];
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+declare const bar: { [Fruit.Apple]: string };
+
+bar[Fruit.Apple];
+bar?.[Fruit.Apple];
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+function takesNothing(): void {}
+
+takesNothing();
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+function takesRest(first: Fruit, ...rest: Fruit[]): void {}
+
+takesRest(Fruit.Apple, Fruit.Apple, Fruit.Apple);
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+function takesFruits(first: Fruit, second: Fruit): void {}
+
+takesFruits(...[Fruit.Apple, ...[Fruit.Apple]]);
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+const { ['fruit']: fruit }: { fruit: Fruit } = { fruit: Fruit.Apple };
+void fruit;
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+const [, ...rest]: Fruit[] = [Fruit.Apple, Fruit.Apple];
+void rest;
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+let fruit: Fruit;
+({ fruit } = { fruit: Fruit.Apple });
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+function pick({ fruit }: { fruit: Fruit } = { fruit: Fruit.Apple }): Fruit {
+  return fruit;
+}
+
+pick();
+    `,
+    {
+      code: `
+enum Vegetable {
+  Asparagus = 'asparagus',
+}
+
+declare function Basket(props: { vegetable: Vegetable }): JSX.Element;
+
+<Basket vegetable="asparagus" />;
+      `,
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          },
+        },
+      },
+    },
+    `
+enum Fruit {
+  Apple,
+}
+
+declare const x: Fruit;
+const y: Fruit = x;
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+function noop(): void {
+  return;
+}
+
+noop();
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+const fruits: Fruit[] = [...[Fruit.Apple]];
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+function takeFruit(fruit: Fruit): void {}
+takeFruit(...[Fruit.Apple, ...[1]]);
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+function takesGeneric<T extends readonly unknown[]>(...args: T): void {}
+
+takesGeneric(Fruit.Apple);
+    `,
+    `
+enum Flags {
+  Read = 1 << 0,
+  Write = 1 << 1,
+}
+
+const combined: Flags = (Flags.Read as Flags) | Flags.Write;
+void combined;
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+interface Basket {
+  fruit: Fruit;
+}
+
+class Base {
+  fruit: Fruit = Fruit.Apple;
+}
+
+class Child extends Base implements Basket {
+  fruit = Fruit.Apple;
+}
+
+void Child;
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+interface Basket {
+  fruit: Fruit;
+}
+
+class Child implements Basket {
+  other = Fruit.Apple;
+  fruit: Fruit = Fruit.Apple;
+}
+
+void Child;
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+const key = 'fruit' as const;
+const { [key]: picked }: { fruit: Fruit } = { fruit: Fruit.Apple };
+void picked;
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+const { fruit: picked }: { fruit: Fruit } = { fruit: Fruit.Apple };
+void picked;
+    `,
+    `
+enum Flags {
+  Read = 1 << 0,
+  Write = 1 << 1,
+}
+
+const combined: Flags = Flags.Read | (Flags.Write & Flags.Read);
+void combined;
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+function takesFruit(fruit: Fruit): void {}
+takesFruit(Fruit.Apple, Fruit.Apple);
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+declare const rec: Record<string, string>;
+rec[Fruit.Apple];
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+doesNotExist(Fruit.Apple);
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+function takesFruits(fruits: Fruit[]): void {}
+
+takesFruits([Fruit.Apple]);
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+[1];
+    `,
+    `
+const numbers: number[] = [1];
+void numbers;
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+interface Basket {
+  fruit: Fruit;
+}
+
+class TestBasket implements Basket {
+  #other = 1;
+  fruit = Fruit.Apple;
+}
+
+void TestBasket;
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+interface Basket {
+  fruit: Fruit;
+}
+
+class TestBasket implements Basket {
+  other = 1;
+  fruit = Fruit.Apple;
+}
+
+void TestBasket;
+    `,
+    `
+function foo(): void {}
+
+foo[0];
+    `,
+    `
+const foo = {};
+
+foo[0];
+    `,
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+declare function Basket(props: { fruit?: Fruit }): JSX.Element;
+
+<Basket fruit={/* empty */} />;
+      `,
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          },
+        },
+      },
+    },
+    `
+enum Fruit {
+  Apple,
+}
+
+function identity<T extends Fruit>(value: T): T {
+  const next: T = value;
+  return next;
+}
+
+identity(Fruit.Apple);
+    `,
+    `
+enum Vegetable {
+  Asparagus = 'asparagus',
+}
+
+function identity<T extends Vegetable>(value: T): T {
+  return value;
+}
+
+identity(Vegetable.Asparagus);
+    `,
+    `
+const enum Direction {
+  Up,
+  Down,
+}
+
+function identity<T extends Direction>(value: T): T {
+  return value;
+}
+
+identity(Direction.Up);
+    `,
+    `
+enum Mixed {
+  A = 'a',
+  B = 1,
+}
+
+function identity<T extends Mixed>(value: T): T {
+  return value;
+}
+
+identity(Mixed.A);
+identity(Mixed.B);
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+function identity<T extends Fruit, V extends T>(value: V): V {
+  const next: V = value;
+  return next;
+}
+
+identity(Fruit.Apple);
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+function takesBox<T extends { fruit: Fruit }>(box: T): T {
+  const next: T = box;
+  return next;
+}
+
+takesBox({ fruit: Fruit.Apple });
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+function takesNestedBox<T extends { box: { fruit: Fruit } }>(box: T): T {
+  return box;
+}
+
+takesNestedBox({ box: { fruit: Fruit.Apple } });
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+function takesArray<T extends Fruit[]>(value: T): T {
+  const next: T = value;
+  return next;
+}
+
+takesArray([Fruit.Apple]);
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+function takesReadonlyArray<T extends readonly Fruit[]>(value: T): T {
+  return value;
+}
+
+takesReadonlyArray([Fruit.Apple] as const);
+    `,
+    `
+enum Fruit {
+  Apple,
+  Banana,
+}
+
+function takesTuple<T extends [Fruit, Fruit]>(...value: T): T {
+  return value;
+}
+
+takesTuple(Fruit.Apple, Fruit.Banana);
+    `,
+    `
+enum Fruit {
+  Apple,
+  Banana,
+}
+
+function takesReadonlyTuple<T extends readonly [Fruit, Fruit]>(value: T): T {
+  return value;
+}
+
+takesReadonlyTuple([Fruit.Apple, Fruit.Banana] as const);
+    `,
+    `
+enum Fruit {
+  Apple,
+  Banana,
+}
+
+function takesRestTuple<T extends [Fruit, ...Fruit[]]>(...value: T): T {
+  return value;
+}
+
+takesRestTuple(Fruit.Apple, Fruit.Banana);
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+type Box<T> = { fruit: T };
+
+function takesAliasBox<T extends Fruit>(box: Box<T>): Box<T> {
+  return box;
+}
+
+takesAliasBox({ fruit: Fruit.Apple });
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+interface Box<T> {
+  fruit: T;
+}
+
+function takesInterfaceBox<T extends Fruit>(box: Box<T>): Box<T> {
+  return box;
+}
+
+takesInterfaceBox({ fruit: Fruit.Apple });
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+class Box<T> {
+  constructor(public fruit: T) {}
+}
+
+const box: Box<Fruit> = new Box(Fruit.Apple);
+void box;
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+async function getFruit<T extends Fruit>(value: T): Promise<T> {
+  return value;
+}
+
+void getFruit(Fruit.Apple);
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+interface Basket<T> {
+  fruit: T;
+}
+
+class BasketImpl<T extends Fruit> implements Basket<T> {
+  fruit: T;
+
+  constructor(fruit: T) {
+    this.fruit = fruit;
+  }
+}
+
+void new BasketImpl(Fruit.Apple);
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+class Base<T> {
+  fruit!: T;
+}
+
+class BasketImpl<T extends Fruit> extends Base<T> {
+  fruit: T;
+
+  constructor(fruit: T) {
+    super();
+    this.fruit = fruit;
+  }
+}
+
+void new BasketImpl(Fruit.Apple);
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+declare const foo: { [key in Fruit]: string };
+
+function readValue<K extends Fruit>(key: K): string {
+  return foo[key];
+}
+
+readValue(Fruit.Apple);
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+function destructureArray<T extends [Fruit]>(value: T): T {
+  const [fruit] = value;
+  void fruit;
+  return value;
+}
+
+destructureArray([Fruit.Apple]);
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+const notFn = 1;
+notFn(Fruit.Apple);
+
+const notTag = 1;
+notTag\`fruit\`;
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+const box: { [key in Fruit]: number } = { [Fruit.Apple]: 1 };
+void box;
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+declare function takeBox(box: { fruit: Fruit }): void;
+
+takeBox([Fruit.Apple]);
+
+const value: {} = [Fruit.Apple];
+void value;
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+type BadThenable = {
+  then(onfulfilled: string): unknown;
+};
+
+async function getFruit(): Promise<Fruit> {
+  return {} as BadThenable;
+}
+
+void getFruit;
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+type BadThenable = {
+  then(onfulfilled: string): unknown;
+};
+
+async function getFruit(): BadThenable {
+  return Promise.resolve(Fruit.Apple);
+}
+
+void getFruit;
+    `,
+    `
+enum Fruit {
+  Apple,
+  Banana,
+}
+
+let foo: { [key in Fruit]: string } = {
+  [Fruit.Apple]: 'apple',
+  [Fruit.Banana]: 'banana',
+};
+
+foo[Math.random() > 0.5 ? Fruit.Apple : Fruit.Banana] = 'fruit';
+
+const value = foo[Math.random() > 0.5 ? Fruit.Apple : Fruit.Banana];
+void value;
+    `,
+    `
+enum Fruit {
+  Apple,
+}
+
+function destructureObject<T extends { fruit: Fruit }>(value: T): T {
+  const { fruit } = value;
+  void fruit;
+  return value;
+}
+
+destructureObject({ fruit: Fruit.Apple });
+    `,
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+declare function Basket<T extends { fruit: Fruit }>(props: T): JSX.Element;
+
+<Basket fruit={Fruit.Apple} />;
+      `,
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          },
+        },
+      },
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+declare namespace JSX {
+  interface IntrinsicElements {
+    div: {};
+  }
+}
+
+<div fruit={Fruit.Apple} />;
+      `,
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          },
+        },
+      },
+    },
+  ],
+  invalid: [
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+let fruit: Fruit = Fruit.Apple;
+fruit++;
+      `,
+      errors: [
+        {
+          column: 1,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 8,
+          line: 7,
+          messageId: 'unsafeEnumMutation',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+let fruit: Fruit = Fruit.Apple;
+--fruit;
+      `,
+      errors: [
+        {
+          column: 1,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 8,
+          line: 7,
+          messageId: 'unsafeEnumMutation',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+let fruit: Fruit = Fruit.Apple;
+fruit += 1;
+      `,
+      errors: [
+        {
+          column: 1,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 11,
+          line: 7,
+          messageId: 'unsafeEnumMutation',
+        },
+      ],
+    },
+    {
+      code: `
+enum Flags {
+  Read = 1 << 0,
+  Write = 1 << 1,
+}
+
+let flags: Flags = Flags.Read;
+flags <<= 1;
+      `,
+      errors: [
+        {
+          column: 1,
+          data: { enumNames: "'Flags'" },
+          endColumn: 12,
+          line: 8,
+          messageId: 'unsafeEnumMutation',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+declare const basket: { fruit: Fruit };
+basket.fruit++;
+      `,
+      errors: [
+        {
+          column: 1,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 15,
+          line: 7,
+          messageId: 'unsafeEnumMutation',
+        },
+      ],
+    },
+    {
+      code: `
+enum Flags {
+  Read = 1 << 0,
+  Write = 1 << 1,
+}
+
+declare const someNumber: number;
+
+let flags: Flags = Flags.Read;
+flags |= someNumber;
+      `,
+      errors: [
+        {
+          column: 1,
+          data: { enumNames: "'Flags'" },
+          endColumn: 20,
+          line: 10,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+let fruit: Fruit | undefined;
+fruit ??= 1;
+      `,
+      errors: [
+        {
+          column: 1,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 12,
+          line: 7,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+declare function takes(...args: [Fruit, Fruit]): void;
+declare const spread: [Fruit, ...Fruit[]];
+takes(...spread, 1);
+      `,
+      errors: [
+        {
+          column: 18,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 19,
+          line: 8,
+          messageId: 'unsafeEnumArgument',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+declare function takes(...args: [Fruit, ...Fruit[]]): void;
+
+takes(Fruit.Apple, Fruit.Apple, 1);
+      `,
+      errors: [
+        {
+          column: 33,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 34,
+          line: 8,
+          messageId: 'unsafeEnumArgument',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+const fruit: Fruit = 1;
+      `,
+      errors: [
+        {
+          column: 7,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 23,
+          line: 6,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+let fruit = Fruit.Apple;
+fruit = 1;
+      `,
+      errors: [
+        {
+          column: 1,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 10,
+          line: 7,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+function takesFruit(fruit: Fruit = 1) {}
+      `,
+      errors: [
+        {
+          column: 21,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 37,
+          line: 6,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+class Basket {
+  fruit: Fruit = 1;
+}
+      `,
+      errors: [
+        {
+          column: 3,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 20,
+          line: 7,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+interface Basket {
+  fruit: Fruit;
+}
+
+class TestBasket implements Basket {
+  fruit = 1;
+}
+      `,
+      errors: [
+        {
+          column: 3,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 13,
+          line: 11,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+const box: { fruit: Fruit } = { fruit: 1 };
+      `,
+      errors: [
+        {
+          column: 33,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 41,
+          line: 6,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+function takesFruit(fruit: Fruit): void {}
+
+takesFruit(1);
+      `,
+      errors: [
+        {
+          column: 12,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 13,
+          line: 8,
+          messageId: 'unsafeEnumArgument',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+declare const maybeFruit: Fruit | number;
+
+const fruit: Fruit = maybeFruit;
+      `,
+      errors: [
+        {
+          column: 7,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 32,
+          line: 8,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+function getFruit(): Fruit {
+  return 1;
+}
+      `,
+      errors: [
+        {
+          column: 3,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 12,
+          line: 7,
+          messageId: 'unsafeEnumReturn',
+        },
+      ],
+    },
+    {
+      code: `
+enum Vegetable {
+  Asparagus = 'asparagus',
+}
+
+const getVegetable = (): Vegetable => 'asparagus';
+      `,
+      errors: [
+        {
+          column: 39,
+          data: { enumNames: "'Vegetable'" },
+          endColumn: 50,
+          line: 6,
+          messageId: 'unsafeEnumReturn',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+const fruit = 1 as Fruit;
+      `,
+      errors: [
+        {
+          column: 15,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 25,
+          line: 6,
+          messageId: 'unsafeEnumAssertion',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+const fruit = <Fruit>1;
+      `,
+      errors: [
+        {
+          column: 15,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 23,
+          line: 6,
+          messageId: 'unsafeEnumAssertion',
+        },
+      ],
+    },
+    {
+      code: `
+enum Vegetable {
+  Asparagus = 'asparagus',
+}
+
+const vegetable: Vegetable = 'asparagus';
+      `,
+      errors: [
+        {
+          column: 7,
+          data: { enumNames: "'Vegetable'" },
+          endColumn: 41,
+          line: 6,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+function takesFruit(...fruit: [Fruit]): void {}
+
+takesFruit(...([1] as const));
+      `,
+      errors: [
+        {
+          column: 12,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 29,
+          line: 8,
+          messageId: 'unsafeEnumArgument',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+function takesFruit(fruit: Fruit): void {}
+
+takesFruit(...[1]);
+      `,
+      errors: [
+        {
+          column: 12,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 18,
+          line: 8,
+          messageId: 'unsafeEnumArgument',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+  Banana,
+}
+
+function takesFruits(first: Fruit, second: Fruit): void {}
+
+takesFruits(...[Fruit.Apple, 1]);
+      `,
+      errors: [
+        {
+          column: 13,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 32,
+          line: 9,
+          messageId: 'unsafeEnumArgument',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+  Banana,
+}
+
+const fruits: Fruit[] = [1, 2];
+      `,
+      errors: [
+        {
+          column: 26,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 27,
+          line: 7,
+          messageId: 'unsafeEnumAssignment',
+        },
+        {
+          column: 29,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 30,
+          line: 7,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+function takesFruits(fruits: Fruit[]): void {}
+
+takesFruits([1]);
+      `,
+      errors: [
+        {
+          column: 14,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 15,
+          line: 8,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+const basket: { fruit: Fruit } = { fruit: Fruit.Apple };
+
+basket.fruit = 1;
+      `,
+      errors: [
+        {
+          column: 1,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 17,
+          line: 8,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Vegetable {
+  Asparagus = 'asparagus',
+}
+
+declare function Basket(props: { vegetable: Vegetable }): JSX.Element;
+
+<Basket vegetable={'asparagus'} />;
+      `,
+      errors: [
+        {
+          column: 20,
+          data: { enumNames: "'Vegetable'" },
+          endColumn: 31,
+          line: 8,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          },
+        },
+      },
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+declare const foo: { [key in Fruit]: string };
+
+foo[0];
+      `,
+      errors: [
+        {
+          column: 5,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 6,
+          line: 8,
+          messageId: 'unsafeEnumAccess',
+        },
+      ],
+    },
+    {
+      code: `
+enum Vegetable {
+  Asparagus = 'asparagus',
+}
+
+declare const foo: { [key in Vegetable]: string };
+
+foo?.['asparagus'];
+      `,
+      errors: [
+        {
+          column: 7,
+          data: { enumNames: "'Vegetable'" },
+          endColumn: 18,
+          line: 8,
+          messageId: 'unsafeEnumAccess',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+declare const bar: { [Fruit.Apple]: string };
+
+bar[0];
+      `,
+      errors: [
+        {
+          column: 5,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 6,
+          line: 8,
+          messageId: 'unsafeEnumAccess',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+declare const bar: { [Fruit.Apple]: string };
+
+bar?.[0];
+      `,
+      errors: [
+        {
+          column: 7,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 8,
+          line: 8,
+          messageId: 'unsafeEnumAccess',
+        },
+      ],
+    },
+    {
+      code: `
+const enum Direction {
+  Up,
+  Down,
+}
+
+const dir: Direction = 0;
+      `,
+      errors: [
+        {
+          column: 7,
+          data: { enumNames: "'Direction'" },
+          endColumn: 25,
+          line: 7,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+enum Vegetable {
+  Asparagus,
+}
+
+const fruit: Fruit = Vegetable.Asparagus;
+      `,
+      errors: [
+        {
+          column: 7,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 41,
+          line: 10,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+async function getFruit(): Promise<Fruit> {
+  return 1;
+}
+      `,
+      errors: [
+        {
+          column: 3,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 12,
+          line: 7,
+          messageId: 'unsafeEnumReturn',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+declare function tag(strings: TemplateStringsArray, fruit: Fruit): string;
+
+tag\`\${1}\`;
+      `,
+      errors: [
+        {
+          column: 7,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 8,
+          line: 8,
+          messageId: 'unsafeEnumArgument',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+class Basket {
+  constructor(public fruit: Fruit) {}
+}
+
+new Basket(1);
+      `,
+      errors: [
+        {
+          column: 12,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 13,
+          line: 10,
+          messageId: 'unsafeEnumArgument',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+declare const num: number;
+
+const fruit: Fruit = num;
+      `,
+      errors: [
+        {
+          column: 7,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 25,
+          line: 8,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+const fruit: Fruit = NaN;
+      `,
+      errors: [
+        {
+          column: 7,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 25,
+          line: 6,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+const fruit: Fruit = Number.MAX_SAFE_INTEGER;
+      `,
+      errors: [
+        {
+          column: 7,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 45,
+          line: 6,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+const a: Fruit = 1,
+  b: Fruit = Fruit.Apple;
+      `,
+      errors: [
+        {
+          column: 7,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 19,
+          line: 6,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+const a: Fruit = 1,
+  b: Fruit = 2;
+      `,
+      errors: [
+        {
+          column: 7,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 19,
+          line: 6,
+          messageId: 'unsafeEnumAssignment',
+        },
+        {
+          column: 3,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 15,
+          line: 7,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+class Basket {
+  constructor(private fruit: Fruit = 1) {}
+}
+      `,
+      errors: [
+        {
+          column: 23,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 39,
+          line: 7,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+declare const fruit: number;
+
+const box: { fruit: Fruit } = { fruit };
+      `,
+      errors: [
+        {
+          column: 33,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 38,
+          line: 8,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+const [fruit]: [Fruit] = [1];
+      `,
+      errors: [
+        {
+          column: 8,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 13,
+          line: 6,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+const { fruit = 1 }: { fruit?: Fruit } = {};
+void fruit;
+      `,
+      errors: [
+        {
+          column: 9,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 18,
+          line: 6,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+function takesBasket({ fruit = 1 }: { fruit?: Fruit }): void {
+  void fruit;
+}
+      `,
+      errors: [
+        {
+          column: 24,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 33,
+          line: 6,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+function takesFruit([fruit]: [Fruit] = [1]): void {}
+      `,
+      errors: [
+        {
+          column: 22,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 27,
+          line: 6,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+const { fruit }: { fruit: Fruit } = { fruit: 1 };
+      `,
+      errors: [
+        {
+          column: 9,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 14,
+          line: 6,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+const { fruit: picked }: { fruit: Fruit } = { fruit: 1 };
+      `,
+      errors: [
+        {
+          column: 16,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 22,
+          line: 6,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+function takesBox({ fruit }: { fruit: Fruit } = { fruit: 1 }): void {}
+      `,
+      errors: [
+        {
+          column: 21,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 26,
+          line: 6,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+const fruits: Set<Fruit> = new Set([1, 2]);
+      `,
+      errors: [
+        {
+          column: 7,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 43,
+          line: 6,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+declare const cond: boolean;
+
+const fruit: Fruit = cond ? 1 : Fruit.Apple;
+      `,
+      errors: [
+        {
+          column: 7,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 44,
+          line: 8,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+class Basket {
+  accessor fruit: Fruit = 1;
+}
+      `,
+      errors: [
+        {
+          column: 3,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 29,
+          line: 7,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+function takesFruit<T extends Fruit>(fruit: T): void {}
+
+takesFruit(1);
+      `,
+      errors: [
+        {
+          column: 12,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 13,
+          line: 8,
+          messageId: 'unsafeEnumArgument',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+const x = [1, Fruit.Apple, 2] as const;
+const y: readonly Fruit[] = x;
+      `,
+      errors: [
+        {
+          column: 7,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 30,
+          line: 7,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Flags {
+  Read = 1 << 0,
+  Write = 1 << 1,
+}
+
+const combined: Flags = 1 | 2;
+      `,
+      errors: [
+        {
+          column: 7,
+          data: { enumNames: "'Flags'" },
+          endColumn: 30,
+          line: 7,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+function takesRest(first: Fruit, ...rest: Fruit[]): void {}
+
+takesRest(Fruit.Apple, 1);
+      `,
+      errors: [
+        {
+          column: 24,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 25,
+          line: 8,
+          messageId: 'unsafeEnumArgument',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+function takesRest(first: Fruit, ...rest: Fruit[]): void {}
+
+takesRest(Fruit.Apple, ...[1]);
+      `,
+      errors: [
+        {
+          column: 24,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 30,
+          line: 8,
+          messageId: 'unsafeEnumArgument',
+        },
+      ],
+    },
+    {
+      code: `
+enum Flags {
+  Read = 1 << 0,
+  Write = 1 << 1,
+}
+
+const combined: Flags = Flags.Read + Flags.Write;
+      `,
+      errors: [
+        {
+          column: 7,
+          data: { enumNames: "'Flags'" },
+          endColumn: 49,
+          line: 7,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+function takesFruit(fruit: Fruit): void {}
+const numbers: number[] = [1, 2, 3];
+
+takesFruit(...[1, ...numbers]);
+      `,
+      errors: [
+        {
+          column: 12,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 30,
+          line: 9,
+          messageId: 'unsafeEnumArgument',
+        },
+      ],
+    },
+    {
+      code: `
+enum Flags {
+  Read = 1 << 0,
+  Write = 1 << 1,
+}
+
+const combined: Flags = Flags.Read | (Flags.Write + Flags.Read);
+      `,
+      errors: [
+        {
+          column: 7,
+          data: { enumNames: "'Flags'" },
+          endColumn: 64,
+          line: 7,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+function takesFruits(...fruits: Fruit[]): void {}
+const numbers: number[] = [1, 2, 3];
+
+takesFruits(...[1, ...numbers]);
+      `,
+      errors: [
+        {
+          column: 13,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 31,
+          line: 9,
+          messageId: 'unsafeEnumArgument',
+        },
+        {
+          column: 13,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 31,
+          line: 9,
+          messageId: 'unsafeEnumArgument',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+interface Basket {
+  fruit: Fruit;
+}
+
+class TestBasket implements Basket {
+  accessor fruit = 1;
+}
+      `,
+      errors: [
+        {
+          column: 3,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 22,
+          line: 11,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+function assignFruit<T extends Fruit>(): void {
+  const fruit: T = 1;
+  void fruit;
+}
+      `,
+      errors: [
+        {
+          column: 9,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 21,
+          line: 7,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+function getFruit<T extends Fruit>(): T {
+  return 1;
+}
+      `,
+      errors: [
+        {
+          column: 3,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 12,
+          line: 7,
+          messageId: 'unsafeEnumReturn',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+function castFruit<T extends Fruit>(): T {
+  return 1 as T;
+}
+      `,
+      errors: [
+        {
+          column: 10,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 16,
+          line: 7,
+          messageId: 'unsafeEnumAssertion',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+class Box<T extends Fruit> {
+  constructor(public fruit: T) {}
+}
+
+new Box(1);
+      `,
+      errors: [
+        {
+          column: 9,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 10,
+          line: 10,
+          messageId: 'unsafeEnumArgument',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+declare function Basket<T extends Fruit>(props: { fruit: T }): JSX.Element;
+
+<Basket fruit={1} />;
+      `,
+      errors: [
+        {
+          column: 16,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 17,
+          line: 8,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          },
+        },
+      },
+    },
+    {
+      code: `
+enum Vegetable {
+  Asparagus = 'asparagus',
+}
+
+function assignVegetable<T extends Vegetable>(): void {
+  const vegetable: T = 'asparagus';
+  void vegetable;
+}
+      `,
+      errors: [
+        {
+          column: 9,
+          data: { enumNames: "'Vegetable'" },
+          endColumn: 35,
+          line: 7,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+const enum Direction {
+  Up,
+  Down,
+}
+
+function assignDirection<T extends Direction>(): void {
+  const direction: T = 0;
+  void direction;
+}
+      `,
+      errors: [
+        {
+          column: 9,
+          data: { enumNames: "'Direction'" },
+          endColumn: 25,
+          line: 8,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Mixed {
+  A = 'a',
+  B = 1,
+}
+
+function assignMixed<T extends Mixed>(): void {
+  const mixed: T = 'a';
+  void mixed;
+}
+      `,
+      errors: [
+        {
+          column: 9,
+          data: { enumNames: "'Mixed'" },
+          endColumn: 23,
+          line: 8,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+function assignFruit<T extends Fruit, V extends T>(): V {
+  return 1;
+}
+      `,
+      errors: [
+        {
+          column: 3,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 12,
+          line: 7,
+          messageId: 'unsafeEnumReturn',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+function takesBox<T extends { fruit: Fruit }>(box: T): void {}
+
+takesBox({ fruit: 1 });
+      `,
+      errors: [
+        {
+          column: 10,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 22,
+          line: 8,
+          messageId: 'unsafeEnumArgument',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+function assignBox<T extends { fruit: Fruit }>(): void {
+  const box: T = { fruit: 1 };
+  void box;
+}
+      `,
+      errors: [
+        {
+          column: 20,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 28,
+          line: 7,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+function getBox<T extends { fruit: Fruit }>(): T {
+  return { fruit: 1 };
+}
+      `,
+      errors: [
+        {
+          column: 3,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 23,
+          line: 7,
+          messageId: 'unsafeEnumReturn',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+function castBox<T extends { fruit: Fruit }>(): T {
+  return { fruit: 1 } as T;
+}
+      `,
+      errors: [
+        {
+          column: 10,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 27,
+          line: 7,
+          messageId: 'unsafeEnumAssertion',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+class Box<T extends { fruit: Fruit }> {
+  constructor(public value: T) {}
+}
+
+new Box({ fruit: 1 });
+      `,
+      errors: [
+        {
+          column: 9,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 21,
+          line: 10,
+          messageId: 'unsafeEnumArgument',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+declare function Basket<T extends { fruit: Fruit }>(props: T): JSX.Element;
+
+<Basket fruit={1} />;
+      `,
+      errors: [
+        {
+          column: 16,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 17,
+          line: 8,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          },
+        },
+      },
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+function takesNestedBox<T extends { box: { fruit: Fruit } }>(box: T): void {}
+
+takesNestedBox({ box: { fruit: 1 } });
+      `,
+      errors: [
+        {
+          column: 16,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 37,
+          line: 8,
+          messageId: 'unsafeEnumArgument',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+function takesArray<T extends Fruit[]>(value: T): void {}
+
+takesArray([1]);
+      `,
+      errors: [
+        {
+          column: 12,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 15,
+          line: 8,
+          messageId: 'unsafeEnumArgument',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+function assignArray<T extends Fruit[]>(): void {
+  const fruits: T = [1];
+  void fruits;
+}
+      `,
+      errors: [
+        {
+          column: 9,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 24,
+          line: 7,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+function getArray<T extends Fruit[]>(): T {
+  return [1];
+}
+      `,
+      errors: [
+        {
+          column: 3,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 14,
+          line: 7,
+          messageId: 'unsafeEnumReturn',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+function castArray<T extends Fruit[]>(): T {
+  return [1] as T;
+}
+      `,
+      errors: [
+        {
+          column: 10,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 18,
+          line: 7,
+          messageId: 'unsafeEnumAssertion',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+function takesReadonlyArray<T extends readonly Fruit[]>(value: T): void {}
+
+takesReadonlyArray([1] as const);
+      `,
+      errors: [
+        {
+          column: 20,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 32,
+          line: 8,
+          messageId: 'unsafeEnumArgument',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+function takesBoxes<T extends Array<{ fruit: Fruit }>>(boxes: T): void {}
+
+takesBoxes([{ fruit: 1 }]);
+      `,
+      errors: [
+        {
+          column: 12,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 26,
+          line: 8,
+          messageId: 'unsafeEnumArgument',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+function assignBoxes<T extends readonly { fruit: Fruit }[]>(): void {
+  const boxes: T = [{ fruit: 1 }] as const;
+  void boxes;
+}
+      `,
+      errors: [
+        {
+          column: 9,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 43,
+          line: 7,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+  Banana,
+}
+
+function assignReadonlyTuple<T extends readonly [Fruit, Fruit]>(): void {
+  const value: T = [Fruit.Apple, 1] as const;
+  void value;
+}
+      `,
+      errors: [
+        {
+          column: 9,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 45,
+          line: 8,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+type Box<T> = { fruit: T };
+
+function takesAliasBox<T extends Fruit>(box: Box<T>): void {}
+
+takesAliasBox({ fruit: 1 });
+      `,
+      errors: [
+        {
+          column: 15,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 27,
+          line: 10,
+          messageId: 'unsafeEnumArgument',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+interface Box<T> {
+  fruit: T;
+}
+
+const box: Box<Fruit> = { fruit: 1 };
+void box;
+      `,
+      errors: [
+        {
+          column: 27,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 35,
+          line: 10,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+class Box<T> {
+  constructor(public fruit: T) {}
+}
+
+const box: Box<Fruit> = new Box(1);
+void box;
+      `,
+      errors: [
+        {
+          column: 7,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 35,
+          line: 10,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+async function getBox<T extends { fruit: Fruit }>(): Promise<T> {
+  return { fruit: 1 };
+}
+      `,
+      errors: [
+        {
+          column: 3,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 23,
+          line: 7,
+          messageId: 'unsafeEnumReturn',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+interface Basket<T> {
+  fruit: T;
+}
+
+class BasketImpl implements Basket<Fruit> {
+  fruit = 1;
+}
+      `,
+      errors: [
+        {
+          column: 3,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 13,
+          line: 11,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+class Base<T> {
+  fruit!: T;
+}
+
+class BasketImpl extends Base<Fruit> {
+  fruit = 1;
+}
+      `,
+      errors: [
+        {
+          column: 3,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 13,
+          line: 11,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+interface Basket<T> {
+  fruit: T;
+}
+
+class BasketImpl<T extends Fruit> implements Basket<T> {
+  fruit = 1;
+}
+      `,
+      errors: [
+        {
+          column: 3,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 13,
+          line: 11,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+declare const foo: { [key in Fruit]: string };
+
+function readValue<K extends number>(key: K): string {
+  return foo[key];
+}
+      `,
+      errors: [
+        {
+          column: 14,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 17,
+          line: 9,
+          messageId: 'unsafeEnumAccess',
+        },
+      ],
+    },
+    {
+      code: `
+enum Fruit {
+  Apple,
+}
+
+function readValue<K extends number>(
+  foo: { [P in Fruit]: string },
+  key: K,
+): string {
+  return foo[key];
+}
+      `,
+      errors: [
+        {
+          column: 14,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 17,
+          line: 10,
+          messageId: 'unsafeEnumAccess',
+        },
+      ],
+    },
+  ],
+});

--- a/packages/eslint-plugin/tests/schema-snapshots/no-unsafe-enum-assignment.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-unsafe-enum-assignment.shot
@@ -1,0 +1,10 @@
+
+# SCHEMA:
+
+[]
+
+
+# TYPES:
+
+/** No options declared */
+type Options = [];

--- a/packages/type-utils/src/typeFlagUtils.ts
+++ b/packages/type-utils/src/typeFlagUtils.ts
@@ -7,8 +7,8 @@ const ANY_OR_UNKNOWN = ts.TypeFlags.Any | ts.TypeFlags.Unknown;
  * Gets all of the type flags in a type, iterating through unions automatically.
  */
 export function getTypeFlags(type: ts.Type): ts.TypeFlags {
-  // @ts-expect-error Since typescript 5.0, this is invalid, but uses 0 as the default value of TypeFlags.
-  let flags: ts.TypeFlags = 0;
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-assignment -- a flags accumulator starts out holding no flags
+  let flags = 0 as ts.TypeFlags;
   for (const t of tsutils.unionConstituents(type)) {
     flags |= t.flags;
   }

--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -2236,6 +2236,7 @@ export class Converter {
       case SyntaxKind.UndefinedKeyword:
       case SyntaxKind.IntrinsicKeyword: {
         return this.createNode<any>(node, {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-assignment -- narrowing a computed AST_NODE_TYPES key at a conversion boundary
           type: AST_NODE_TYPES[`TS${SyntaxKind[node.kind]}` as AST_NODE_TYPES],
         });
       }
@@ -2908,6 +2909,7 @@ export class Converter {
       );
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-assignment -- narrowing a computed AST_NODE_TYPES key at a conversion boundary
     const customType = `TS${SyntaxKind[node.kind]}` as AST_NODE_TYPES;
 
     /**

--- a/packages/typescript-estree/src/create-program/getScriptKind.ts
+++ b/packages/typescript-estree/src/create-program/getScriptKind.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import * as ts from 'typescript';
 
 export function getScriptKind(filePath: string, jsx: boolean): ts.ScriptKind {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-assignment -- narrowing a file extension string to ts.Extension at a parse boundary
   const extension = path.extname(filePath).toLowerCase() as ts.Extension;
   // note - we only respect the user's jsx setting for unknown extensions
   // this is so that we always match TS's internal script kind logic, preventing

--- a/packages/typescript-estree/src/parseSettings/createParseSettings.ts
+++ b/packages/typescript-estree/src/parseSettings/createParseSettings.ts
@@ -96,6 +96,7 @@ export function createParseSettings(
       : getFileName(tsestreeOptions.jsx),
     tsconfigRootDir,
   );
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-assignment -- narrowing a file extension string to ts.Extension at a parse boundary
   const extension = path.extname(filePath).toLowerCase() as ts.Extension;
   const jsDocParsingMode = ((): ts.JSDocParsingMode => {
     switch (tsestreeOptions.jsDocParsingMode) {

--- a/packages/website/src/components/ErrorsViewer.tsx
+++ b/packages/website/src/components/ErrorsViewer.tsx
@@ -71,6 +71,7 @@ function ErrorBlock({
   setIsLocked,
 }: ErrorBlockProps): React.JSX.Element {
   return (
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-assignment -- monaco is only available as a type import here
     <AlertBlock type={severityClass(item.severity)}>
       <div className={clsx(!!item.fixer && styles.fixerContainer)}>
         <pre className={styles.errorPre}>

--- a/packages/website/src/components/editor/LoadedEditor.tsx
+++ b/packages/website/src/components/editor/LoadedEditor.tsx
@@ -129,6 +129,7 @@ export const LoadedEditor: React.FC<LoadedEditorProps> = ({
       parseTSConfig(tsconfig).compilerOptions,
     );
     monaco.languages.typescript.typescriptDefaults.setCompilerOptions(
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-assignment -- monaco is only available as a type import here
       config as Monaco.languages.typescript.CompilerOptions,
     );
   }, [monaco, tsconfig]);
@@ -329,6 +330,7 @@ export const LoadedEditor: React.FC<LoadedEditorProps> = ({
     setDecorations(prevDecorations =>
       tabs.code.deltaDecorations(
         prevDecorations,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-assignment -- monaco is only available as a type import here
         selectedRange && showAST
           ? [
               {

--- a/packages/website/src/components/editor/useSandboxServices.ts
+++ b/packages/website/src/components/editor/useSandboxServices.ts
@@ -52,6 +52,7 @@ export const useSandboxServices = (
           {
             acquireTypes: true,
             compilerOptions:
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-assignment -- monaco is only available as a type import here
               compilerOptions as Monaco.languages.typescript.CompilerOptions,
             domID: editorEmbedId,
             monacoSettings: {

--- a/packages/website/src/components/linter/bridge.ts
+++ b/packages/website/src/components/linter/bridge.ts
@@ -56,6 +56,7 @@ export function createFileSystem(
 
   system.deleteFile = (fileName): void => {
     files.delete(fileName);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-assignment -- typescript is only available as a type import here
     triggerCallbacks(fileName, 1);
   };
 
@@ -69,6 +70,7 @@ export function createFileSystem(
       return;
     }
     files.set(fileName, contents);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-assignment -- typescript is only available as a type import here
     triggerCallbacks(fileName, file ? 2 : 0);
   };
 

--- a/packages/website/src/components/linter/utils.ts
+++ b/packages/website/src/components/linter/utils.ts
@@ -140,6 +140,7 @@ export function parseLintResults(
       endColumn,
       endLineNumber,
       message: message.message,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-assignment -- monaco is only available as a type import here
       severity:
         message.severity === 2
           ? 8 // MarkerSeverity.Error

--- a/packages/website/tools/typedoc-plugin-no-inherit-fork.mjs
+++ b/packages/website/tools/typedoc-plugin-no-inherit-fork.mjs
@@ -60,6 +60,7 @@ class NoInheritPlugin {
     if (reflection instanceof DeclarationReflection) {
       // class or interface that won't inherit docs
       if (
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-assignment -- ReflectionKind.ClassOrInterface is a composed flags value
         reflection.kindOf(ReflectionKind.ClassOrInterface)
         // Fork: always add reflections, regardless of a @noInheritDoc tag
         // &&
@@ -74,6 +75,7 @@ class NoInheritPlugin {
       if (
         reflection.inheritedFrom &&
         reflection.parent &&
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-assignment -- ReflectionKind.ClassOrInterface is a composed flags value
         reflection.parent.kindOf(ReflectionKind.ClassOrInterface) &&
         (!reflection.overwrites ||
           (reflection.overwrites &&


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #308
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Adds `no-unsafe-enum-assignment` to `strict-type-checked`: reports non-enum values flowing into enum-typed locations (declarations, assignments, mutations, arguments, returns, properties, JSX attributes, computed access, assertions).

The other half of #308 — #6107 shipped comparisons. Revives #12154, which revived #6091 (co-authored with @Zamiell).

> [!NOTE]
> Stacked on #12722, which extracts the shared utils this rule needs out of `no-unsafe-argument` and `no-unsafe-enum-comparison`. Review that one first; this PR targets its branch, so the diff here is just the new rule.

Numeric enums are where this earns its keep: TS accepts any `number`, and accepts literals that coincide with a member's value. String enums are already well guarded, so there it only catches assertions.

Mutation is covered too, since it's just assignment through an operator — `fruit++`, `fruit += 1`, and `flags <<= 1` all produce a plain number. `|=`, `&=`, and `^=` stay allowed when the right side shares the enum type, so the bit flags idiom still works.

## Performance

@bradzacher called this one on #6091. As written in #12154 it was **+161%** on lint time; the memo key was calling `checker.typeToString` on every type pair it walked. Keying on type identity instead gets it to **+3.0s on a 19.2s baseline (+16%)** across three packages, median of three. Control: disabling a different type-aware rule leaves the run unchanged.

## Enabling it here

27 reports. Six were loose typing worth fixing (composed flag constants now annotated `ts.TypeFlags`). One was a crash — `'target' in type` as a type-reference guard, which mapped types and generic signatures also satisfy.

The other 20 are disables with reasons: 9 third-party enums only reachable via `import type`, 5 computed flag masks, 5 parse-boundary assertions, 1 sentinel. **The flag-mask ones are the allowlist option you proposed on #6091 and I deferred** — worth deciding whether that lands before this goes into `strict-type-checked`.

Written agentically and reviewed by me; the perf numbers and the self-report triage are my own.

💖
