### PR TITLE
feat(eslint-plugin): add no-misleading-return-type rule

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-misleading-return-type.mdx
+++ b/packages/eslint-plugin/docs/rules/no-misleading-return-type.mdx
@@ -1,0 +1,75 @@
+---
+description: 'Disallow return type annotations containing types not required by returned expressions.'
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+> 🛑 This file is source code, not the primary documentation location! 🛑
+>
+> See **https://typescript-eslint.io/rules/no-misleading-return-type** for documentation.
+
+Explicit return type annotations can retain union constituents after the implementation no longer requires them.
+Callers must then handle types that TypeScript does not infer for any returned expression.
+
+This rule compares explicitly written union return types with the types of a function's return expressions.
+It reports a union constituent when no returned type is assignable to it and no returned type is a supertype of it.
+Literal types satisfy their corresponding primitive types, so returning `'ready'` satisfies a `string` constituent.
+The rule treats enum members with the same string or number value as the same returned value.
+It also checks unions written as array element types and as the awaited value of `Promise` and compatible promise-like return types.
+
+## Examples
+
+<Tabs>
+<TabItem value="❌ Incorrect">
+
+```ts
+function getStatus(): string | null {
+  return 'ready';
+}
+
+async function getAsyncStatus(): Promise<string | null> {
+  return 'ready';
+}
+```
+
+</TabItem>
+<TabItem value="✅ Correct">
+
+```ts
+function getStatus(): string {
+  return 'ready';
+}
+
+async function getAsyncStatus(): Promise<string> {
+  return 'ready';
+}
+```
+
+</TabItem>
+</Tabs>
+
+## Limitations
+
+This rule checks unions in three places: directly in a return type, in an array element type, and as the single type argument of an array-like or promise-like return type.
+For the type-argument form, the projected return type must be equivalent to the type argument.
+It does not expand a type alias used as the complete return type or inspect unions nested in other containers or object properties.
+It skips comparisons involving `any` or `unknown`.
+For unresolved conditional and string mapping constituents, and template literal constituents that depend on type parameters, it reports only when a stable constraint proves that the returned types are disjoint from the constituent.
+
+To avoid reporting on return types that may describe an external contract, the rule skips overload implementations, contextually typed functions and object methods, inherited or implemented class methods and function-valued fields, decorated members, and members in decorated classes.
+It also skips generators and does not report `undefined` or `void` constituents because a function body may complete without an explicit return expression.
+
+The rule follows the types produced by TypeScript's type checker rather than performing separate runtime reachability analysis.
+Compiler options such as `noUncheckedIndexedAccess` therefore affect its results.
+When that option is disabled, an indexed access can exclude `undefined` from its inferred type even though it may produce `undefined` at runtime.
+
+## When Not To Use It
+
+An API may intentionally declare values that its current implementation does not return, such as for forward compatibility.
+If that convention is common in your project, you might not want to use this rule.
+
+## Related To
+
+- [explicit-function-return-type](./explicit-function-return-type.mdx)
+- [no-redundant-type-constituents](./no-redundant-type-constituents.mdx)

