### PR TITLE
test(eslint-plugin): cover no-unnecessary-type-assertion error handling

### DIFF
--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -1,4 +1,10 @@
+import * as parser from '@typescript-eslint/parser';
 import { noFormat } from '@typescript-eslint/rule-tester';
+import { TSESLint } from '@typescript-eslint/utils';
+import * as ts from 'typescript';
+import { describe, expect, it, vi } from 'vitest';
+
+import type * as util from '../../src/util';
 
 import rule from '../../src/rules/no-unnecessary-type-assertion';
 import { getFixturesRootDir, createRuleTesterWithTypes } from '../RuleTester';
@@ -2913,4 +2919,65 @@ maybeFn?.(s);
       `,
     },
   ],
+});
+
+describe('error handling', () => {
+  it.each([
+    { error: new Error('unexpected error'), name: 'non-RangeError' },
+    {
+      error: new RangeError('unexpected range error'),
+      name: 'RangeError with a different message',
+    },
+  ])('rethrows $name', async ({ error }) => {
+    vi.resetModules();
+    vi.doMock('../../src/util', async () => {
+      const actual = await vi.importActual<typeof util>('../../src/util');
+      return {
+        ...actual,
+        isTypeFlagSet(type: ts.Type, flags: ts.TypeFlags): boolean {
+          if (flags === ts.TypeFlags.Any) {
+            throw error;
+          }
+          return actual.isTypeFlagSet(type, flags);
+        },
+      };
+    });
+
+    const { default: ruleWithMockedTypeFlagCheck } =
+      (await import('../../src/rules/no-unnecessary-type-assertion.js')) as unknown as {
+        default: typeof rule;
+      };
+    const linter = new TSESLint.Linter({ configType: 'flat' });
+    const config: TSESLint.FlatConfig.Config = {
+      files: ['**/*.ts'],
+      languageOptions: {
+        parser,
+        parserOptions: {
+          project: './tsconfig.json',
+          tsconfigRootDir: rootDir,
+        },
+      },
+      plugins: {
+        '@typescript-eslint': {
+          rules: {
+            'no-unnecessary-type-assertion': ruleWithMockedTypeFlagCheck,
+          },
+        },
+      },
+      rules: {
+        '@typescript-eslint/no-unnecessary-type-assertion': 'error',
+      },
+    };
+
+    try {
+      expect(() =>
+        linter.verify('const value = 1 as number;', config, {
+          filename: `${rootDir}/file.ts`,
+        }),
+      ).toThrow(error);
+    } finally {
+      vi.doUnmock('../../src/util');
+      vi.resetModules();
+    }
+  });
 });


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #12705
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

<!-- Description of what is changed and how the code change does that. -->
Following up on #12711  and comment with @StyleShit , to ensure that only the specific issue was affected, implemented a fallback solely for call stack errors and allowed other errors to be thrown as usual.
The existing test case does not cover that branch, so we are updating it to ensure coverage. (ref: [codecov](https://app.codecov.io/gh/typescript-eslint/typescript-eslint/pull/12711?src=pr&el=tree&filepath=packages%2Feslint-plugin%2Fsrc%2Frules%2Fno-unnecessary-type-assertion.ts&utm_medium=referral&utm_source=github&utm_content=comment&utm_campaign=pr+comments&utm_term=typescript-eslint#diff-cGFja2FnZXMvZXNsaW50LXBsdWdpbi9zcmMvcnVsZXMvbm8tdW5uZWNlc3NhcnktdHlwZS1hc3NlcnRpb24udHM=))

These tests inject non-matching errors to verify that the catch remains narrow and does not swallow unexpected failures.

I am not used to writing test cases like this, so I’m not sure if I’m heading in the right direction.
It appears difficult to reproduce the error using only the source code, as most errors are handled during the parsing stage.