### PR TITLE
fix(eslint-plugin): [no-empty-object-type] ignore suggestions that result in invalid interfaces and export defaults

### DIFF
--- a/packages/eslint-plugin/src/rules/no-empty-object-type.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-object-type.ts
@@ -105,18 +105,26 @@ export default createRule<Options, MessageIds>({
 
           const scope = context.sourceCode.getScope(node);
 
-          const mergedWithClassDeclaration = scope.set
+          const mergedWithOtherDeclaration = scope.set
             .get(node.id.name)
             ?.defs.some(
-              def => def.node.type === AST_NODE_TYPES.ClassDeclaration,
+              def =>
+                def.node !== node &&
+                (def.node.type === AST_NODE_TYPES.ClassDeclaration ||
+                  def.node.type === AST_NODE_TYPES.TSInterfaceDeclaration),
             );
+
+          const isDefaultExport =
+            node.parent.type === AST_NODE_TYPES.ExportDefaultDeclaration;
+
+          const shouldSuggest = !mergedWithOtherDeclaration && !isDefaultExport;
 
           if (extend.length === 0) {
             context.report({
               node: node.id,
               messageId: 'noEmptyInterface',
               data: { option: 'allowInterfaces' },
-              ...(!mergedWithClassDeclaration && {
+              ...(shouldSuggest && {
                 suggest: ['object', 'unknown'].map(replacement => ({
                   messageId: 'replaceEmptyInterface',
                   data: { replacement },
@@ -140,7 +148,7 @@ export default createRule<Options, MessageIds>({
           context.report({
             node: node.id,
             messageId: 'noEmptyInterfaceWithSuper',
-            ...(!mergedWithClassDeclaration && {
+            ...(shouldSuggest && {
               suggest: [
                 {
                   messageId: 'replaceEmptyInterfaceWithSuper',

--- a/packages/eslint-plugin/tests/rules/no-empty-object-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-empty-object-type.test.ts
@@ -214,6 +214,171 @@ const derived = class Derived {};
     },
     {
       code: `
+interface Base {}
+
+interface Base {
+  name: string;
+}
+      `,
+      errors: [
+        {
+          column: 11,
+          data: { option: 'allowInterfaces' },
+          endColumn: 15,
+          endLine: 2,
+          line: 2,
+          messageId: 'noEmptyInterface',
+        },
+      ],
+    },
+    {
+      code: `
+interface Base {}
+
+interface Base {}
+      `,
+      errors: [
+        {
+          column: 11,
+          data: { option: 'allowInterfaces' },
+          endColumn: 15,
+          endLine: 2,
+          line: 2,
+          messageId: 'noEmptyInterface',
+        },
+        {
+          column: 11,
+          data: { option: 'allowInterfaces' },
+          endColumn: 15,
+          endLine: 4,
+          line: 4,
+          messageId: 'noEmptyInterface',
+        },
+      ],
+    },
+    {
+      code: `
+interface Base {}
+
+function foo() {
+  interface Base {
+    name: string;
+  }
+}
+      `,
+      errors: [
+        {
+          column: 11,
+          data: { option: 'allowInterfaces' },
+          endColumn: 15,
+          endLine: 2,
+          line: 2,
+          messageId: 'noEmptyInterface',
+          suggestions: [
+            {
+              data: { replacement: 'object' },
+              messageId: 'replaceEmptyInterface',
+              output: `
+type Base = object
+
+function foo() {
+  interface Base {
+    name: string;
+  }
+}
+      `,
+            },
+            {
+              data: { replacement: 'unknown' },
+              messageId: 'replaceEmptyInterface',
+              output: `
+type Base = unknown
+
+function foo() {
+  interface Base {
+    name: string;
+  }
+}
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+interface Base {
+  props: string;
+}
+
+interface Derived extends Base {}
+
+interface Derived {
+  name: string;
+}
+      `,
+      errors: [
+        {
+          column: 11,
+          endColumn: 18,
+          endLine: 6,
+          line: 6,
+          messageId: 'noEmptyInterfaceWithSuper',
+        },
+      ],
+    },
+    {
+      code: 'export default interface Base {}',
+      errors: [
+        {
+          column: 26,
+          data: { option: 'allowInterfaces' },
+          endColumn: 30,
+          endLine: 1,
+          line: 1,
+          messageId: 'noEmptyInterface',
+        },
+      ],
+    },
+    {
+      code: 'export default interface Derived extends Base {}',
+      errors: [
+        {
+          column: 26,
+          endColumn: 33,
+          endLine: 1,
+          line: 1,
+          messageId: 'noEmptyInterfaceWithSuper',
+        },
+      ],
+    },
+    {
+      code: 'export interface Base {}',
+      errors: [
+        {
+          column: 18,
+          data: { option: 'allowInterfaces' },
+          endColumn: 22,
+          endLine: 1,
+          line: 1,
+          messageId: 'noEmptyInterface',
+          suggestions: [
+            {
+              data: { replacement: 'object' },
+              messageId: 'replaceEmptyInterface',
+              output: `export type Base = object`,
+            },
+            {
+              data: { replacement: 'unknown' },
+              messageId: 'replaceEmptyInterface',
+              output: `export type Base = unknown`,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
 interface Base {
   name: string;
 }


### PR DESCRIPTION


<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [X] Addresses an existing open issue: fixes #12736
- [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [X] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

We already accounted for class declaration merging, so it was easy to add interfaces and export default
