### PR TITLE
fix(eslint-plugin): [no-misused-promises] check all statically analyzable declarations

### DIFF
--- a/packages/eslint-plugin/src/rules/no-misused-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-misused-promises.ts
@@ -1,4 +1,8 @@
-import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
+import type {
+  ParserServicesWithTypeInformation,
+  TSESLint,
+  TSESTree,
+} from '@typescript-eslint/utils';
 
 import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 import * as tsutils from 'ts-api-utils';
@@ -9,14 +13,17 @@ import {
   getConstrainedTypeAtLocation,
   getFunctionHeadLoc,
   getParserServices,
+  getStaticMemberAccessValue,
   isArrayMethodCallWithPredicate,
   isFunction,
   isPromiseLike,
   isRestParameterDeclaration,
+  NodeWithKey,
   nullThrows,
   NullThrowsReasons,
 } from '../util';
 import { parseFinallyCall } from '../util/promiseUtils';
+import { ParserWeakMapESTreeToTSNode } from '../../../typescript-estree/src/parser-options';
 
 export type Options = [
   {
@@ -516,9 +523,6 @@ export default createRule<Options, MessageId>({
           });
         }
       } else if (ts.isMethodDeclaration(tsNode)) {
-        if (ts.isComputedPropertyName(tsNode.name)) {
-          return;
-        }
         const obj = tsNode.parent;
 
         // Below condition isn't satisfied unless something goes wrong,
@@ -538,10 +542,27 @@ export default createRule<Options, MessageId>({
         if (objType == null) {
           return;
         }
-        const propertySymbol = tsutils
-          .unionConstituents(objType)
-          .map(t => checker.getPropertyOfType(t, tsNode.name.getText()))
-          .find(p => p);
+
+        const staticAccessValue = getStaticMemberAccessValue(node, context);
+        if (staticAccessValue == null) {
+          return;
+        }
+
+        const symbol = checker.getTypeAtLocation(obj.parent).getSymbol();
+        const staticSymbolsMap = getSymbolsToStaticSymbols(
+          services,
+          checker,
+          context,
+          symbol ? [symbol] : [],
+        );
+
+        const propertySymbol = getMemberIfExists(
+          objType,
+          staticAccessValue,
+          checker,
+          staticSymbolsMap,
+        );
+
         if (propertySymbol == null) {
           return;
         }
@@ -634,6 +655,18 @@ export default createRule<Options, MessageId>({
         return;
       }
 
+      const symbols = getHeritageSymbols(
+        checker,
+        services.esTreeNodeToTSNodeMap,
+        node,
+      ).filter(symbol => symbol !== undefined);
+      const staticSymbolsMap = getSymbolsToStaticSymbols(
+        services,
+        checker,
+        context,
+        symbols,
+      );
+
       for (const nodeMember of tsNode.members) {
         const memberName = nodeMember.name?.getText();
         if (memberName == null) {
@@ -652,11 +685,31 @@ export default createRule<Options, MessageId>({
           continue;
         }
 
+        const staticAccessValue = getStaticMemberAccessValue(
+          node as NodeWithKey,
+          context,
+        );
+
+        if (staticAccessValue == null) {
+          continue;
+        }
+
         for (const heritageType of heritageTypes) {
+          const heritageMember = getMemberIfExists(
+            heritageType,
+            staticAccessValue,
+            checker,
+            staticSymbolsMap,
+          );
+
+          if (heritageMember == null) {
+            continue;
+          }
+
           checkHeritageTypeForMemberReturningVoid(
             nodeMember,
             heritageType,
-            memberName,
+            heritageMember,
           );
         }
       }
@@ -672,12 +725,8 @@ export default createRule<Options, MessageId>({
     function checkHeritageTypeForMemberReturningVoid(
       nodeMember: ts.Node,
       heritageType: ts.Type,
-      memberName: string,
+      heritageMember: ts.Symbol,
     ): void {
-      const heritageMember = getMemberIfExists(heritageType, memberName);
-      if (heritageMember == null) {
-        return;
-      }
       const memberType = checker.getTypeOfSymbolAtLocation(
         heritageMember,
         nodeMember,
@@ -1030,17 +1079,39 @@ function getHeritageTypes(
 }
 
 /**
- * @returns The member with the given name in `type`, if it exists.
+ * @returns The member with the given name or known-symbol in `type`, if it exists.
  */
 function getMemberIfExists(
   type: ts.Type,
-  memberName: string,
+  staticAccessValue: string | symbol,
+  checker: ts.TypeChecker,
+  staticSymbolsMap: Map<symbol, ts.Symbol>,
 ): ts.Symbol | undefined {
-  const escapedMemberName = ts.escapeLeadingUnderscores(memberName);
-  const symbolMemberMatch = type.getSymbol()?.members?.get(escapedMemberName);
-  return (
-    symbolMemberMatch ?? tsutils.getPropertyOfType(type, escapedMemberName)
-  );
+  if (typeof staticAccessValue === 'string') {
+    const escapedMemberName = ts.escapeLeadingUnderscores(staticAccessValue);
+    const symbolMemberMatch = type.getSymbol()?.members?.get(escapedMemberName);
+    return (
+      symbolMemberMatch ??
+      tsutils
+        .unionConstituents(type)
+        .map(t => checker.getPropertyOfType(t, staticAccessValue))
+        .find(p => p)
+    );
+  }
+
+  const wellKnownSymbolName = getWellKnownStringOfSymbol(staticAccessValue);
+
+  if (wellKnownSymbolName != null) {
+    return tsutils.getWellKnownSymbolPropertyOfType(
+      type,
+      wellKnownSymbolName,
+      checker,
+    );
+  }
+
+  const symbol = staticSymbolsMap.get(staticAccessValue);
+  staticSymbolsMap.delete(staticAccessValue);
+  return symbol;
 }
 
 function isStaticMember(node: TSESTree.Node): boolean {
@@ -1102,4 +1173,108 @@ function hasWellKnownSymbolWithVoidReturn(
         checker.getTypeOfSymbolAtLocation(symbol, node),
       );
     });
+}
+
+function getWellKnownStringOfSymbol(symbol: symbol): string | null {
+  const globalSymbolKeys = Object.getOwnPropertyNames(Symbol);
+
+  for (const key of globalSymbolKeys) {
+    if (symbol === Symbol[key as keyof typeof Symbol]) {
+      return key;
+    }
+  }
+
+  return null;
+}
+
+function isValidSymbolDeclaration(
+  declaration: ts.Declaration,
+): declaration is
+  | ts.InterfaceDeclaration
+  | ts.ClassDeclaration
+  | ts.ClassExpression
+  | ts.TypeLiteralNode
+  | ts.InterfaceDeclaration {
+  if (
+    ts.isInterfaceDeclaration(declaration) ||
+    ts.isClassDeclaration(declaration) ||
+    ts.isClassExpression(declaration) ||
+    ts.isTypeLiteralNode(declaration) ||
+    ts.isInterfaceDeclaration(declaration)
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+function getHeritageSymbols(
+  checker: ts.TypeChecker,
+  treeNodeToTSNode: ParserWeakMapESTreeToTSNode<TSESTree.Node>,
+  node:
+    | TSESTree.ClassExpression
+    | TSESTree.TSInterfaceDeclaration
+    | TSESTree.ClassDeclaration,
+) {
+  const nodeToSymbols = (
+    node: TSESTree.TSInterfaceHeritage | TSESTree.TSClassImplements,
+  ) => {
+    const tsNode = treeNodeToTSNode.get(node);
+    return checker.getSymbolAtLocation(tsNode?.expression ?? tsNode);
+  };
+
+  if (node.type === AST_NODE_TYPES.TSInterfaceDeclaration) {
+    return node.extends.map(nodeToSymbols);
+  }
+
+  const implementedSymbols = node.implements.map(nodeToSymbols);
+
+  if (node.superClass) {
+    const superClassSymbol = checker.getSymbolAtLocation(
+      treeNodeToTSNode.get(node.superClass),
+    );
+
+    return [...implementedSymbols, superClassSymbol];
+  }
+
+  return implementedSymbols;
+}
+
+function getSymbolsToStaticSymbols(
+  services: ParserServicesWithTypeInformation,
+  checker: ts.TypeChecker,
+  context: TSESLint.RuleContext<MessageId, Options>,
+  symbols: ts.Symbol[],
+) {
+  const staticSymbolsMap = new Map<symbol, ts.Symbol>();
+  for (const symbol of symbols) {
+    const declaration = symbol.declarations?.[0];
+    if (declaration && isValidSymbolDeclaration(declaration)) {
+      const members = declaration.members;
+
+      for (const member of members) {
+        const node = services.tsNodeToESTreeNodeMap.get(member);
+
+        if (isStaticMember(node) || !member.name) {
+          continue;
+        }
+
+        const staticAccessValue = getStaticMemberAccessValue(
+          node as NodeWithKey,
+          context,
+        );
+
+        if (typeof staticAccessValue === 'symbol') {
+          if (member.name) {
+            const symbol = checker.getSymbolAtLocation(member.name);
+            if (symbol) {
+              staticSymbolsMap.set(staticAccessValue, symbol);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return staticSymbolsMap;
 }

--- a/packages/eslint-plugin/src/rules/no-misused-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-misused-promises.ts
@@ -8,6 +8,8 @@ import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 import * as tsutils from 'ts-api-utils';
 import * as ts from 'typescript';
 
+import type { NodeWithKey } from '../util';
+
 import {
   createRule,
   getConstrainedTypeAtLocation,
@@ -18,12 +20,10 @@ import {
   isFunction,
   isPromiseLike,
   isRestParameterDeclaration,
-  NodeWithKey,
   nullThrows,
   NullThrowsReasons,
 } from '../util';
 import { parseFinallyCall } from '../util/promiseUtils';
-import { ParserWeakMapESTreeToTSNode } from '../../../typescript-estree/src/parser-options';
 
 export type Options = [
   {
@@ -655,11 +655,9 @@ export default createRule<Options, MessageId>({
         return;
       }
 
-      const symbols = getHeritageSymbols(
-        checker,
-        services.esTreeNodeToTSNodeMap,
-        node,
-      ).filter(symbol => symbol !== undefined);
+      const symbols = getHeritageSymbols(checker, services, node).filter(
+        symbol => symbol != null,
+      );
       const staticSymbolsMap = getSymbolsToStaticSymbols(
         services,
         checker,
@@ -1190,13 +1188,11 @@ function getWellKnownStringOfSymbol(symbol: symbol): string | null {
 function isValidSymbolDeclaration(
   declaration: ts.Declaration,
 ): declaration is
-  | ts.InterfaceDeclaration
   | ts.ClassDeclaration
   | ts.ClassExpression
-  | ts.TypeLiteralNode
-  | ts.InterfaceDeclaration {
+  | ts.InterfaceDeclaration
+  | ts.TypeLiteralNode {
   if (
-    ts.isInterfaceDeclaration(declaration) ||
     ts.isClassDeclaration(declaration) ||
     ts.isClassExpression(declaration) ||
     ts.isTypeLiteralNode(declaration) ||
@@ -1210,17 +1206,17 @@ function isValidSymbolDeclaration(
 
 function getHeritageSymbols(
   checker: ts.TypeChecker,
-  treeNodeToTSNode: ParserWeakMapESTreeToTSNode<TSESTree.Node>,
+  services: ParserServicesWithTypeInformation,
   node:
+    | TSESTree.ClassDeclaration
     | TSESTree.ClassExpression
-    | TSESTree.TSInterfaceDeclaration
-    | TSESTree.ClassDeclaration,
+    | TSESTree.TSInterfaceDeclaration,
 ) {
   const nodeToSymbols = (
-    node: TSESTree.TSInterfaceHeritage | TSESTree.TSClassImplements,
+    node: TSESTree.TSClassImplements | TSESTree.TSInterfaceHeritage,
   ) => {
-    const tsNode = treeNodeToTSNode.get(node);
-    return checker.getSymbolAtLocation(tsNode?.expression ?? tsNode);
+    const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+    return checker.getSymbolAtLocation(tsNode.expression);
   };
 
   if (node.type === AST_NODE_TYPES.TSInterfaceDeclaration) {
@@ -1231,7 +1227,7 @@ function getHeritageSymbols(
 
   if (node.superClass) {
     const superClassSymbol = checker.getSymbolAtLocation(
-      treeNodeToTSNode.get(node.superClass),
+      services.esTreeNodeToTSNodeMap.get(node.superClass),
     );
 
     return [...implementedSymbols, superClassSymbol];
@@ -1248,11 +1244,15 @@ function getSymbolsToStaticSymbols(
 ) {
   const staticSymbolsMap = new Map<symbol, ts.Symbol>();
   for (const symbol of symbols) {
-    const declaration = symbol.declarations?.[0];
+    const declaration = symbol.getDeclarations()?.[0];
     if (declaration && isValidSymbolDeclaration(declaration)) {
       const members = declaration.members;
 
       for (const member of members) {
+        if (!services.tsNodeToESTreeNodeMap.has(member)) {
+          continue;
+        }
+
         const node = services.tsNodeToESTreeNodeMap.get(member);
 
         if (isStaticMember(node) || !member.name) {
@@ -1265,11 +1265,9 @@ function getSymbolsToStaticSymbols(
         );
 
         if (typeof staticAccessValue === 'symbol') {
-          if (member.name) {
-            const symbol = checker.getSymbolAtLocation(member.name);
-            if (symbol) {
-              staticSymbolsMap.set(staticAccessValue, symbol);
-            }
+          const symbol = checker.getSymbolAtLocation(member.name);
+          if (symbol) {
+            staticSymbolsMap.set(staticAccessValue, symbol);
           }
         }
       }

--- a/packages/eslint-plugin/tests/rules/no-misused-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-misused-promises.test.ts
@@ -1,3 +1,4 @@
+import { noFormat } from '@typescript-eslint/rule-tester';
 import rule from '../../src/rules/no-misused-promises';
 import { createRuleTesterWithTypes } from '../RuleTester';
 
@@ -1109,6 +1110,319 @@ using c = {
   async [Symbol.asyncDispose]() {},
 };
     `,
+    {
+      code: `
+type O = {
+  1: () => void;
+};
+
+const obj: O = {
+  1() {},
+};
+      `,
+    },
+    {
+      code: `
+type O = {
+  1: () => void;
+};
+
+const obj: O = {
+  [1]() {},
+};
+      `,
+    },
+    {
+      code: noFormat`
+type O = {
+  stringLiteral: () => void;
+};
+
+const obj: O = {
+  'stringLiteral'() {},
+};
+      `,
+    },
+    {
+      code: `
+type O = {
+  computedStringLiteral: () => void;
+};
+
+const obj: O = {
+  ['computedStringLiteral']() {},
+};
+      `,
+    },
+    {
+      code: `
+type O = {
+  [Symbol.iterator]: () => void;
+};
+
+const obj: O = {
+  [Symbol.iterator]() {},
+};
+      `,
+    },
+    {
+      code: `
+const staticSymbol = Symbol.for('static symbol');
+
+type O = {
+  [staticSymbol]: () => void;
+};
+
+const obj: O = {
+  [staticSymbol]() {},
+};
+      `,
+    },
+    {
+      code: `
+type O = {
+  1: () => Promise<void>;
+};
+
+const obj: O = {
+  async 1() {},
+};
+      `,
+    },
+    {
+      code: `
+type O = {
+  1: () => Promise<void>;
+};
+
+const obj: O = {
+  async [1]() {},
+};
+      `,
+    },
+    {
+      code: noFormat`
+type O = {
+  stringLiteral: () => Promise<void>;
+};
+
+const obj: O = {
+  async 'stringLiteral'() {},
+};
+      `,
+    },
+    {
+      code: `
+type O = {
+  computedStringLiteral: () => Promise<void>;
+};
+
+const obj: O = {
+  async ['computedStringLiteral']() {},
+};
+      `,
+    },
+    {
+      code: `
+type O = {
+  [Symbol.iterator]: () => Promise<void>;
+};
+
+const obj: O = {
+  async [Symbol.iterator]() {},
+};
+      `,
+    },
+    {
+      code: `
+const staticSymbol = Symbol.for('static symbol');
+
+type O = {
+  [staticSymbol]: () => Promise<void>;
+};
+
+const obj: O = {
+  async [staticSymbol]() {},
+};
+      `,
+    },
+    {
+      code: `
+class MyClass {
+  1(): void {}
+}
+
+class MySubclass extends MyClass {
+  1(): void {}
+}
+      `,
+    },
+    {
+      code: `
+class MyClass {
+  1(): void {}
+}
+
+class MySubclass extends MyClass {
+  [1](): void {}
+}
+      `,
+    },
+    {
+      code: noFormat`
+class MyClass {
+  stringLiteral(): void {}
+}
+
+class MySubclass extends MyClass {
+  'stringLiteral'(): void {}
+}
+
+      `,
+    },
+    {
+      code: `
+class MyClass {
+  computedStringLiteral(): void {}
+}
+
+class MySubclass extends MyClass {
+  ['computedStringLiteral'](): void {}
+}
+      `,
+    },
+    {
+      code: `
+class MyClass {
+  [Symbol.iterator](): void {}
+}
+
+class MySubclass extends MyClass {
+  [Symbol.iterator](): void {}
+}
+      `,
+    },
+    {
+      code: `
+const staticSymbol = Symbol.for('static symbol');
+
+class MyClass {
+  [staticSymbol](): void {}
+}
+
+class MySubclass extends MyClass {
+  [staticSymbol](): void {}
+}
+      `,
+    },
+    {
+      code: `
+interface MyInterface {
+  1(): void;
+}
+
+class MySubclass implements MyInterface {
+  1(): void {}
+}
+      `,
+    },
+    {
+      code: `
+interface MyInterface {
+  1(): void;
+}
+
+class MySubclass implements MyInterface {
+  [1](): void {}
+}
+      `,
+    },
+    {
+      code: noFormat`
+interface MyInterface {
+  stringLiteral(): void;
+}
+
+class MySubclass implements MyInterface {
+  'stringLiteral'(): void {}
+}
+
+      `,
+    },
+    {
+      code: `
+interface MyInterface {
+  computedStringLiteral(): void;
+}
+
+class MySubclass implements MyInterface {
+  ['computedStringLiteral'](): void {}
+}
+      `,
+    },
+    {
+      code: `
+interface MyInterface {
+  [Symbol.iterator](): void;
+}
+
+class MySubclass implements MyInterface {
+  [Symbol.iterator](): void {}
+}
+      `,
+    },
+    {
+      code: `
+const staticSymbol = Symbol.for('static symbol');
+
+interface MyInterface {
+  [staticSymbol](): void;
+}
+
+class MySubclass implements MyInterface {
+  [staticSymbol](): void {}
+}
+      `,
+    },
+    {
+      code: `
+let a;
+
+type O = {
+  [a]: () => Promise<void>;
+};
+
+const obj: O = {
+  async [a]() {},
+};
+      `,
+    },
+    {
+      code: `
+let a;
+
+interface MyInterface {
+  [a](): void;
+}
+
+class MySubinterfaceExtendsMyInterface implements MyInterface {
+  [a]: () => Promise<void>;
+}
+      `,
+    },
+    {
+      code: `
+const staticSymbol = Symbol();
+
+interface MyInterface {
+  [staticSymbol](): Promise<void>;
+}
+
+class MySubclass implements MyInterface {
+  async [staticSymbol](): Promise<void> {}
+}
+      `,
+    },
   ],
 
   invalid: [
@@ -2719,6 +3033,359 @@ using e = d;
       errors: [
         {
           messageId: 'voidReturnVariable',
+        },
+      ],
+    },
+    {
+      code: `
+type O = {
+  1: () => void;
+};
+
+const obj: O = {
+  async 1() {},
+};
+      `,
+      errors: [
+        {
+          line: 7,
+          messageId: 'voidReturnProperty',
+        },
+      ],
+    },
+    {
+      code: `
+type O = {
+  1: () => void;
+};
+
+const obj: O = {
+  async [1]() {},
+};
+      `,
+      errors: [
+        {
+          line: 7,
+          messageId: 'voidReturnProperty',
+        },
+      ],
+    },
+    {
+      code: noFormat`
+type O = {
+  stringLiteral: () => void;
+};
+
+const obj: O = {
+  async 'stringLiteral'() {},
+};
+      `,
+      errors: [
+        {
+          line: 7,
+          messageId: 'voidReturnProperty',
+        },
+      ],
+    },
+    {
+      code: `
+type O = {
+  computedStringLiteral: () => void;
+};
+
+const obj: O = {
+  async ['computedStringLiteral']() {},
+};
+      `,
+      errors: [
+        {
+          line: 7,
+          messageId: 'voidReturnProperty',
+        },
+      ],
+    },
+    {
+      code: `
+type O = {
+  [Symbol.iterator]: () => void;
+};
+
+const obj: O = {
+  async [Symbol.iterator]() {},
+};
+      `,
+      errors: [
+        {
+          line: 7,
+          messageId: 'voidReturnProperty',
+        },
+      ],
+      // only: true
+    },
+    {
+      code: `
+const testSymbol = Symbol.for("test symbol");
+
+type O = {
+  [testSymbol]: () => void;
+};
+
+const obj: O = {
+  async [testSymbol]() {},
+};
+      `,
+      errors: [
+        {
+          line: 9,
+          messageId: 'voidReturnProperty',
+        },
+      ],
+    },
+    {
+      code: `
+class MyClass {
+  1(): void {}
+}
+
+class MySubclass extends MyClass {
+  async 1(): Promise<void> {}
+}
+      `,
+      errors: [
+        {
+          line: 7,
+          messageId: 'voidReturnInheritedMethod',
+        },
+      ],
+    },
+    {
+      code: `
+class MyClass {
+  1(): void {}
+}
+
+class MySubclass extends MyClass {
+  async [1](): Promise<void> {}
+}
+      `,
+      errors: [
+        {
+          line: 7,
+          messageId: 'voidReturnInheritedMethod',
+        },
+      ],
+    },
+    {
+      code: noFormat`
+class MyClass {
+  stringLiteral(): void {}
+}
+
+class MySubclass extends MyClass {
+  async 'stringLiteral'(): Promise<void> {}
+}
+      `,
+      errors: [
+        {
+          line: 7,
+          messageId: 'voidReturnInheritedMethod',
+        },
+      ],
+    },
+    {
+      code: `
+class MyClass {
+  computedStringLiteral(): void {}
+}
+
+class MySubclass extends MyClass {
+  async ['computedStringLiteral'](): Promise<void> {}
+}
+      `,
+      errors: [
+        {
+          line: 7,
+          messageId: 'voidReturnInheritedMethod',
+        },
+      ],
+    },
+    {
+      code: `
+class MyClass {
+  [Symbol.asyncIterator](): void {}
+}
+
+class MySubclass extends MyClass {
+  async [Symbol.asyncIterator](): Promise<void> {}
+}
+      `,
+      errors: [
+        {
+          line: 7,
+          messageId: 'voidReturnInheritedMethod',
+        },
+      ],
+    },
+    {
+      code: `
+interface MyInterface {
+  1(): void;
+}
+
+interface MySubinterface extends MyInterface {
+  1(): Promise<void>;
+}
+      `,
+      errors: [
+        {
+          line: 7,
+          messageId: 'voidReturnInheritedMethod',
+        },
+      ],
+    },
+    {
+      code: `
+interface MyInterface {
+  1(): void;
+}
+
+interface MySubinterface extends MyInterface {
+  [1](): Promise<void>;
+}
+      `,
+      errors: [
+        {
+          line: 7,
+          messageId: 'voidReturnInheritedMethod',
+        },
+      ],
+    },
+    {
+      code: `
+interface MyInterface {
+  stringLiteral(): void;
+}
+
+interface MySubinterface extends MyInterface {
+  'stringLiteral'(): Promise<void>;
+}
+      `,
+      errors: [
+        {
+          line: 7,
+          messageId: 'voidReturnInheritedMethod',
+        },
+      ],
+    },
+    {
+      code: `
+interface MyInterface {
+  computedStringLiteral(): void;
+}
+
+interface MySubinterface extends MyInterface {
+  ['computedStringLiteral'](): Promise<void>;
+}
+      `,
+      errors: [
+        {
+          line: 7,
+          messageId: 'voidReturnInheritedMethod',
+        },
+      ],
+    },
+    {
+      code: `
+interface MyInterface {
+  [Symbol.asyncIterator](): void;
+}
+
+interface MySubinterface extends MyInterface {
+  [Symbol.asyncIterator](): Promise<void>;
+}
+      `,
+      errors: [
+        {
+          line: 7,
+          messageId: 'voidReturnInheritedMethod',
+        },
+      ],
+    },
+    {
+      code: `
+class MyClass {
+  ''(): void {}
+}
+
+class MySubclass extends MyClass {
+  async ''(): Promise<void> {}
+}
+      `,
+      errors: [
+        {
+          line: 7,
+          messageId: 'voidReturnInheritedMethod',
+        },
+      ],
+    },
+    {
+      code: `
+const testSymbol = Symbol.for('test symbol');
+interface MyInterface {
+  [testSymbol](): void;
+}
+
+interface MySubinterface extends MyInterface {
+  [testSymbol](): Promise<void>;
+}
+      `,
+      errors: [
+        {
+          line: 8,
+          messageId: 'voidReturnInheritedMethod',
+        },
+      ],
+    },
+    {
+      code: `
+const interfaceKey = Symbol.for('test symbol');
+const subInterfaceKey = Symbol.for('test symbol');
+interface MyInterface {
+  [interfaceKey](): void;
+}
+
+interface MySubinterface extends MyInterface {
+  [subInterfaceKey](): Promise<void>;
+}
+      `,
+      errors: [
+        {
+          line: 9,
+          messageId: 'voidReturnInheritedMethod',
+        },
+      ],
+    },
+    {
+      code: `
+const symbolKey = Symbol.for('test symbol');
+
+interface MyInterface {
+  test(): void;
+}
+
+class MyClass {
+  [symbolKey](): void {}
+}
+
+class MySubclass extends MyClass implements MyInterface {
+  async [symbolKey](): Promise<void> {}
+  test(): void {}
+}
+      `,
+      errors: [
+        {
+          line: 13,
+          messageId: 'voidReturnInheritedMethod',
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/no-misused-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-misused-promises.test.ts
@@ -1,4 +1,5 @@
 import { noFormat } from '@typescript-eslint/rule-tester';
+
 import rule from '../../src/rules/no-misused-promises';
 import { createRuleTesterWithTypes } from '../RuleTester';
 
@@ -3124,7 +3125,7 @@ const obj: O = {
     },
     {
       code: `
-const testSymbol = Symbol.for("test symbol");
+const testSymbol = Symbol.for('test symbol');
 
 type O = {
   [testSymbol]: () => void;
@@ -3267,7 +3268,7 @@ interface MyInterface {
 }
 
 interface MySubinterface extends MyInterface {
-  'stringLiteral'(): Promise<void>;
+  stringLiteral(): Promise<void>;
 }
       `,
       errors: [


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [X] Addresses an existing open issue: fixes #10211
- [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [X] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

<!-- Description of what is changed and how the code change does that. -->
This was completed by adding Custom Symbol handling based on the previous PR, #10310.

We extract ts.Symbol from the Heritage (implements, extends) of a class or interface, or from an object's type, and use the actual static symbols referenced by those Symbols as keys and the ts.Symbol as values in a Map.

I initially implemented this logic inside create, but later extracted it into a separate helper function. Since the helper requires context and services, I currently pass them as parameters. I noticed that other rules don't seem to follow this pattern, so I'm not sure if this is the preferred approach. I'd appreciate any feedback on this.