### PR TITLE
test(eslint-plugin): [prefer-optional-chain] use `createRuleTesterWithTypes` instead of `RuleTester` directly

### DIFF
--- a/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain-and-boolean.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain-and-boolean.test.ts
@@ -1,16 +1,7 @@
-import { RuleTester } from '@typescript-eslint/rule-tester';
-
 import rule from '../../../src/rules/prefer-optional-chain';
-import { getFixturesRootDir } from '../../RuleTester';
+import { createRuleTesterWithTypes } from '../../RuleTester';
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      projectService: true,
-      tsconfigRootDir: getFixturesRootDir(),
-    },
-  },
-});
+const ruleTester = createRuleTesterWithTypes();
 
 ruleTester.run('prefer-optional-chain-and-boolean', rule, {
   invalid: [

--- a/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain-and-neq-null.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain-and-neq-null.test.ts
@@ -1,16 +1,7 @@
-import { RuleTester } from '@typescript-eslint/rule-tester';
-
 import rule from '../../../src/rules/prefer-optional-chain';
-import { getFixturesRootDir } from '../../RuleTester';
+import { createRuleTesterWithTypes } from '../../RuleTester';
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      projectService: true,
-      tsconfigRootDir: getFixturesRootDir(),
-    },
-  },
-});
+const ruleTester = createRuleTesterWithTypes();
 
 ruleTester.run('prefer-optional-chain-and-neq-null', rule, {
   invalid: [

--- a/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain-and-neq-undefined.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain-and-neq-undefined.test.ts
@@ -1,16 +1,7 @@
-import { RuleTester } from '@typescript-eslint/rule-tester';
-
 import rule from '../../../src/rules/prefer-optional-chain';
-import { getFixturesRootDir } from '../../RuleTester';
+import { createRuleTesterWithTypes } from '../../RuleTester';
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      projectService: true,
-      tsconfigRootDir: getFixturesRootDir(),
-    },
-  },
-});
+const ruleTester = createRuleTesterWithTypes();
 
 ruleTester.run('prefer-optional-chain-and-neq-undefined', rule, {
   invalid: [

--- a/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain-and-neqeq-null.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain-and-neqeq-null.test.ts
@@ -1,16 +1,7 @@
-import { RuleTester } from '@typescript-eslint/rule-tester';
-
 import rule from '../../../src/rules/prefer-optional-chain';
-import { getFixturesRootDir } from '../../RuleTester';
+import { createRuleTesterWithTypes } from '../../RuleTester';
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      projectService: true,
-      tsconfigRootDir: getFixturesRootDir(),
-    },
-  },
-});
+const ruleTester = createRuleTesterWithTypes();
 
 ruleTester.run('prefer-optional-chain-and-neqeq-null', rule, {
   // with the `| null | undefined` type - `!== null` doesn't cover the

--- a/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain-and-neqeq-undefined.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain-and-neqeq-undefined.test.ts
@@ -1,16 +1,7 @@
-import { RuleTester } from '@typescript-eslint/rule-tester';
-
 import rule from '../../../src/rules/prefer-optional-chain';
-import { getFixturesRootDir } from '../../RuleTester';
+import { createRuleTesterWithTypes } from '../../RuleTester';
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      projectService: true,
-      tsconfigRootDir: getFixturesRootDir(),
-    },
-  },
-});
+const ruleTester = createRuleTesterWithTypes();
 
 ruleTester.run('prefer-optional-chain-and-neqeq-undefined', rule, {
   // with the `| null | undefined` type - `!== undefined` doesn't cover the

--- a/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain-ending-comparison.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain-ending-comparison.test.ts
@@ -1,16 +1,9 @@
-import { noFormat, RuleTester } from '@typescript-eslint/rule-tester';
+import { noFormat } from '@typescript-eslint/rule-tester';
 
 import rule from '../../../src/rules/prefer-optional-chain';
-import { getFixturesRootDir } from '../../RuleTester';
+import { createRuleTesterWithTypes } from '../../RuleTester';
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      projectService: true,
-      tsconfigRootDir: getFixturesRootDir(),
-    },
-  },
-});
+const ruleTester = createRuleTesterWithTypes();
 
 ruleTester.run('prefer-optional-chain-ending-comparison', rule, {
   invalid: [

--- a/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain-ignore-spacing.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain-ignore-spacing.test.ts
@@ -1,16 +1,9 @@
-import { noFormat, RuleTester } from '@typescript-eslint/rule-tester';
+import { noFormat } from '@typescript-eslint/rule-tester';
 
 import rule from '../../../src/rules/prefer-optional-chain';
-import { getFixturesRootDir } from '../../RuleTester';
+import { createRuleTesterWithTypes } from '../../RuleTester';
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      projectService: true,
-      tsconfigRootDir: getFixturesRootDir(),
-    },
-  },
-});
+const ruleTester = createRuleTesterWithTypes();
 
 ruleTester.run('prefer-optional-chain-ignore-spacing', rule, {
   valid: [],

--- a/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain-or-boolean.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain-or-boolean.test.ts
@@ -1,16 +1,7 @@
-import { RuleTester } from '@typescript-eslint/rule-tester';
-
 import rule from '../../../src/rules/prefer-optional-chain';
-import { getFixturesRootDir } from '../../RuleTester';
+import { createRuleTesterWithTypes } from '../../RuleTester';
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      projectService: true,
-      tsconfigRootDir: getFixturesRootDir(),
-    },
-  },
-});
+const ruleTester = createRuleTesterWithTypes();
 
 ruleTester.run('prefer-optional-chain-or-boolean', rule, {
   invalid: [

--- a/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain-or-empty-object.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain-or-empty-object.test.ts
@@ -1,16 +1,9 @@
-import { noFormat, RuleTester } from '@typescript-eslint/rule-tester';
+import { noFormat } from '@typescript-eslint/rule-tester';
 
 import rule from '../../../src/rules/prefer-optional-chain';
-import { getFixturesRootDir } from '../../RuleTester';
+import { createRuleTesterWithTypes } from '../../RuleTester';
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      projectService: true,
-      tsconfigRootDir: getFixturesRootDir(),
-    },
-  },
-});
+const ruleTester = createRuleTesterWithTypes();
 
 ruleTester.run('prefer-optional-chain-or-empty-object', rule, {
   invalid: [

--- a/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain-or-eqeq-null.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain-or-eqeq-null.test.ts
@@ -1,16 +1,7 @@
-import { RuleTester } from '@typescript-eslint/rule-tester';
-
 import rule from '../../../src/rules/prefer-optional-chain';
-import { getFixturesRootDir } from '../../RuleTester';
+import { createRuleTesterWithTypes } from '../../RuleTester';
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      projectService: true,
-      tsconfigRootDir: getFixturesRootDir(),
-    },
-  },
-});
+const ruleTester = createRuleTesterWithTypes();
 
 ruleTester.run('prefer-optional-chain-or-eqeq-null', rule, {
   invalid: [

--- a/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain-or-eqeq-undefined.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain-or-eqeq-undefined.test.ts
@@ -1,16 +1,7 @@
-import { RuleTester } from '@typescript-eslint/rule-tester';
-
 import rule from '../../../src/rules/prefer-optional-chain';
-import { getFixturesRootDir } from '../../RuleTester';
+import { createRuleTesterWithTypes } from '../../RuleTester';
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      projectService: true,
-      tsconfigRootDir: getFixturesRootDir(),
-    },
-  },
-});
+const ruleTester = createRuleTesterWithTypes();
 
 ruleTester.run('prefer-optional-chain-or-eqeq-undefined', rule, {
   invalid: [

--- a/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain-or-eqeqeq-null.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain-or-eqeqeq-null.test.ts
@@ -1,16 +1,7 @@
-import { RuleTester } from '@typescript-eslint/rule-tester';
-
 import rule from '../../../src/rules/prefer-optional-chain';
-import { getFixturesRootDir } from '../../RuleTester';
+import { createRuleTesterWithTypes } from '../../RuleTester';
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      projectService: true,
-      tsconfigRootDir: getFixturesRootDir(),
-    },
-  },
-});
+const ruleTester = createRuleTesterWithTypes();
 
 ruleTester.run('prefer-optional-chain-or-eqeqeq-null', rule, {
   // with the `| null | undefined` type - `=== null` doesn't cover the

--- a/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain-or-eqeqeq-undefined.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain-or-eqeqeq-undefined.test.ts
@@ -1,16 +1,7 @@
-import { RuleTester } from '@typescript-eslint/rule-tester';
-
 import rule from '../../../src/rules/prefer-optional-chain';
-import { getFixturesRootDir } from '../../RuleTester';
+import { createRuleTesterWithTypes } from '../../RuleTester';
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      projectService: true,
-      tsconfigRootDir: getFixturesRootDir(),
-    },
-  },
-});
+const ruleTester = createRuleTesterWithTypes();
 
 ruleTester.run('prefer-optional-chain-or-eqeqeq-undefined', rule, {
   // with the `| null | undefined` type - `=== undefined` doesn't cover the

--- a/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain.test.ts
@@ -1,16 +1,9 @@
-import { noFormat, RuleTester } from '@typescript-eslint/rule-tester';
+import { noFormat } from '@typescript-eslint/rule-tester';
 
 import rule from '../../../src/rules/prefer-optional-chain';
-import { getFixturesRootDir } from '../../RuleTester';
+import { createRuleTesterWithTypes } from '../../RuleTester';
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      projectService: true,
-      tsconfigRootDir: getFixturesRootDir(),
-    },
-  },
-});
+const ruleTester = createRuleTesterWithTypes();
 
 ruleTester.run('prefer-optional-chain', rule, {
   invalid: [


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [X] Addresses an existing open issue: fixes #12752 
- [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [X] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

<!-- Description of what is changed and how the code change does that. -->

* What it says in the title