### PR TITLE
fix(website): respect allowJs playground config

### DIFF
--- a/packages/website/src/components/lib/createCompilerOptions.ts
+++ b/packages/website/src/components/lib/createCompilerOptions.ts
@@ -8,7 +8,6 @@ export function createCompilerOptions(
 ): ts.CompilerOptions {
   const config = window.ts.convertCompilerOptionsFromJson(
     {
-      allowJs: true,
       jsx: 'preserve',
       module: 'esnext',
       target: 'esnext',

--- a/packages/website/src/components/lib/createCompilerOptions.ts
+++ b/packages/website/src/components/lib/createCompilerOptions.ts
@@ -8,11 +8,11 @@ export function createCompilerOptions(
 ): ts.CompilerOptions {
   const config = window.ts.convertCompilerOptionsFromJson(
     {
+      allowJs: true,
       jsx: 'preserve',
       module: 'esnext',
       target: 'esnext',
       ...tsConfig,
-      allowJs: true,
       baseUrl: undefined,
       lib: Array.isArray(tsConfig.lib) ? tsConfig.lib : undefined,
       moduleDetection: undefined,

--- a/packages/website/src/components/options.ts
+++ b/packages/website/src/components/options.ts
@@ -42,6 +42,7 @@ export const defaultConfig: ConfigModel = {
   ts: process.env.TS_VERSION,
   tsconfig: toJson({
     compilerOptions: {
+      allowJs: true,
       strictNullChecks: true,
     },
   }),


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #12699
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

<!-- Description of what is changed and how the code change does that. -->
According to the context in armano2's comment, handled it by adjusting the spread order. Setting default values ​​based on file type seems like overkill at this stage.


https://github.com/user-attachments/assets/c22e63b9-ee8c-41c2-a845-b8e9aa3d4972

