### PR TITLE
chore: [ci] fix nx outputs and enable snapshot checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -575,10 +575,8 @@ jobs:
       - lint_with_build
       - lint_with_build_eslint
       - integration_tests
-
-      # Temporarily make these optional until we figure out why it's sometimes failing in CI.
-      # - ast_spec_snapshots_clean
-      # - scope_manager_snapshots_clean
+      - ast_spec_snapshots_clean
+      - scope_manager_snapshots_clean
       - plugin_unit_tests
       - unit_tests
       - unit_tests_project_service

--- a/nx.json
+++ b/nx.json
@@ -17,7 +17,6 @@
     {
       "plugin": "@nx/vitest",
       "exclude": ["*"],
-      "outputs": ["{projectRoot}/coverage", "{projectRoot}/**/*.shot"],
       "options": {
         "testTargetName": "test",
         "typecheckTargetName": "vitest:typecheck"
@@ -70,7 +69,8 @@
       "options": {
         "config": "vitest.config.mts"
       },
-      "inputs": ["default", "{workspaceRoot}/vitest.config.base.mts"]
+      "inputs": ["default", "{workspaceRoot}/vitest.config.base.mts"],
+      "outputs": ["{projectRoot}/coverage", "{projectRoot}/**/*.shot"]
     },
     "attw-check": {
       "cache": false,

--- a/nx.json
+++ b/nx.json
@@ -70,8 +70,7 @@
       "options": {
         "config": "vitest.config.mts"
       },
-      "inputs": ["default", "{workspaceRoot}/vitest.config.base.mts"],
-      "outputs": ["{projectRoot}/coverage"]
+      "inputs": ["default", "{workspaceRoot}/vitest.config.base.mts"]
     },
     "attw-check": {
       "cache": false,


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [X] Addresses an existing open issue: fixes #
- [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [X] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

Not sure why it worked for me in #12651, it seems not to work at all now?

We have multiple 2 places declaring `outputs` - `targetDefaults.test` & `plugins['@nx/vitest']`.

I tried removing the `targetDefaults.test.outputs`, and then resolving the final nx config for the `ast-spec` package, which resulted in this:

```JSON
{
    // ...
	"test": {
      // ...
      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
    },
}
```

Turns out `@nx/vitest` plugin makes some (wrong?) assumptions regarding the coverage output, generates a wrong path (`{workspaceRoot}/coverage/{projectRoot}`), and doesn't even support overriding `outputs`...

https://github.com/nrwl/nx/blob/15a88615219b031d30dbc11f8405bf7a9c516907/packages/vitest/src/plugins/plugin.ts#L496-L501

Anyway, using only `targetDefaults` seems to be fixing this:

```JSON
{
    // ...
	"test": {
      // ...
      "outputs": ["{projectRoot}/coverage", "{projectRoot}/**/*.shot"],
    },
}
```

I ~think~ hope it'll fix this
Also, I was ~brave~ stupid enough to make these tasks required again. Pray for us 🤞
