### PR TITLE
test(eslint-plugin): [no-floating-promises] format test snippets

### DIFF
--- a/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
@@ -871,9 +871,9 @@ myAsyncFunction();
     "document.addEventListener('click', () => void fetch('/api/click'));",
 
     `
-      document.addEventListener('click', () => {
-        void fetch('/api/click');
-      });
+document.addEventListener('click', () => {
+  void fetch('/api/click');
+});
     `,
 
     // This code makes TypeScript type checker to crash with infinite recursion
@@ -5724,14 +5724,14 @@ await (async () => {
 
     {
       code: `
-        document.addEventListener('click', () => {
-          void fetch('/api/click');
-        });
+document.addEventListener('click', () => {
+  void fetch('/api/click');
+});
       `,
       errors: [
         {
-          column: 11,
-          endColumn: 36,
+          column: 3,
+          endColumn: 28,
           endLine: 3,
           line: 3,
           messageId: 'floating',
@@ -5739,9 +5739,9 @@ await (async () => {
             {
               messageId: 'floatingFixAwait',
               output: `
-        document.addEventListener('click', () => {
-          await fetch('/api/click');
-        });
+document.addEventListener('click', () => {
+  await fetch('/api/click');
+});
       `,
             },
           ],


### PR DESCRIPTION
## PR Checklist

- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

`main` is currently failing `Lint with build (1/4, eslint-plugin)`: three `@typescript-eslint/internal/plugin-test-formatting` errors in `no-floating-promises.test.ts`. The snippets added in #12646 are indented, and that rule wants them at column 0.

Running the fixer shifts the invalid case's reported columns, which is what the rule's "the automated fixer may break your test locations" warning is about, so this also updates `column` 11 → 3 and `endColumn` 36 → 28, and de-indents the suggestion `output` to match its `code`.
