### PR TITLE
feat(website): respect playground allowJs setting

### DIFF
--- a/packages/website/src/components/lib/createCompilerOptions.ts
+++ b/packages/website/src/components/lib/createCompilerOptions.ts
@@ -8,11 +8,11 @@ export function createCompilerOptions(
 ): ts.CompilerOptions {
   const config = window.ts.convertCompilerOptionsFromJson(
     {
+      allowJs: true,
       jsx: 'preserve',
       module: 'esnext',
       target: 'esnext',
       ...tsConfig,
-      allowJs: true,
       baseUrl: undefined,
       lib: Array.isArray(tsConfig.lib) ? tsConfig.lib : undefined,
       moduleDetection: undefined,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #12699
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

Keep allowJs enabled by default for JavaScript playground files while respecting an explicit user setting in tsconfig.

Validated with the website lint, typecheck, and production build commands, plus direct checks for default, true, and false allowJs values.

💖