--- a/packages/eslint-plugin/src/configs/eslintrc/all.ts
+++ b/packages/eslint-plugin/src/configs/eslintrc/all.ts
@@ -70,6 +70,7 @@ export = {
     'no-magic-numbers': 'off',
     '@typescript-eslint/no-magic-numbers': 'error',
     '@typescript-eslint/no-meaningless-void-operator': 'error',
+    '@typescript-eslint/no-misleading-return-type': 'error',
     '@typescript-eslint/no-misused-new': 'error',
     '@typescript-eslint/no-misused-promises': 'error',
     '@typescript-eslint/no-misused-spread': 'error',

--- a/packages/eslint-plugin/src/configs/eslintrc/disable-type-checked.ts
+++ b/packages/eslint-plugin/src/configs/eslintrc/disable-type-checked.ts
@@ -24,6 +24,7 @@ export = {
     '@typescript-eslint/no-for-in-array': 'off',
     '@typescript-eslint/no-implied-eval': 'off',
     '@typescript-eslint/no-meaningless-void-operator': 'off',
+    '@typescript-eslint/no-misleading-return-type': 'off',
     '@typescript-eslint/no-misused-promises': 'off',
     '@typescript-eslint/no-misused-spread': 'off',
     '@typescript-eslint/no-mixed-enums': 'off',

--- a/packages/eslint-plugin/src/configs/flat/all.ts
+++ b/packages/eslint-plugin/src/configs/flat/all.ts
@@ -83,6 +83,7 @@ export default (
       'no-magic-numbers': 'off',
       '@typescript-eslint/no-magic-numbers': 'error',
       '@typescript-eslint/no-meaningless-void-operator': 'error',
+      '@typescript-eslint/no-misleading-return-type': 'error',
       '@typescript-eslint/no-misused-new': 'error',
       '@typescript-eslint/no-misused-promises': 'error',
       '@typescript-eslint/no-misused-spread': 'error',

--- a/packages/eslint-plugin/src/configs/flat/disable-type-checked.ts
+++ b/packages/eslint-plugin/src/configs/flat/disable-type-checked.ts
@@ -31,6 +31,7 @@ export default (
     '@typescript-eslint/no-for-in-array': 'off',
     '@typescript-eslint/no-implied-eval': 'off',
     '@typescript-eslint/no-meaningless-void-operator': 'off',
+    '@typescript-eslint/no-misleading-return-type': 'off',
     '@typescript-eslint/no-misused-promises': 'off',
     '@typescript-eslint/no-misused-spread': 'off',
     '@typescript-eslint/no-mixed-enums': 'off',

--- a/packages/eslint-plugin/src/rules/index.ts
+++ b/packages/eslint-plugin/src/rules/index.ts
@@ -51,6 +51,7 @@ import noLoopFunc from './no-loop-func';
 import noLossOfPrecision from './no-loss-of-precision';
 import noMagicNumbers from './no-magic-numbers';
 import noMeaninglessVoidOperator from './no-meaningless-void-operator';
+import noMisleadingReturnType from './no-misleading-return-type';
 import noMisusedNew from './no-misused-new';
 import noMisusedPromises from './no-misused-promises';
 import noMisusedSpread from './no-misused-spread';
@@ -187,6 +188,7 @@ const rules = {
   'no-loss-of-precision': noLossOfPrecision,
   'no-magic-numbers': noMagicNumbers,
   'no-meaningless-void-operator': noMeaninglessVoidOperator,
+  'no-misleading-return-type': noMisleadingReturnType,
   'no-misused-new': noMisusedNew,
   'no-misused-promises': noMisusedPromises,
   'no-misused-spread': noMisusedSpread,

--- a/packages/eslint-plugin/src/rules/no-misleading-return-type.ts
+++ b/packages/eslint-plugin/src/rules/no-misleading-return-type.ts
@@ -35,6 +35,12 @@ type FunctionNode =
   | TSESTree.FunctionDeclaration
   | TSESTree.FunctionExpression;
 
+type ClassMemberDeclaration =
+  | ts.GetAccessorDeclaration
+  | ts.MethodDeclaration
+  | ts.PropertyDeclaration
+  | ts.SetAccessorDeclaration;
+
 type TypeProjection = 'arrayElement' | 'awaited' | 'identity';
 
 type UnionCandidate =
@@ -60,8 +66,7 @@ export default createRule({
       requiresTypeChecking: true,
     },
     messages: {
-      unnecessaryType:
-        'The return type includes `{{type}}`, but no returned expression requires it.',
+      unnecessaryType: 'No returned expression requires this type.',
     },
     schema: [],
   },
@@ -76,7 +81,7 @@ export default createRule({
         : [type];
     }
 
-    function hasUnresolvedTemplatePart(types: readonly ts.Type[]): boolean {
+    function hasUnresolvedTemplatePart(types: readonly ts.Type[]) {
       function isUnresolved(type: ts.Type): boolean {
         if (
           tsutils.isTypeFlagSet(type, ts.TypeFlags.Instantiable) ||
@@ -96,7 +101,7 @@ export default createRule({
       return types.some(isUnresolved);
     }
 
-    function isUnresolvedTypeOperation(type: ts.Type): boolean {
+    function isUnresolvedTypeOperation(type: ts.Type) {
       // Assignability can be false until these types are instantiated, even
       // when a returned type will satisfy them for every valid instantiation.
       return (
@@ -107,7 +112,7 @@ export default createRule({
       );
     }
 
-    function getWidenedObjectLiteralType(type: ts.Type): ts.Type {
+    function getWidenedObjectLiteralType(type: ts.Type) {
       // Fresh object literal types trigger excess-property checks in
       // isTypeAssignableTo(). Widening removes freshness while preserving the
       // structural type that can satisfy more than one union constituent.
@@ -117,7 +122,7 @@ export default createRule({
         : type;
     }
 
-    function getStableBaseConstraint(type: ts.Type): ts.Type | null {
+    function getStableBaseConstraint(type: ts.Type) {
       const seen = new Set<ts.Type>([type]);
       let constraint = type;
 
@@ -139,17 +144,17 @@ export default createRule({
         : constraint;
     }
 
-    function isConcreteType(type: ts.Type): boolean {
+    function isConcreteType(type: ts.Type) {
       return tsutils.isTypeFlagSet(type, CONCRETE_TYPE_FLAGS);
     }
 
-    function isPrimitiveType(type: ts.Type): boolean {
+    function isPrimitiveType(type: ts.Type) {
       return tsutils
         .unionConstituents(type)
         .every(type => tsutils.isTypeFlagSet(type, PRIMITIVE_TYPE_FLAGS));
     }
 
-    function isImplicitReturnType(type: ts.Type): boolean {
+    function isImplicitReturnType(type: ts.Type) {
       return tsutils.isTypeFlagSet(
         type,
         ts.TypeFlags.Undefined | ts.TypeFlags.Void,
@@ -159,7 +164,7 @@ export default createRule({
     function mayRepresentImplicitReturn(
       type: ts.Type,
       constraint: ts.Type | null,
-    ): boolean {
+    ) {
       if (tsutils.unionConstituents(type).some(isImplicitReturnType)) {
         return true;
       }
@@ -170,7 +175,7 @@ export default createRule({
       );
     }
 
-    function enumLiteralsHaveSameValue(left: ts.Type, right: ts.Type): boolean {
+    function enumLiteralsHaveSameValue(left: ts.Type, right: ts.Type) {
       // Distinct enum member types can represent the same runtime value.
       if (
         !tsutils.isTypeFlagSet(left, ts.TypeFlags.EnumLiteral) ||
@@ -187,10 +192,7 @@ export default createRule({
       );
     }
 
-    function typesHaveAssignableRelation(
-      left: ts.Type,
-      right: ts.Type,
-    ): boolean {
+    function typesHaveAssignableRelation(left: ts.Type, right: ts.Type) {
       return (
         checker.isTypeAssignableTo(getWidenedObjectLiteralType(left), right) ||
         checker.isTypeAssignableTo(right, left) ||
@@ -198,7 +200,7 @@ export default createRule({
       );
     }
 
-    function canProveNoOverlap(left: ts.Type, right: ts.Type): boolean {
+    function canProveNoOverlap(left: ts.Type, right: ts.Type) {
       const comparableLeft =
         isConcreteType(left) || tsutils.isTypeFlagSet(left, ts.TypeFlags.Object)
           ? left
@@ -220,10 +222,7 @@ export default createRule({
       );
     }
 
-    function getReturnedTypes(
-      node: FunctionNode,
-      projection: TypeProjection,
-    ): ts.Type[] | null {
+    function getReturnedTypes(node: FunctionNode, projection: TypeProjection) {
       const body = services.esTreeNodeToTSNodeMap.get(
         node.body,
       ) as ts.ConciseBody;
@@ -235,7 +234,8 @@ export default createRule({
             returnExpressions.push(statement.expression);
           }
         });
-      } else {
+      }
+      if (!ts.isBlock(body)) {
         returnExpressions.push(body);
       }
 
@@ -332,10 +332,7 @@ export default createRule({
       return null;
     }
 
-    function getProjectedType(
-      type: ts.Type,
-      projection: TypeProjection,
-    ): ts.Type | null {
+    function getProjectedType(type: ts.Type, projection: TypeProjection) {
       if (projection === 'identity') {
         return type;
       }
@@ -355,7 +352,7 @@ export default createRule({
     function getProjectedTypeArgument(
       type: ts.Type,
       projection: TypeProjection,
-    ): ts.Type | null {
+    ) {
       return projection === 'awaited'
         ? (checker.getAwaitedType(type) ?? null)
         : type;
@@ -365,7 +362,7 @@ export default createRule({
       candidate: UnionCandidate,
       projection: TypeProjection,
       returnType: ts.Type,
-    ): ts.Type | null {
+    ) {
       const projectedReturnType = getProjectedType(returnType, projection);
       if (
         !projectedReturnType ||
@@ -399,13 +396,11 @@ export default createRule({
 
     function hasBaseClassMember(
       memberNode: TSESTree.MethodDefinition | TSESTree.PropertyDefinition,
-    ): boolean {
-      const memberTsNode = services.esTreeNodeToTSNodeMap.get(memberNode);
-      const memberName = memberTsNode.name;
-      if (memberName == null) {
-        return false;
-      }
-      const memberNameNode: ts.PropertyName = memberName;
+    ) {
+      const memberTsNode = services.esTreeNodeToTSNodeMap.get(
+        memberNode,
+      ) as ClassMemberDeclaration;
+      const memberNameNode = memberTsNode.name;
 
       const classNode = memberTsNode.parent as ts.ClassLikeDeclaration;
       const heritageClauses = classNode.heritageClauses ?? [];
@@ -414,15 +409,14 @@ export default createRule({
       }
 
       const memberSymbol = checker.getSymbolAtLocation(memberNameNode);
-      if (memberSymbol == null) {
+      if (!memberSymbol) {
         return false;
       }
-      const memberSymbolEscapedName = memberSymbol.escapedName;
       const memberSymbolName = memberSymbol.name;
 
       let memberNameType: ts.Type | null = null;
       let memberNameTypeResolved = false;
-      function getMemberNameType(): ts.Type | null {
+      function getMemberNameType() {
         if (memberNameTypeResolved) {
           return memberNameType;
         }
@@ -458,7 +452,7 @@ export default createRule({
       function hasMatchingIndexSignature(
         baseType: ts.Type,
         nameType: ts.Type | null,
-      ): boolean {
+      ) {
         const indexInfos = checker.getIndexInfosOfType(baseType);
         if (
           nameType &&
@@ -527,7 +521,7 @@ export default createRule({
               .getPropertiesOfType(baseType)
               .some(
                 baseMember =>
-                  baseMember.escapedName === memberSymbolEscapedName,
+                  baseMember.escapedName === memberSymbol.escapedName,
               )
           ) {
             return true;
@@ -545,7 +539,7 @@ export default createRule({
       return false;
     }
 
-    function shouldSkipFunction(node: FunctionNode): boolean {
+    function shouldSkipFunction(node: FunctionNode) {
       if (node.generator) {
         return true;
       }
@@ -581,7 +575,7 @@ export default createRule({
       return services.getContextualType(node) != null;
     }
 
-    function checkFunction(node: FunctionNode): void {
+    function checkFunction(node: FunctionNode) {
       const candidate = getUnionCandidate(node);
       if (!candidate || shouldSkipFunction(node)) {
         return;
@@ -654,7 +648,7 @@ export default createRule({
       const analyzedCandidates = resolvedCandidates.map(
         ({ type, constraint, typeNode }) => {
           const unresolved = isUnresolvedTypeOperation(type);
-          const mayBeReturned = returnedTypeParts.some(returnedType => {
+          const isRequired = returnedTypeParts.some(returnedType => {
             if (typesHaveAssignableRelation(returnedType, type)) {
               return true;
             }
@@ -665,21 +659,21 @@ export default createRule({
             );
           });
 
-          return { type, mayBeReturned, typeNode };
+          return { type, isRequired, typeNode };
         },
       );
-      const returnedCandidateTypes = analyzedCandidates
-        .filter(candidate => candidate.mayBeReturned)
+      const requiredCandidateTypes = analyzedCandidates
+        .filter(candidate => candidate.isRequired)
         .map(candidate => candidate.type);
       const hasBooleanCandidate = analyzedCandidates.some(({ type }) =>
         tsutils.isTypeFlagSet(type, ts.TypeFlags.Boolean),
       );
 
-      for (const { type, mayBeReturned, typeNode } of analyzedCandidates) {
+      for (const { type, isRequired, typeNode } of analyzedCandidates) {
         if (
-          mayBeReturned ||
-          returnedCandidateTypes.some(returnedCandidateType =>
-            checker.isTypeAssignableTo(type, returnedCandidateType),
+          isRequired ||
+          requiredCandidateTypes.some(requiredCandidateType =>
+            checker.isTypeAssignableTo(type, requiredCandidateType),
           )
         ) {
           continue;
@@ -701,7 +695,6 @@ export default createRule({
         context.report({
           node: typeNode,
           messageId: 'unnecessaryType',
-          data: { type: context.sourceCode.getText(typeNode) },
         });
       }
     }

--- a/packages/eslint-plugin/src/rules/no-misleading-return-type.ts
+++ b/packages/eslint-plugin/src/rules/no-misleading-return-type.ts
@@ -1,0 +1,715 @@
+import type { TSESTree } from '@typescript-eslint/utils';
+
+import { AST_NODE_TYPES } from '@typescript-eslint/utils';
+import * as tsutils from 'ts-api-utils';
+import * as ts from 'typescript';
+
+import {
+  createRule,
+  forEachReturnStatement,
+  getParserServices,
+  hasOverloadSignatures,
+  isTypeAnyType,
+  isTypeNeverType,
+  isTypeUnknownType,
+} from '../util';
+
+const PRIMITIVE_TYPE_FLAGS =
+  ts.TypeFlags.Undefined |
+  ts.TypeFlags.Null |
+  ts.TypeFlags.Void |
+  ts.TypeFlags.String |
+  ts.TypeFlags.Number |
+  ts.TypeFlags.BigInt |
+  ts.TypeFlags.Boolean |
+  ts.TypeFlags.ESSymbol |
+  ts.TypeFlags.Literal |
+  ts.TypeFlags.UniqueESSymbol |
+  ts.TypeFlags.Enum |
+  ts.TypeFlags.EnumLiteral;
+
+const CONCRETE_TYPE_FLAGS = PRIMITIVE_TYPE_FLAGS | ts.TypeFlags.NonPrimitive;
+
+type FunctionNode =
+  | TSESTree.ArrowFunctionExpression
+  | TSESTree.FunctionDeclaration
+  | TSESTree.FunctionExpression;
+
+type TypeProjection = 'arrayElement' | 'awaited' | 'identity';
+
+type UnionCandidate =
+  | {
+      kind: 'array' | 'direct';
+      returnType: TSESTree.TypeNode;
+      types: TSESTree.TypeNode[];
+    }
+  | {
+      kind: 'reference';
+      returnType: TSESTree.TypeNode;
+      typeArgument: TSESTree.TSUnionType;
+      types: TSESTree.TypeNode[];
+    };
+
+export default createRule({
+  name: 'no-misleading-return-type',
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Disallow return type annotations containing types not required by returned expressions',
+      requiresTypeChecking: true,
+    },
+    messages: {
+      unnecessaryType:
+        'The return type includes `{{type}}`, but no returned expression requires it.',
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    const services = getParserServices(context);
+    const checker = services.program.getTypeChecker();
+
+    function getUnionMembers(type: TSESTree.TypeNode): TSESTree.TypeNode[] {
+      return type.type === AST_NODE_TYPES.TSUnionType
+        ? type.types.flatMap(getUnionMembers)
+        : [type];
+    }
+
+    function hasUnresolvedTemplatePart(types: readonly ts.Type[]): boolean {
+      function isUnresolved(type: ts.Type): boolean {
+        if (
+          tsutils.isTypeFlagSet(type, ts.TypeFlags.Instantiable) ||
+          tsutils.isConditionalType(type) ||
+          tsutils.isStringMappingType(type)
+        ) {
+          return true;
+        }
+
+        return (
+          (type.isUnionOrIntersection() ||
+            tsutils.isTemplateLiteralType(type)) &&
+          type.types.some(isUnresolved)
+        );
+      }
+
+      return types.some(isUnresolved);
+    }
+
+    function isUnresolvedTypeOperation(type: ts.Type): boolean {
+      // Assignability can be false until these types are instantiated, even
+      // when a returned type will satisfy them for every valid instantiation.
+      return (
+        tsutils.isConditionalType(type) ||
+        tsutils.isStringMappingType(type) ||
+        (tsutils.isTemplateLiteralType(type) &&
+          hasUnresolvedTemplatePart(type.types))
+      );
+    }
+
+    function getWidenedObjectLiteralType(type: ts.Type): ts.Type {
+      // Fresh object literal types trigger excess-property checks in
+      // isTypeAssignableTo(). Widening removes freshness while preserving the
+      // structural type that can satisfy more than one union constituent.
+      return tsutils.isObjectType(type) &&
+        tsutils.isObjectFlagSet(type, ts.ObjectFlags.ObjectLiteral)
+        ? checker.getWidenedType(type)
+        : type;
+    }
+
+    function getStableBaseConstraint(type: ts.Type): ts.Type | null {
+      const seen = new Set<ts.Type>([type]);
+      let constraint = type;
+
+      for (;;) {
+        const next = checker.getBaseConstraintOfType(constraint);
+        if (!next || seen.has(next)) {
+          break;
+        }
+        seen.add(next);
+        constraint = next;
+      }
+
+      return constraint === type ||
+        tsutils.isIntrinsicErrorType(constraint) ||
+        isTypeAnyType(constraint) ||
+        isTypeUnknownType(constraint) ||
+        isUnresolvedTypeOperation(constraint)
+        ? null
+        : constraint;
+    }
+
+    function isConcreteType(type: ts.Type): boolean {
+      return tsutils.isTypeFlagSet(type, CONCRETE_TYPE_FLAGS);
+    }
+
+    function isPrimitiveType(type: ts.Type): boolean {
+      return tsutils
+        .unionConstituents(type)
+        .every(type => tsutils.isTypeFlagSet(type, PRIMITIVE_TYPE_FLAGS));
+    }
+
+    function isImplicitReturnType(type: ts.Type): boolean {
+      return tsutils.isTypeFlagSet(
+        type,
+        ts.TypeFlags.Undefined | ts.TypeFlags.Void,
+      );
+    }
+
+    function mayRepresentImplicitReturn(
+      type: ts.Type,
+      constraint: ts.Type | null,
+    ): boolean {
+      if (tsutils.unionConstituents(type).some(isImplicitReturnType)) {
+        return true;
+      }
+
+      return (
+        constraint != null &&
+        tsutils.unionConstituents(constraint).some(isImplicitReturnType)
+      );
+    }
+
+    function enumLiteralsHaveSameValue(left: ts.Type, right: ts.Type): boolean {
+      // Distinct enum member types can represent the same runtime value.
+      if (
+        !tsutils.isTypeFlagSet(left, ts.TypeFlags.EnumLiteral) ||
+        !tsutils.isTypeFlagSet(right, ts.TypeFlags.EnumLiteral) ||
+        !left.isLiteral() ||
+        !right.isLiteral()
+      ) {
+        return false;
+      }
+
+      return (
+        (typeof left.value === 'number' || typeof left.value === 'string') &&
+        left.value === right.value
+      );
+    }
+
+    function typesHaveAssignableRelation(
+      left: ts.Type,
+      right: ts.Type,
+    ): boolean {
+      return (
+        checker.isTypeAssignableTo(getWidenedObjectLiteralType(left), right) ||
+        checker.isTypeAssignableTo(right, left) ||
+        enumLiteralsHaveSameValue(left, right)
+      );
+    }
+
+    function canProveNoOverlap(left: ts.Type, right: ts.Type): boolean {
+      const comparableLeft =
+        isConcreteType(left) || tsutils.isTypeFlagSet(left, ts.TypeFlags.Object)
+          ? left
+          : (getStableBaseConstraint(left) ?? left);
+      if (
+        typesHaveAssignableRelation(left, right) ||
+        (comparableLeft !== left &&
+          typesHaveAssignableRelation(comparableLeft, right))
+      ) {
+        return false;
+      }
+
+      return (
+        isConcreteType(comparableLeft) ||
+        // Non-assignable structural object types can still overlap. An object
+        // type is disjoint only when the other side is entirely primitive.
+        (isPrimitiveType(right) &&
+          tsutils.isTypeFlagSet(comparableLeft, ts.TypeFlags.Object))
+      );
+    }
+
+    function getReturnedTypes(
+      node: FunctionNode,
+      projection: TypeProjection,
+    ): ts.Type[] | null {
+      const body = services.esTreeNodeToTSNodeMap.get(
+        node.body,
+      ) as ts.ConciseBody;
+
+      const returnExpressions: ts.Expression[] = [];
+      if (ts.isBlock(body)) {
+        forEachReturnStatement(body, statement => {
+          if (statement.expression) {
+            returnExpressions.push(statement.expression);
+          }
+        });
+      } else {
+        returnExpressions.push(body);
+      }
+
+      const returnedTypes: ts.Type[] = [];
+      for (const expression of returnExpressions) {
+        const type = checker.getTypeAtLocation(expression);
+        const returnedType = getProjectedType(type, projection);
+        if (
+          !returnedType ||
+          tsutils.isIntrinsicErrorType(returnedType) ||
+          isTypeAnyType(returnedType) ||
+          isTypeUnknownType(returnedType)
+        ) {
+          return null;
+        }
+        returnedTypes.push(returnedType);
+      }
+
+      return returnedTypes;
+    }
+
+    function getUnionCandidate(node: FunctionNode): UnionCandidate | null {
+      const returnType = node.returnType?.typeAnnotation;
+      if (!returnType) {
+        return null;
+      }
+
+      if (returnType.type === AST_NODE_TYPES.TSUnionType) {
+        return {
+          kind: 'direct',
+          returnType,
+          types: getUnionMembers(returnType),
+        };
+      }
+
+      const operatedType =
+        returnType.type === AST_NODE_TYPES.TSTypeOperator &&
+        returnType.operator === 'readonly'
+          ? returnType.typeAnnotation
+          : null;
+      const operatedArrayType =
+        operatedType?.type === AST_NODE_TYPES.TSArrayType ? operatedType : null;
+      const arrayType =
+        returnType.type === AST_NODE_TYPES.TSArrayType
+          ? returnType
+          : operatedArrayType;
+      if (arrayType?.elementType.type === AST_NODE_TYPES.TSUnionType) {
+        return {
+          kind: 'array',
+          returnType,
+          types: getUnionMembers(arrayType.elementType),
+        };
+      }
+
+      if (
+        returnType.type !== AST_NODE_TYPES.TSTypeReference ||
+        returnType.typeArguments?.params.length !== 1 ||
+        returnType.typeArguments.params[0].type !== AST_NODE_TYPES.TSUnionType
+      ) {
+        return null;
+      }
+
+      const typeArgument = returnType.typeArguments.params[0];
+      return {
+        kind: 'reference',
+        returnType,
+        typeArgument,
+        types: getUnionMembers(typeArgument),
+      };
+    }
+
+    function getProjection(
+      candidate: UnionCandidate,
+      returnType: ts.Type,
+    ): TypeProjection | null {
+      if (candidate.kind === 'direct') {
+        return 'identity';
+      }
+      if (candidate.kind === 'array') {
+        return 'arrayElement';
+      }
+
+      if (checker.isArrayLikeType(returnType)) {
+        return 'arrayElement';
+      }
+
+      const tsReturnType = services.esTreeNodeToTSNodeMap.get(
+        candidate.returnType,
+      );
+      if (tsutils.isThenableType(checker, tsReturnType, returnType)) {
+        return 'awaited';
+      }
+
+      return null;
+    }
+
+    function getProjectedType(
+      type: ts.Type,
+      projection: TypeProjection,
+    ): ts.Type | null {
+      if (projection === 'identity') {
+        return type;
+      }
+      if (projection === 'awaited') {
+        return checker.getAwaitedType(type) ?? null;
+      }
+      const arrayType = checker.isArrayLikeType(type)
+        ? type
+        : getStableBaseConstraint(type);
+      if (!arrayType || !checker.isArrayLikeType(arrayType)) {
+        return null;
+      }
+
+      return checker.getIndexTypeOfType(arrayType, ts.IndexKind.Number) ?? null;
+    }
+
+    function getProjectedTypeArgument(
+      type: ts.Type,
+      projection: TypeProjection,
+    ): ts.Type | null {
+      return projection === 'awaited'
+        ? (checker.getAwaitedType(type) ?? null)
+        : type;
+    }
+
+    function getEffectiveReturnType(
+      candidate: UnionCandidate,
+      projection: TypeProjection,
+      returnType: ts.Type,
+    ): ts.Type | null {
+      const projectedReturnType = getProjectedType(returnType, projection);
+      if (
+        !projectedReturnType ||
+        tsutils.isIntrinsicErrorType(projectedReturnType)
+      ) {
+        return null;
+      }
+      if (candidate.kind !== 'reference') {
+        return projectedReturnType;
+      }
+
+      const projectedTypeArgument = getProjectedTypeArgument(
+        services.getTypeAtLocation(candidate.typeArgument),
+        projection,
+      );
+
+      if (
+        !projectedTypeArgument ||
+        tsutils.isIntrinsicErrorType(projectedTypeArgument) ||
+        !checker.isTypeAssignableTo(
+          projectedReturnType,
+          projectedTypeArgument,
+        ) ||
+        !checker.isTypeAssignableTo(projectedTypeArgument, projectedReturnType)
+      ) {
+        return null;
+      }
+
+      return projectedReturnType;
+    }
+
+    function hasBaseClassMember(
+      memberNode: TSESTree.MethodDefinition | TSESTree.PropertyDefinition,
+    ): boolean {
+      const memberTsNode = services.esTreeNodeToTSNodeMap.get(memberNode);
+      const memberName = memberTsNode.name;
+      if (memberName == null) {
+        return false;
+      }
+      const memberNameNode: ts.PropertyName = memberName;
+
+      const classNode = memberTsNode.parent as ts.ClassLikeDeclaration;
+      const heritageClauses = classNode.heritageClauses ?? [];
+      if (heritageClauses.length === 0) {
+        return false;
+      }
+
+      const memberSymbol = checker.getSymbolAtLocation(memberNameNode);
+      if (memberSymbol == null) {
+        return false;
+      }
+      const memberSymbolEscapedName = memberSymbol.escapedName;
+      const memberSymbolName = memberSymbol.name;
+
+      let memberNameType: ts.Type | null = null;
+      let memberNameTypeResolved = false;
+      function getMemberNameType(): ts.Type | null {
+        if (memberNameTypeResolved) {
+          return memberNameType;
+        }
+        memberNameTypeResolved = true;
+
+        if (
+          ts.isIdentifier(memberNameNode) ||
+          ts.isStringLiteralLike(memberNameNode)
+        ) {
+          memberNameType =
+            typeof checker.getStringLiteralType === 'function'
+              ? checker.getStringLiteralType(memberNameNode.text)
+              : null;
+          return memberNameType;
+        }
+
+        if (ts.isNumericLiteral(memberNameNode)) {
+          memberNameType =
+            typeof checker.getNumberLiteralType === 'function'
+              ? checker.getNumberLiteralType(Number(memberNameNode.text))
+              : null;
+          return memberNameType;
+        }
+
+        if (ts.isComputedPropertyName(memberNameNode)) {
+          memberNameType = checker.getTypeAtLocation(memberNameNode.expression);
+          return memberNameType;
+        }
+
+        return memberNameType;
+      }
+
+      function hasMatchingIndexSignature(
+        baseType: ts.Type,
+        nameType: ts.Type | null,
+      ): boolean {
+        const indexInfos = checker.getIndexInfosOfType(baseType);
+        if (
+          nameType &&
+          indexInfos.some(indexInfo =>
+            checker.isTypeAssignableTo(nameType, indexInfo.keyType),
+          )
+        ) {
+          return true;
+        }
+
+        const isNumericName = tsutils.isNumericPropertyName(memberSymbolName);
+        if (
+          isNumericName &&
+          (checker.getIndexInfoOfType(baseType, ts.IndexKind.Number) != null ||
+            checker.getIndexInfoOfType(baseType, ts.IndexKind.String) != null)
+        ) {
+          return true;
+        }
+
+        if (
+          nameType ||
+          (!ts.isIdentifier(memberNameNode) &&
+            !ts.isStringLiteralLike(memberNameNode) &&
+            !ts.isNumericLiteral(memberNameNode))
+        ) {
+          return false;
+        }
+
+        // Literal-type factories are unavailable in older supported TypeScript
+        // versions. In that case, conservatively match string-like index keys.
+        return indexInfos.some(indexInfo =>
+          tsutils
+            .unionConstituents(indexInfo.keyType)
+            .some(
+              keyType =>
+                tsutils.isTypeFlagSet(keyType, ts.TypeFlags.String) ||
+                tsutils.isTemplateLiteralType(keyType) ||
+                (isNumericName &&
+                  tsutils.isTypeFlagSet(keyType, ts.TypeFlags.Number)),
+            ),
+        );
+      }
+
+      const isStaticMember = memberNode.static;
+      for (const heritageClause of heritageClauses) {
+        if (
+          isStaticMember &&
+          heritageClause.token === ts.SyntaxKind.ImplementsKeyword
+        ) {
+          continue;
+        }
+
+        for (const baseTypeNode of heritageClause.types) {
+          const baseType = checker.getTypeAtLocation(
+            isStaticMember ? baseTypeNode.expression : baseTypeNode,
+          );
+          if (checker.getPropertyOfType(baseType, memberSymbolName)) {
+            return true;
+          }
+
+          const nameType = getMemberNameType();
+          if (
+            nameType &&
+            tsutils.isTypeFlagSet(nameType, ts.TypeFlags.UniqueESSymbol) &&
+            checker
+              .getPropertiesOfType(baseType)
+              .some(
+                baseMember =>
+                  baseMember.escapedName === memberSymbolEscapedName,
+              )
+          ) {
+            return true;
+          }
+
+          if (
+            !isStaticMember &&
+            hasMatchingIndexSignature(baseType, nameType)
+          ) {
+            return true;
+          }
+        }
+      }
+
+      return false;
+    }
+
+    function shouldSkipFunction(node: FunctionNode): boolean {
+      if (node.generator) {
+        return true;
+      }
+
+      if (node.type === AST_NODE_TYPES.FunctionDeclaration) {
+        return hasOverloadSignatures(node, context);
+      }
+
+      if (
+        node.parent.type === AST_NODE_TYPES.MethodDefinition ||
+        node.parent.type === AST_NODE_TYPES.PropertyDefinition
+      ) {
+        if (
+          node.parent.decorators.length > 0 ||
+          node.parent.parent.parent.decorators.length > 0 ||
+          node.parent.override ||
+          (node.parent.type === AST_NODE_TYPES.MethodDefinition &&
+            hasOverloadSignatures(node.parent, context))
+        ) {
+          return true;
+        }
+
+        return hasBaseClassMember(node.parent);
+      }
+
+      if (
+        node.parent.type === AST_NODE_TYPES.Property &&
+        services.getContextualType(node.parent.parent) != null
+      ) {
+        return true;
+      }
+
+      return services.getContextualType(node) != null;
+    }
+
+    function checkFunction(node: FunctionNode): void {
+      const candidate = getUnionCandidate(node);
+      if (!candidate || shouldSkipFunction(node)) {
+        return;
+      }
+
+      const returnType = services.getTypeAtLocation(candidate.returnType);
+      const projection = getProjection(candidate, returnType);
+      if (!projection) {
+        return;
+      }
+
+      const effectiveReturnType = getEffectiveReturnType(
+        candidate,
+        projection,
+        returnType,
+      );
+      if (
+        !effectiveReturnType ||
+        isTypeAnyType(effectiveReturnType) ||
+        isTypeUnknownType(effectiveReturnType)
+      ) {
+        return;
+      }
+
+      const returnedTypes = getReturnedTypes(node, projection);
+
+      if (!returnedTypes || returnedTypes.length === 0) {
+        return;
+      }
+
+      const returnedTypeParts = returnedTypes.flatMap(type =>
+        tsutils.unionConstituents(type).filter(type => !isTypeNeverType(type)),
+      );
+      if (returnedTypeParts.length === 0) {
+        return;
+      }
+      const effectiveReturnTypeParts =
+        tsutils.unionConstituents(effectiveReturnType);
+      const effectiveReturnTypePartSet = new Set(effectiveReturnTypeParts);
+
+      const resolvedCandidates: {
+        constraint: ts.Type | null;
+        type: ts.Type;
+        typeNode: TSESTree.TypeNode;
+      }[] = [];
+      for (const typeNode of candidate.types) {
+        const typeAtNode = services.getTypeAtLocation(typeNode);
+        const type = getProjectedTypeArgument(typeAtNode, projection);
+        if (
+          !type ||
+          tsutils.isIntrinsicErrorType(type) ||
+          isTypeAnyType(type) ||
+          isTypeUnknownType(type) ||
+          isTypeNeverType(type)
+        ) {
+          continue;
+        }
+
+        const constraint = tsutils
+          .unionConstituents(type)
+          .some(type => tsutils.isTypeFlagSet(type, ts.TypeFlags.Instantiable))
+          ? getStableBaseConstraint(type)
+          : null;
+        if (mayRepresentImplicitReturn(type, constraint)) {
+          continue;
+        }
+
+        resolvedCandidates.push({ type, constraint, typeNode });
+      }
+      const analyzedCandidates = resolvedCandidates.map(
+        ({ type, constraint, typeNode }) => {
+          const unresolved = isUnresolvedTypeOperation(type);
+          const mayBeReturned = returnedTypeParts.some(returnedType => {
+            if (typesHaveAssignableRelation(returnedType, type)) {
+              return true;
+            }
+
+            return (
+              unresolved &&
+              (!constraint || !canProveNoOverlap(returnedType, constraint))
+            );
+          });
+
+          return { type, mayBeReturned, typeNode };
+        },
+      );
+      const returnedCandidateTypes = analyzedCandidates
+        .filter(candidate => candidate.mayBeReturned)
+        .map(candidate => candidate.type);
+      const hasBooleanCandidate = analyzedCandidates.some(({ type }) =>
+        tsutils.isTypeFlagSet(type, ts.TypeFlags.Boolean),
+      );
+
+      for (const { type, mayBeReturned, typeNode } of analyzedCandidates) {
+        if (
+          mayBeReturned ||
+          returnedCandidateTypes.some(returnedCandidateType =>
+            checker.isTypeAssignableTo(type, returnedCandidateType),
+          )
+        ) {
+          continue;
+        }
+
+        const isNormalizedAway =
+          (tsutils.isTypeFlagSet(type, ts.TypeFlags.BooleanLiteral) &&
+            hasBooleanCandidate) ||
+          (!effectiveReturnTypePartSet.has(type) &&
+            effectiveReturnTypeParts.some(
+              effectiveType =>
+                checker.isTypeAssignableTo(type, effectiveType) &&
+                !checker.isTypeAssignableTo(effectiveType, type),
+            ));
+        if (isNormalizedAway) {
+          continue;
+        }
+
+        context.report({
+          node: typeNode,
+          messageId: 'unnecessaryType',
+          data: { type: context.sourceCode.getText(typeNode) },
+        });
+      }
+    }
+
+    return {
+      'ArrowFunctionExpression:exit': checkFunction,
+      'FunctionDeclaration:exit': checkFunction,
+      'FunctionExpression:exit': checkFunction,
+    };
+  },
+});

--- a/packages/eslint-plugin/src/rules/no-misleading-return-type.ts
+++ b/packages/eslint-plugin/src/rules/no-misleading-return-type.ts
@@ -8,12 +8,14 @@ import {
   createRule,
   forEachReturnStatement,
   getParserServices,
+  getValueOfLiteralType,
   hasOverloadSignatures,
   isTypeAnyType,
   isTypeNeverType,
   isTypeUnknownType,
 } from '../util';
 
+// TypeFlags.Primitive is not declared in TypeScript's public API.
 const PRIMITIVE_TYPE_FLAGS =
   ts.TypeFlags.Undefined |
   ts.TypeFlags.Null |
@@ -128,7 +130,7 @@ export default createRule({
 
       for (;;) {
         const next = checker.getBaseConstraintOfType(constraint);
-        if (!next || seen.has(next)) {
+        if (next == null || seen.has(next)) {
           break;
         }
         seen.add(next);
@@ -186,10 +188,7 @@ export default createRule({
         return false;
       }
 
-      return (
-        (typeof left.value === 'number' || typeof left.value === 'string') &&
-        left.value === right.value
-      );
+      return getValueOfLiteralType(left) === getValueOfLiteralType(right);
     }
 
     function typesHaveAssignableRelation(left: ts.Type, right: ts.Type) {
@@ -244,7 +243,7 @@ export default createRule({
         const type = checker.getTypeAtLocation(expression);
         const returnedType = getProjectedType(type, projection);
         if (
-          !returnedType ||
+          returnedType == null ||
           tsutils.isIntrinsicErrorType(returnedType) ||
           isTypeAnyType(returnedType) ||
           isTypeUnknownType(returnedType)
@@ -259,7 +258,7 @@ export default createRule({
 
     function getUnionCandidate(node: FunctionNode): UnionCandidate | null {
       const returnType = node.returnType?.typeAnnotation;
-      if (!returnType) {
+      if (returnType == null) {
         return null;
       }
 
@@ -318,7 +317,7 @@ export default createRule({
         return 'arrayElement';
       }
 
-      if (checker.isArrayLikeType(returnType)) {
+      if (checker.getIndexTypeOfType(returnType, ts.IndexKind.Number) != null) {
         return 'arrayElement';
       }
 
@@ -339,14 +338,7 @@ export default createRule({
       if (projection === 'awaited') {
         return checker.getAwaitedType(type) ?? null;
       }
-      const arrayType = checker.isArrayLikeType(type)
-        ? type
-        : getStableBaseConstraint(type);
-      if (!arrayType || !checker.isArrayLikeType(arrayType)) {
-        return null;
-      }
-
-      return checker.getIndexTypeOfType(arrayType, ts.IndexKind.Number) ?? null;
+      return checker.getIndexTypeOfType(type, ts.IndexKind.Number) ?? null;
     }
 
     function getProjectedTypeArgument(
@@ -365,7 +357,7 @@ export default createRule({
     ) {
       const projectedReturnType = getProjectedType(returnType, projection);
       if (
-        !projectedReturnType ||
+        projectedReturnType == null ||
         tsutils.isIntrinsicErrorType(projectedReturnType)
       ) {
         return null;
@@ -380,7 +372,7 @@ export default createRule({
       );
 
       if (
-        !projectedTypeArgument ||
+        projectedTypeArgument == null ||
         tsutils.isIntrinsicErrorType(projectedTypeArgument) ||
         !checker.isTypeAssignableTo(
           projectedReturnType,
@@ -409,7 +401,7 @@ export default createRule({
       }
 
       const memberSymbol = checker.getSymbolAtLocation(memberNameNode);
-      if (!memberSymbol) {
+      if (memberSymbol == null) {
         return false;
       }
       const memberSymbolName = memberSymbol.name;
@@ -455,7 +447,7 @@ export default createRule({
       ) {
         const indexInfos = checker.getIndexInfosOfType(baseType);
         if (
-          nameType &&
+          nameType != null &&
           indexInfos.some(indexInfo =>
             checker.isTypeAssignableTo(nameType, indexInfo.keyType),
           )
@@ -473,7 +465,7 @@ export default createRule({
         }
 
         if (
-          nameType ||
+          nameType != null ||
           (!ts.isIdentifier(memberNameNode) &&
             !ts.isStringLiteralLike(memberNameNode) &&
             !ts.isNumericLiteral(memberNameNode))
@@ -509,13 +501,13 @@ export default createRule({
           const baseType = checker.getTypeAtLocation(
             isStaticMember ? baseTypeNode.expression : baseTypeNode,
           );
-          if (checker.getPropertyOfType(baseType, memberSymbolName)) {
+          if (checker.getPropertyOfType(baseType, memberSymbolName) != null) {
             return true;
           }
 
           const nameType = getMemberNameType();
           if (
-            nameType &&
+            nameType != null &&
             tsutils.isTypeFlagSet(nameType, ts.TypeFlags.UniqueESSymbol) &&
             checker
               .getPropertiesOfType(baseType)
@@ -577,13 +569,13 @@ export default createRule({
 
     function checkFunction(node: FunctionNode) {
       const candidate = getUnionCandidate(node);
-      if (!candidate || shouldSkipFunction(node)) {
+      if (candidate == null || shouldSkipFunction(node)) {
         return;
       }
 
       const returnType = services.getTypeAtLocation(candidate.returnType);
       const projection = getProjection(candidate, returnType);
-      if (!projection) {
+      if (projection == null) {
         return;
       }
 
@@ -593,7 +585,7 @@ export default createRule({
         returnType,
       );
       if (
-        !effectiveReturnType ||
+        effectiveReturnType == null ||
         isTypeAnyType(effectiveReturnType) ||
         isTypeUnknownType(effectiveReturnType)
       ) {
@@ -602,7 +594,7 @@ export default createRule({
 
       const returnedTypes = getReturnedTypes(node, projection);
 
-      if (!returnedTypes || returnedTypes.length === 0) {
+      if (returnedTypes == null || returnedTypes.length === 0) {
         return;
       }
 
@@ -625,7 +617,7 @@ export default createRule({
         const typeAtNode = services.getTypeAtLocation(typeNode);
         const type = getProjectedTypeArgument(typeAtNode, projection);
         if (
-          !type ||
+          type == null ||
           tsutils.isIntrinsicErrorType(type) ||
           isTypeAnyType(type) ||
           isTypeUnknownType(type) ||
@@ -655,7 +647,8 @@ export default createRule({
 
             return (
               unresolved &&
-              (!constraint || !canProveNoOverlap(returnedType, constraint))
+              (constraint == null ||
+                !canProveNoOverlap(returnedType, constraint))
             );
           });
 

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-misleading-return-type.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-misleading-return-type.shot
@@ -1,12 +1,12 @@
 Incorrect
 
 function getStatus(): string | null {
-                               ~~~~ The return type includes `null`, but no returned expression requires it.
+                               ~~~~ No returned expression requires this type.
   return 'ready';
 }
 
 async function getAsyncStatus(): Promise<string | null> {
-                                                  ~~~~ The return type includes `null`, but no returned expression requires it.
+                                                  ~~~~ No returned expression requires this type.
   return 'ready';
 }
 

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-misleading-return-type.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-misleading-return-type.shot
@@ -1,0 +1,21 @@
+Incorrect
+
+function getStatus(): string | null {
+                               ~~~~ The return type includes `null`, but no returned expression requires it.
+  return 'ready';
+}
+
+async function getAsyncStatus(): Promise<string | null> {
+                                                  ~~~~ The return type includes `null`, but no returned expression requires it.
+  return 'ready';
+}
+
+Correct
+
+function getStatus(): string {
+  return 'ready';
+}
+
+async function getAsyncStatus(): Promise<string> {
+  return 'ready';
+}

--- a/packages/eslint-plugin/tests/rules/no-misleading-return-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-misleading-return-type.test.ts
@@ -85,6 +85,11 @@ function getValue<T extends { right: true }, U>(
 }
     `,
     `
+function getValue<T, U>(value: T): T | (U extends string ? string : number) {
+  return value;
+}
+    `,
+    `
 function createValue(): { left: string } | { right: number } {
   return { left: 'value', right: 1 };
 }
@@ -444,6 +449,14 @@ interface InvalidThenable {
 declare const thenable: InvalidThenable;
 function getValue(): Promise<string | null> {
   return thenable;
+}
+    `,
+    `
+interface InvalidThenable {
+  then(onfulfilled: string): unknown;
+}
+function getValue(): Promise<string | InvalidThenable> {
+  return Promise.resolve('value');
 }
     `,
     // Recursive thenables have no safely computable awaited type.

--- a/packages/eslint-plugin/tests/rules/no-misleading-return-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-misleading-return-type.test.ts
@@ -214,6 +214,20 @@ class ProviderImpl implements Provider {
 }
     `,
     `
+interface NumericProvider {
+  [key: number]: () => string | null;
+}
+interface NamedProvider {
+  [key: string]: () => string | null;
+}
+class ProviderImpl implements NumericProvider, NamedProvider {
+  [key: string]: () => string | null;
+  getValue(): string | null {
+    return 'value';
+  }
+}
+    `,
+    `
 interface Provider {
   [key: string]: () => string | null;
 }
@@ -242,6 +256,29 @@ interface Provider {
 class ProviderImpl implements Provider {
   [key: string]: () => string | null;
   0(): string | null {
+    return 'value';
+  }
+}
+    `,
+    `
+interface Provider {
+  [key: \`get\${string}\`]: () => string | null;
+}
+class ProviderImpl implements Provider {
+  [key: \`get\${string}\`]: () => string | null;
+  getValue(): string | null {
+    return 'value';
+  }
+}
+    `,
+    `
+interface Provider {
+  [key: symbol]: () => string | null;
+}
+declare const method: unique symbol;
+class ProviderImpl implements Provider {
+  [key: symbol]: () => string | null;
+  [method](): string | null {
     return 'value';
   }
 }
@@ -471,7 +508,6 @@ function getValue(): string | null {
       errors: [
         {
           column: 31,
-          data: { type: 'null' },
           endColumn: 35,
           endLine: 2,
           line: 2,
@@ -488,7 +524,6 @@ function getValue(): string | (number | null) {
       errors: [
         {
           column: 22,
-          data: { type: 'string' },
           endColumn: 28,
           endLine: 2,
           line: 2,
@@ -496,7 +531,6 @@ function getValue(): string | (number | null) {
         },
         {
           column: 41,
-          data: { type: 'null' },
           endColumn: 45,
           endLine: 2,
           line: 2,
@@ -515,7 +549,6 @@ class Values {
       errors: [
         {
           column: 31,
-          data: { type: 'null' },
           endColumn: 35,
           endLine: 3,
           line: 3,
@@ -534,7 +567,6 @@ class Values {
       errors: [
         {
           column: 24,
-          data: { type: 'null' },
           endColumn: 28,
           endLine: 3,
           line: 3,
@@ -546,7 +578,7 @@ class Values {
       code: `
 class Base {
   #getValue(): string | null {
-    return 'value';
+    return Math.random() > 0.5 ? 'value' : null;
   }
 }
 class Derived extends Base {
@@ -558,15 +590,6 @@ class Derived extends Base {
       errors: [
         {
           column: 25,
-          data: { type: 'null' },
-          endColumn: 29,
-          endLine: 3,
-          line: 3,
-          messageId: 'unnecessaryType',
-        },
-        {
-          column: 25,
-          data: { type: 'null' },
           endColumn: 29,
           endLine: 8,
           line: 8,
@@ -592,7 +615,6 @@ class ProviderImpl implements Provider {
       errors: [
         {
           column: 31,
-          data: { type: 'null' },
           endColumn: 35,
           endLine: 6,
           line: 6,
@@ -614,10 +636,31 @@ class Derived extends Base {
       errors: [
         {
           column: 31,
-          data: { type: 'null' },
           endColumn: 35,
           endLine: 6,
           line: 6,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+interface Provider {
+  [key: \`get\${string}\`]: () => string | null;
+}
+class ProviderImpl implements Provider {
+  [key: \`get\${string}\`]: () => string | null;
+  other(): string | null {
+    return 'value';
+  }
+}
+      `,
+      errors: [
+        {
+          column: 21,
+          endColumn: 25,
+          endLine: 7,
+          line: 7,
           messageId: 'unnecessaryType',
         },
       ],
@@ -627,7 +670,6 @@ class Derived extends Base {
       errors: [
         {
           column: 31,
-          data: { type: 'null' },
           endColumn: 35,
           endLine: 1,
           line: 1,
@@ -644,7 +686,6 @@ const getValue = function (): string | null {
       errors: [
         {
           column: 40,
-          data: { type: 'null' },
           endColumn: 44,
           endLine: 2,
           line: 2,
@@ -661,7 +702,6 @@ async function getValue(): Promise<string | null> {
       errors: [
         {
           column: 45,
-          data: { type: 'null' },
           endColumn: 49,
           endLine: 2,
           line: 2,
@@ -678,7 +718,6 @@ async function getValue(): globalThis.Promise<string | null> {
       errors: [
         {
           column: 56,
-          data: { type: 'null' },
           endColumn: 60,
           endLine: 2,
           line: 2,
@@ -695,8 +734,23 @@ async function getValue<T>(value: T): Promise<T | null> {
       errors: [
         {
           column: 51,
-          data: { type: 'null' },
           endColumn: 55,
+          endLine: 2,
+          line: 2,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+function getValue<T>(value: T): Promise<T | null> {
+  return Promise.resolve(value);
+}
+      `,
+      errors: [
+        {
+          column: 45,
+          endColumn: 49,
           endLine: 2,
           line: 2,
           messageId: 'unnecessaryType',
@@ -712,7 +766,6 @@ function getValue(): PromiseLike<string | null> {
       errors: [
         {
           column: 43,
-          data: { type: 'null' },
           endColumn: 47,
           endLine: 2,
           line: 2,
@@ -731,7 +784,6 @@ function getValue(): CustomPromise<string | null> {
       errors: [
         {
           column: 45,
-          data: { type: 'null' },
           endColumn: 49,
           endLine: 4,
           line: 4,
@@ -748,7 +800,6 @@ async function getValue(): Promise<Promise<string> | null> {
       errors: [
         {
           column: 54,
-          data: { type: 'null' },
           endColumn: 58,
           endLine: 2,
           line: 2,
@@ -765,7 +816,6 @@ function getValues(): Array<string | null> {
       errors: [
         {
           column: 38,
-          data: { type: 'null' },
           endColumn: 42,
           endLine: 2,
           line: 2,
@@ -782,7 +832,6 @@ function getValues(): (string | null)[] {
       errors: [
         {
           column: 33,
-          data: { type: 'null' },
           endColumn: 37,
           endLine: 2,
           line: 2,
@@ -799,7 +848,6 @@ function getValues(): readonly (string | null)[] {
       errors: [
         {
           column: 42,
-          data: { type: 'null' },
           endColumn: 46,
           endLine: 2,
           line: 2,
@@ -816,7 +864,6 @@ function getValues<T extends string[]>(values: T): Array<string | null> {
       errors: [
         {
           column: 67,
-          data: { type: 'null' },
           endColumn: 71,
           endLine: 2,
           line: 2,
@@ -835,7 +882,6 @@ function getValues(): ReadonlyArray<string | null> {
       errors: [
         {
           column: 46,
-          data: { type: 'null' },
           endColumn: 50,
           endLine: 4,
           line: 4,
@@ -852,7 +898,6 @@ function getValue(): Promise<string | null> {
       errors: [
         {
           column: 39,
-          data: { type: 'null' },
           endColumn: 43,
           endLine: 2,
           line: 2,
@@ -869,7 +914,6 @@ function getValue(): 'ready' | 'idle' {
       errors: [
         {
           column: 32,
-          data: { type: "'idle'" },
           endColumn: 38,
           endLine: 2,
           line: 2,
@@ -886,7 +930,6 @@ function getValue(): 'ready' | string | null {
       errors: [
         {
           column: 32,
-          data: { type: 'string' },
           endColumn: 38,
           endLine: 2,
           line: 2,
@@ -903,7 +946,6 @@ function getValue(): true | boolean | null {
       errors: [
         {
           column: 29,
-          data: { type: 'boolean' },
           endColumn: 36,
           endLine: 2,
           line: 2,
@@ -920,7 +962,6 @@ function createValue(): { kind: 'ready' } | { kind: 'idle' } {
       errors: [
         {
           column: 45,
-          data: { type: "{ kind: 'idle' }" },
           endColumn: 61,
           endLine: 2,
           line: 2,
@@ -937,7 +978,6 @@ function createValue(): { left: string } | { right: number } | null {
       errors: [
         {
           column: 64,
-          data: { type: 'null' },
           endColumn: 68,
           endLine: 2,
           line: 2,
@@ -955,7 +995,6 @@ function getValue(): object | typeof missing {
       errors: [
         {
           column: 31,
-          data: { type: 'typeof missing' },
           endColumn: 45,
           endLine: 3,
           line: 3,
@@ -974,7 +1013,6 @@ function getValue(): TextValue | MissingValue {
       errors: [
         {
           column: 34,
-          data: { type: 'MissingValue' },
           endColumn: 46,
           endLine: 4,
           line: 4,
@@ -991,8 +1029,23 @@ function getValue<T>(value: T): T | null {
       errors: [
         {
           column: 37,
-          data: { type: 'null' },
           endColumn: 41,
+          endLine: 2,
+          line: 2,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+function getValue<T>(values: Map<string, T>, key: string): T | null {
+  return values.get(key)!;
+}
+      `,
+      errors: [
+        {
+          column: 64,
+          endColumn: 68,
           endLine: 2,
           line: 2,
           messageId: 'unnecessaryType',
@@ -1008,7 +1061,6 @@ function getValue<T extends string | null>(value: T): string | null | number {
       errors: [
         {
           column: 71,
-          data: { type: 'number' },
           endColumn: 77,
           endLine: 2,
           line: 2,
@@ -1025,7 +1077,6 @@ function getValue<T extends string>(value: null): \`\${T}\` | null {
       errors: [
         {
           column: 51,
-          data: { type: '`${T}`' },
           endColumn: 57,
           endLine: 2,
           line: 2,
@@ -1042,7 +1093,6 @@ function getValue(): \`value-\${string}\` | 'fallback' {
       errors: [
         {
           column: 22,
-          data: { type: '`value-${string}`' },
           endColumn: 39,
           endLine: 2,
           line: 2,
@@ -1059,7 +1109,6 @@ function getValue<T>(value: null): (T extends string ? string : number) | null {
       errors: [
         {
           column: 37,
-          data: { type: 'T extends string ? string : number' },
           endColumn: 71,
           endLine: 2,
           line: 2,
@@ -1078,7 +1127,6 @@ function getValue<T>(value: {
       errors: [
         {
           column: 6,
-          data: { type: 'T extends string ? string : number' },
           endColumn: 40,
           endLine: 4,
           line: 4,
@@ -1097,7 +1145,6 @@ function getValue<T extends object, U>(
       errors: [
         {
           column: 9,
-          data: { type: 'U extends string ? string : number' },
           endColumn: 43,
           endLine: 4,
           line: 4,
@@ -1114,7 +1161,6 @@ function getValue<T extends string>(value: null): Uppercase<T> | null {
       errors: [
         {
           column: 51,
-          data: { type: 'Uppercase<T>' },
           endColumn: 63,
           endLine: 2,
           line: 2,
@@ -1131,7 +1177,6 @@ function getValue(): boolean | null {
       errors: [
         {
           column: 32,
-          data: { type: 'null' },
           endColumn: 36,
           endLine: 2,
           line: 2,
@@ -1150,7 +1195,6 @@ const values = {
       errors: [
         {
           column: 24,
-          data: { type: 'null' },
           endColumn: 28,
           endLine: 3,
           line: 3,
@@ -1169,7 +1213,6 @@ const values = {
       errors: [
         {
           column: 27,
-          data: { type: 'null' },
           endColumn: 31,
           endLine: 3,
           line: 3,
@@ -1190,7 +1233,6 @@ function getValue(): string | null {
       errors: [
         {
           column: 31,
-          data: { type: 'null' },
           endColumn: 35,
           endLine: 2,
           line: 2,
@@ -1208,7 +1250,6 @@ function getValue(): string | number | null {
       errors: [
         {
           column: 40,
-          data: { type: 'null' },
           endColumn: 44,
           endLine: 3,
           line: 3,
@@ -1226,7 +1267,6 @@ function getValue(): string | null {
       errors: [
         {
           column: 31,
-          data: { type: 'null' },
           endColumn: 35,
           endLine: 3,
           line: 3,
@@ -1244,7 +1284,6 @@ function getValue(): string | null {
       errors: [
         {
           column: 31,
-          data: { type: 'null' },
           endColumn: 35,
           endLine: 3,
           line: 3,
@@ -1262,7 +1301,6 @@ function getValue(): string | null {
       errors: [
         {
           column: 31,
-          data: { type: 'null' },
           endColumn: 35,
           endLine: 2,
           line: 2,
@@ -1280,7 +1318,6 @@ function getValue(): string | null {
       errors: [
         {
           column: 31,
-          data: { type: 'null' },
           endColumn: 35,
           endLine: 3,
           line: 3,
@@ -1298,7 +1335,6 @@ function getValue(): string | null {
       errors: [
         {
           column: 31,
-          data: { type: 'null' },
           endColumn: 35,
           endLine: 3,
           line: 3,

--- a/packages/eslint-plugin/tests/rules/no-misleading-return-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-misleading-return-type.test.ts
@@ -174,6 +174,22 @@ function getValues(): Array<string | null> {
 }
     `,
     `
+declare const values: ArrayLike<string | null>;
+function getValues(): ArrayLike<string | null> {
+  return values;
+}
+    `,
+    `
+interface NumberIndexed<T> {
+  readonly [index: number]: string;
+  readonly metadata: T;
+}
+declare const values: NumberIndexed<string>;
+function getValues(): NumberIndexed<string | null> {
+  return values;
+}
+    `,
+    `
 declare const values: string[];
 function getValues(): Array<string | undefined> {
   return values;
@@ -898,6 +914,23 @@ function getValues(): ReadonlyArray<string | null> {
           endColumn: 50,
           endLine: 4,
           line: 4,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+declare const values: ArrayLike<string>;
+function getValues(): ArrayLike<string | null> {
+  return values;
+}
+      `,
+      errors: [
+        {
+          column: 42,
+          endColumn: 46,
+          endLine: 3,
+          line: 3,
           messageId: 'unnecessaryType',
         },
       ],

--- a/packages/eslint-plugin/tests/rules/no-misleading-return-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-misleading-return-type.test.ts
@@ -1,0 +1,1316 @@
+import rule from '../../src/rules/no-misleading-return-type';
+import { createRuleTesterWithTypes } from '../RuleTester';
+
+const ruleTester = createRuleTesterWithTypes();
+
+ruleTester.run('no-misleading-return-type', rule, {
+  valid: [
+    `
+function getValue() {
+  return 'value';
+}
+    `,
+    `
+function getValue(): string {
+  return 'value';
+}
+    `,
+    `
+function getValue(flag: boolean): string | null {
+  if (flag) {
+    return null;
+  }
+  return 'value';
+}
+    `,
+    `
+function getValue<T extends string | null>(value: T): string | null {
+  return value;
+}
+    `,
+    `
+function getValue<T extends string | number>(
+  value: T,
+): T | (T extends string ? string : number) {
+  return value;
+}
+    `,
+    `
+function getValue<T>(
+  flag: boolean,
+): (T extends unknown ? undefined : never) | string {
+  if (flag) {
+    return 'value';
+  }
+  return;
+}
+    `,
+    `
+function getValue<T extends string>(value: T): T | \`\${T}\` {
+  return value;
+}
+    `,
+    `
+function getValue<T>(value: T & string): \`\${T & string}\` | (T & string) {
+  return value;
+}
+    `,
+    `
+function getValue(flag: boolean): \`value-\${string}\` | 'fallback' {
+  return flag ? 'value-ready' : 'fallback';
+}
+    `,
+    `
+function getValue<T extends 'A' | 'B'>(value: T): T | Uppercase<T> {
+  return value;
+}
+    `,
+    `
+function getValue<T extends { key?: string }>(value: T): T | Required<T> {
+  return value;
+}
+    `,
+    `
+function getValue<T>(value: {
+  right: true;
+}): (T extends string ? { left: true } : { other: true }) | { right: true } {
+  return value;
+}
+    `,
+    `
+function getValue<T extends { right: true }, U>(
+  value: T,
+): T | (U extends string ? { left: true } : { other: true }) {
+  return value;
+}
+    `,
+    `
+function createValue(): { left: string } | { right: number } {
+  return { left: 'value', right: 1 };
+}
+    `,
+    `
+declare const value: string;
+function getValue(): string | 'value' {
+  return value;
+}
+    `,
+    `
+function getValue(flag: boolean): 'ready' | 'idle' | string | null {
+  return flag ? 'ready' : null;
+}
+    `,
+    `
+function getValue(flag: boolean): true | boolean | null {
+  return flag ? false : null;
+}
+    `,
+    `
+enum AllowedType {
+  Number,
+  String,
+  Unknown,
+}
+enum TypeFlags {
+  Unknown = 2,
+}
+declare function getAllowedType(): AllowedType;
+function getValue(): AllowedType | TypeFlags.Unknown | undefined {
+  return getAllowedType();
+}
+
+enum FirstText {
+  Value = 'value',
+}
+enum SecondText {
+  Value = 'value',
+}
+function getText(): FirstText.Value | SecondText.Value {
+  return FirstText.Value;
+}
+    `,
+    `
+type BooleanResult = boolean | 'fallback';
+function getValue(flag: boolean): true | BooleanResult | null {
+  return flag ? false : null;
+}
+    `,
+    `
+declare const result: string | null;
+function getValue(): string | null {
+  return result;
+}
+    `,
+    {
+      code: `
+declare const values: string[];
+function getValue(): string | null {
+  const value = values[0];
+  return value ?? null;
+}
+      `,
+      languageOptions: {
+        parserOptions: {
+          project: './tsconfig.noUncheckedIndexedAccess.json',
+          projectService: false,
+        },
+      },
+    },
+    `
+type Result = string | null;
+function getValue(): Result {
+  return 'value';
+}
+    `,
+    `
+declare const values: Array<string | null>;
+function getValues(): Array<string | null> {
+  return values;
+}
+    `,
+    `
+declare const values: string[];
+function getValues(): Array<string | undefined> {
+  return values;
+}
+    `,
+    `
+function getValue(): string;
+function getValue(): string | null {
+  return 'value';
+}
+    `,
+    `
+const getValue: () => string | null = (): string | null => 'value';
+    `,
+    `
+interface Provider {
+  getValue(): string | null;
+}
+const provider = {
+  getValue(): string | null {
+    return 'value';
+  },
+} as Provider;
+    `,
+    `
+interface Provider {
+  getValue(): string | null;
+}
+const provider = {
+  getValue(): string | null {
+    return 'value';
+  },
+} satisfies Provider;
+    `,
+    `
+interface Provider {
+  getValue(): string | null;
+}
+class ProviderImpl implements Provider {
+  getValue(): string | null {
+    return 'value';
+  }
+}
+    `,
+    `
+interface Provider {
+  [key: string]: () => string | null;
+}
+class ProviderImpl implements Provider {
+  [key: string]: () => string | null;
+  getValue(): string | null {
+    return 'value';
+  }
+}
+    `,
+    `
+interface Provider {
+  [key: number]: () => string | null;
+}
+class ProviderImpl implements Provider {
+  [key: number]: () => string | null;
+  '0'(): string | null {
+    return 'value';
+  }
+}
+    `,
+    `
+interface Provider {
+  [key: string]: () => string | null;
+}
+class ProviderImpl implements Provider {
+  [key: string]: () => string | null;
+  0(): string | null {
+    return 'value';
+  }
+}
+    `,
+    `
+interface Provider {
+  getValue: () => string | null;
+}
+class ProviderImpl implements Provider {
+  getValue = (): string | null => 'value';
+}
+    `,
+    `
+class Base {
+  getValue = (): string | null => (Math.random() > 0.5 ? 'value' : null);
+}
+class Derived extends Base {
+  override getValue = (): string | null => 'value';
+}
+    `,
+    `
+function getValue(): string | null {
+  throw new Error('unreachable');
+}
+    `,
+    `
+function getValue(): string | null {
+  return JSON.parse('"value"');
+}
+    `,
+    `
+function getValue(flag: boolean): string | undefined {
+  if (flag) {
+    return 'value';
+  }
+}
+    `,
+    `
+function getValue<T extends undefined>(): string | T {
+  return 'value';
+}
+    `,
+    `
+class Values {
+  getValue(): string;
+  getValue(): string | null {
+    return 'value';
+  }
+}
+    `,
+    `
+class Base {
+  static getValue(): string | null {
+    return Math.random() > 0.5 ? 'value' : null;
+  }
+}
+class Derived extends Base {
+  static getValue(): string | null {
+    return 'value';
+  }
+}
+    `,
+    `
+declare const method: unique symbol;
+class Base {
+  [method](): string | null {
+    return Math.random() > 0.5 ? 'value' : null;
+  }
+}
+class Derived extends Base {
+  [method](): string | null {
+    return 'value';
+  }
+}
+    `,
+    `
+function preserveClass<T extends Function>(value: T): T {
+  return value;
+}
+
+@preserveClass
+class Values {
+  getValue(): string | null {
+    return 'value';
+  }
+}
+    `,
+    `
+function replaceMethod(
+  _target: object,
+  _propertyKey: string | symbol,
+  descriptor: TypedPropertyDescriptor<() => string | null>,
+): void {
+  descriptor.value = () => null;
+}
+
+class Values {
+  @replaceMethod
+  getValue(): string | null {
+    return 'value';
+  }
+}
+    `,
+    `
+async function getValue(flag: boolean): Promise<string | null> {
+  if (flag) {
+    return 'value';
+  }
+  return null;
+}
+    `,
+    `
+type DefinedPromise<T> = Promise<Exclude<T, null>>;
+function getValue(): DefinedPromise<string | null> {
+  return Promise.resolve('value');
+}
+    `,
+    `
+type DefinedArray<T> = Array<Exclude<T, null>>;
+function getValues(): DefinedArray<string | null> {
+  return ['value'];
+}
+    `,
+    `
+function createProvider() {
+  type Promise<T> = { value: T };
+  function getValue(): Promise<string | null> {
+    return { value: 'value' };
+  }
+  return getValue;
+}
+    `,
+    `
+function createValues() {
+  type Array<T> = { value: T };
+  function getValues(): Array<string | null> {
+    return { value: 'value' };
+  }
+  return getValues;
+}
+    `,
+    // Type-invalid implementations must not make array projection throw.
+    `
+function getValues(): Array<string | null> {
+  return 1;
+}
+    `,
+    `
+interface MisalignedThenable<T> {
+  marker: T;
+  then(onfulfilled: (value: number) => unknown): unknown;
+}
+declare const thenable: MisalignedThenable<string | null>;
+function getValue(): MisalignedThenable<string | null> {
+  return thenable;
+}
+    `,
+    // Invalid thenables can make the checker return no awaited type.
+    `
+interface InvalidThenable {
+  then(onfulfilled: string): unknown;
+}
+declare const thenable: InvalidThenable;
+function getValue(): Promise<string | null> {
+  return thenable;
+}
+    `,
+    // Recursive thenables have no safely computable awaited type.
+    `
+interface CircularThenable<T> {
+  then(onfulfilled: (value: CircularThenable<T>) => unknown): unknown;
+}
+declare const thenable: CircularThenable<string>;
+function getValue(): CircularThenable<string | null> {
+  return thenable;
+}
+    `,
+    `
+function* getValues():
+  Generator<string, void, unknown> | Generator<'value', void, unknown> {
+  yield 'value';
+}
+    `,
+    `
+declare const value: unknown;
+function getValue(): unknown | string {
+  return value;
+}
+    `,
+    `
+function getValue(): string | never {
+  return 'value';
+}
+    `,
+    `
+function getValue(): string | any {
+  return 1;
+}
+    `,
+    `
+async function getValue(): Promise<string | unknown> {
+  return 1;
+}
+    `,
+    `
+declare function fail(): never;
+function getValue(): string | null {
+  return fail();
+}
+    `,
+    `
+function getValue(flag: boolean): string | void {
+  if (flag) {
+    return 'value';
+  }
+  return;
+}
+    `,
+  ],
+  invalid: [
+    {
+      code: `
+function getValue(): string | null {
+  return 'value';
+}
+      `,
+      errors: [
+        {
+          column: 31,
+          data: { type: 'null' },
+          endColumn: 35,
+          endLine: 2,
+          line: 2,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+function getValue(): string | (number | null) {
+  return 1;
+}
+      `,
+      errors: [
+        {
+          column: 22,
+          data: { type: 'string' },
+          endColumn: 28,
+          endLine: 2,
+          line: 2,
+          messageId: 'unnecessaryType',
+        },
+        {
+          column: 41,
+          data: { type: 'null' },
+          endColumn: 45,
+          endLine: 2,
+          line: 2,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+class Values {
+  static getValue(): string | null {
+    return 'value';
+  }
+}
+      `,
+      errors: [
+        {
+          column: 31,
+          data: { type: 'null' },
+          endColumn: 35,
+          endLine: 3,
+          line: 3,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+class Values {
+  getValue(): string | null {
+    return 'value';
+  }
+}
+      `,
+      errors: [
+        {
+          column: 24,
+          data: { type: 'null' },
+          endColumn: 28,
+          endLine: 3,
+          line: 3,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+class Base {
+  #getValue(): string | null {
+    return 'value';
+  }
+}
+class Derived extends Base {
+  #getValue(): string | null {
+    return 'value';
+  }
+}
+      `,
+      errors: [
+        {
+          column: 25,
+          data: { type: 'null' },
+          endColumn: 29,
+          endLine: 3,
+          line: 3,
+          messageId: 'unnecessaryType',
+        },
+        {
+          column: 25,
+          data: { type: 'null' },
+          endColumn: 29,
+          endLine: 8,
+          line: 8,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+interface Provider {
+  getValue(): string | null;
+}
+class ProviderImpl implements Provider {
+  static getValue(): string | null {
+    return 'value';
+  }
+
+  getValue(): string | null {
+    return Math.random() > 0.5 ? 'value' : null;
+  }
+}
+      `,
+      errors: [
+        {
+          column: 31,
+          data: { type: 'null' },
+          endColumn: 35,
+          endLine: 6,
+          line: 6,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+class Base {
+  static [key: string]: () => number;
+}
+class Derived extends Base {
+  static getValue(): string | null {
+    return 'value';
+  }
+}
+      `,
+      errors: [
+        {
+          column: 31,
+          data: { type: 'null' },
+          endColumn: 35,
+          endLine: 6,
+          line: 6,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: "const getValue = (): string | null => 'value';",
+      errors: [
+        {
+          column: 31,
+          data: { type: 'null' },
+          endColumn: 35,
+          endLine: 1,
+          line: 1,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+const getValue = function (): string | null {
+  return 'value';
+};
+      `,
+      errors: [
+        {
+          column: 40,
+          data: { type: 'null' },
+          endColumn: 44,
+          endLine: 2,
+          line: 2,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+async function getValue(): Promise<string | null> {
+  return 'value';
+}
+      `,
+      errors: [
+        {
+          column: 45,
+          data: { type: 'null' },
+          endColumn: 49,
+          endLine: 2,
+          line: 2,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+async function getValue(): globalThis.Promise<string | null> {
+  return 'value';
+}
+      `,
+      errors: [
+        {
+          column: 56,
+          data: { type: 'null' },
+          endColumn: 60,
+          endLine: 2,
+          line: 2,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+async function getValue<T>(value: T): Promise<T | null> {
+  return value;
+}
+      `,
+      errors: [
+        {
+          column: 51,
+          data: { type: 'null' },
+          endColumn: 55,
+          endLine: 2,
+          line: 2,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+function getValue(): PromiseLike<string | null> {
+  return Promise.resolve('value');
+}
+      `,
+      errors: [
+        {
+          column: 43,
+          data: { type: 'null' },
+          endColumn: 47,
+          endLine: 2,
+          line: 2,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+interface CustomPromise<T> extends PromiseLike<T> {}
+declare const result: CustomPromise<string>;
+function getValue(): CustomPromise<string | null> {
+  return result;
+}
+      `,
+      errors: [
+        {
+          column: 45,
+          data: { type: 'null' },
+          endColumn: 49,
+          endLine: 4,
+          line: 4,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+async function getValue(): Promise<Promise<string> | null> {
+  return 'value';
+}
+      `,
+      errors: [
+        {
+          column: 54,
+          data: { type: 'null' },
+          endColumn: 58,
+          endLine: 2,
+          line: 2,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+function getValues(): Array<string | null> {
+  return ['value'];
+}
+      `,
+      errors: [
+        {
+          column: 38,
+          data: { type: 'null' },
+          endColumn: 42,
+          endLine: 2,
+          line: 2,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+function getValues(): (string | null)[] {
+  return ['value'];
+}
+      `,
+      errors: [
+        {
+          column: 33,
+          data: { type: 'null' },
+          endColumn: 37,
+          endLine: 2,
+          line: 2,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+function getValues(): readonly (string | null)[] {
+  return ['value'];
+}
+      `,
+      errors: [
+        {
+          column: 42,
+          data: { type: 'null' },
+          endColumn: 46,
+          endLine: 2,
+          line: 2,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+function getValues<T extends string[]>(values: T): Array<string | null> {
+  return values;
+}
+      `,
+      errors: [
+        {
+          column: 67,
+          data: { type: 'null' },
+          endColumn: 71,
+          endLine: 2,
+          line: 2,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+interface Values extends ReadonlyArray<string> {}
+declare const values: Values;
+function getValues(): ReadonlyArray<string | null> {
+  return values;
+}
+      `,
+      errors: [
+        {
+          column: 46,
+          data: { type: 'null' },
+          endColumn: 50,
+          endLine: 4,
+          line: 4,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+function getValue(): Promise<string | null> {
+  return Promise.resolve('value');
+}
+      `,
+      errors: [
+        {
+          column: 39,
+          data: { type: 'null' },
+          endColumn: 43,
+          endLine: 2,
+          line: 2,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+function getValue(): 'ready' | 'idle' {
+  return 'ready';
+}
+      `,
+      errors: [
+        {
+          column: 32,
+          data: { type: "'idle'" },
+          endColumn: 38,
+          endLine: 2,
+          line: 2,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+function getValue(): 'ready' | string | null {
+  return null;
+}
+      `,
+      errors: [
+        {
+          column: 32,
+          data: { type: 'string' },
+          endColumn: 38,
+          endLine: 2,
+          line: 2,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+function getValue(): true | boolean | null {
+  return null;
+}
+      `,
+      errors: [
+        {
+          column: 29,
+          data: { type: 'boolean' },
+          endColumn: 36,
+          endLine: 2,
+          line: 2,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+function createValue(): { kind: 'ready' } | { kind: 'idle' } {
+  return { kind: 'ready' };
+}
+      `,
+      errors: [
+        {
+          column: 45,
+          data: { type: "{ kind: 'idle' }" },
+          endColumn: 61,
+          endLine: 2,
+          line: 2,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+function createValue(): { left: string } | { right: number } | null {
+  return { left: 'value', right: 1 };
+}
+      `,
+      errors: [
+        {
+          column: 64,
+          data: { type: 'null' },
+          endColumn: 68,
+          endLine: 2,
+          line: 2,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+declare const missing: unique symbol;
+function getValue(): object | typeof missing {
+  return {};
+}
+      `,
+      errors: [
+        {
+          column: 31,
+          data: { type: 'typeof missing' },
+          endColumn: 45,
+          endLine: 3,
+          line: 3,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+type TextValue = string;
+type MissingValue = null;
+function getValue(): TextValue | MissingValue {
+  return 'value';
+}
+      `,
+      errors: [
+        {
+          column: 34,
+          data: { type: 'MissingValue' },
+          endColumn: 46,
+          endLine: 4,
+          line: 4,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+function getValue<T>(value: T): T | null {
+  return value;
+}
+      `,
+      errors: [
+        {
+          column: 37,
+          data: { type: 'null' },
+          endColumn: 41,
+          endLine: 2,
+          line: 2,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+function getValue<T extends string | null>(value: T): string | null | number {
+  return value;
+}
+      `,
+      errors: [
+        {
+          column: 71,
+          data: { type: 'number' },
+          endColumn: 77,
+          endLine: 2,
+          line: 2,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+function getValue<T extends string>(value: null): \`\${T}\` | null {
+  return value;
+}
+      `,
+      errors: [
+        {
+          column: 51,
+          data: { type: '`${T}`' },
+          endColumn: 57,
+          endLine: 2,
+          line: 2,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+function getValue(): \`value-\${string}\` | 'fallback' {
+  return 'fallback';
+}
+      `,
+      errors: [
+        {
+          column: 22,
+          data: { type: '`value-${string}`' },
+          endColumn: 39,
+          endLine: 2,
+          line: 2,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+function getValue<T>(value: null): (T extends string ? string : number) | null {
+  return value;
+}
+      `,
+      errors: [
+        {
+          column: 37,
+          data: { type: 'T extends string ? string : number' },
+          endColumn: 71,
+          endLine: 2,
+          line: 2,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+function getValue<T>(value: {
+  key: string;
+}): (T extends string ? string : number) | { key: string } {
+  return value;
+}
+      `,
+      errors: [
+        {
+          column: 6,
+          data: { type: 'T extends string ? string : number' },
+          endColumn: 40,
+          endLine: 4,
+          line: 4,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+function getValue<T extends object, U>(
+  value: T,
+): T | (U extends string ? string : number) {
+  return value;
+}
+      `,
+      errors: [
+        {
+          column: 9,
+          data: { type: 'U extends string ? string : number' },
+          endColumn: 43,
+          endLine: 4,
+          line: 4,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+function getValue<T extends string>(value: null): Uppercase<T> | null {
+  return value;
+}
+      `,
+      errors: [
+        {
+          column: 51,
+          data: { type: 'Uppercase<T>' },
+          endColumn: 63,
+          endLine: 2,
+          line: 2,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+function getValue(): boolean | null {
+  return true;
+}
+      `,
+      errors: [
+        {
+          column: 32,
+          data: { type: 'null' },
+          endColumn: 36,
+          endLine: 2,
+          line: 2,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+const values = {
+  getValue(): string | null {
+    return 'value';
+  },
+};
+      `,
+      errors: [
+        {
+          column: 24,
+          data: { type: 'null' },
+          endColumn: 28,
+          endLine: 3,
+          line: 3,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+const values = {
+  get current(): string | null {
+    return 'value';
+  },
+};
+      `,
+      errors: [
+        {
+          column: 27,
+          data: { type: 'null' },
+          endColumn: 31,
+          endLine: 3,
+          line: 3,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+function getValue(): string | null {
+  function getFallback(): null {
+    return null;
+  }
+  getFallback;
+  return 'value';
+}
+      `,
+      errors: [
+        {
+          column: 31,
+          data: { type: 'null' },
+          endColumn: 35,
+          endLine: 2,
+          line: 2,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+declare const result: string | number;
+function getValue(): string | number | null {
+  return result;
+}
+      `,
+      errors: [
+        {
+          column: 40,
+          data: { type: 'null' },
+          endColumn: 44,
+          endLine: 3,
+          line: 3,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+const values = ['value'] as const;
+function getValue(): string | null {
+  return values[0];
+}
+      `,
+      errors: [
+        {
+          column: 31,
+          data: { type: 'null' },
+          endColumn: 35,
+          endLine: 3,
+          line: 3,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+declare const values: string[];
+function getValue(): string | null {
+  return values[0];
+}
+      `,
+      errors: [
+        {
+          column: 31,
+          data: { type: 'null' },
+          endColumn: 35,
+          endLine: 3,
+          line: 3,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+function getValue(): string | null {
+  const [value] = ['value'] as const;
+  return value;
+}
+      `,
+      errors: [
+        {
+          column: 31,
+          data: { type: 'null' },
+          endColumn: 35,
+          endLine: 2,
+          line: 2,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+declare const values: string[];
+function getValue(): string | null {
+  return values[0] ?? null;
+}
+      `,
+      errors: [
+        {
+          column: 31,
+          data: { type: 'null' },
+          endColumn: 35,
+          endLine: 3,
+          line: 3,
+          messageId: 'unnecessaryType',
+        },
+      ],
+    },
+    {
+      code: `
+declare const values: string[];
+function getValue(): string | null {
+  return values[0] ?? 'fallback';
+}
+      `,
+      errors: [
+        {
+          column: 31,
+          data: { type: 'null' },
+          endColumn: 35,
+          endLine: 3,
+          line: 3,
+          messageId: 'unnecessaryType',
+        },
+      ],
+      languageOptions: {
+        parserOptions: {
+          project: './tsconfig.noUncheckedIndexedAccess.json',
+          projectService: false,
+        },
+      },
+    },
+  ],
+});

--- a/packages/eslint-plugin/tests/schema-snapshots/no-misleading-return-type.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-misleading-return-type.shot
@@ -1,0 +1,10 @@
+
+# SCHEMA:
+
+[]
+
+
+# TYPES:
+
+/** No options declared */
+type Options = [];


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: closes #6442
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

Adds `@typescript-eslint/no-misleading-return-type` to report return annotations such as `string | null` when the function only returns strings.

It checks written unions in direct return types and in the built-in array and promise types. Custom container annotations and unions hidden behind return-type aliases are excluded. Annotations that may define an external contract are skipped. No options or autofix; the rule is not enabled in the recommended or strict configs.

🐹
