### PR TITLE
fix(eslint-plugin): [prefer-optional-chain] don't end a chain on a strict null comparison

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-optional-chain-utils/analyzeChain.ts
+++ b/packages/eslint-plugin/src/rules/prefer-optional-chain-utils/analyzeChain.ts
@@ -682,6 +682,35 @@ function getReportDescriptor(
   }
 }
 
+/**
+ * A logical chain short-circuits as soon as one of its operands is nullish -
+ * `||` evaluates to `true` and `&&` to `false`. The optional chain that
+ * replaces it has no such escape hatch: it evaluates the final comparison with
+ * `undefined` on the left-hand side instead. So the final operand has to
+ * produce that same short-circuit value, or the chain changes behavior.
+ *
+ * `x === null || x.y === null` is the case this rules out - it short-circuits
+ * to `true` when `x` is nullish, whereas `x?.y === null` compares
+ * `undefined === null` and yields `false`.
+ */
+function isValidChainTerminator(
+  operator: '&&' | '||',
+  comparisonType: NullishComparisonType,
+): boolean {
+  switch (comparisonType) {
+    // `undefined === null` is `false`, but `||` short-circuited to `true`
+    case NullishComparisonType.StrictEqualNull:
+      return operator === '&&';
+
+    // `undefined !== null` is `true`, but `&&` short-circuited to `false`
+    case NullishComparisonType.NotStrictEqualNull:
+      return operator === '||';
+
+    default:
+      return true;
+  }
+}
+
 export function analyzeChain(
   context: RuleContext<
     PreferOptionalChainMessageIds,
@@ -722,6 +751,22 @@ export function analyzeChain(
   const maybeReportThenReset = (
     newChainSeed?: readonly [ValidOperand, ...ValidOperand[]],
   ): void => {
+    // the operand a chain ends on decides the value of the optional chain we
+    // would produce, so trailing operands that wouldn't reproduce the
+    // short-circuit value of the logical expression can't be part of the report
+    if (!lastChain) {
+      while (subChain.length > 0) {
+        const lastOperand = nullThrows(
+          [subChain.at(-1)].flat().at(-1),
+          'a chain operand group always has at least one operand',
+        );
+        if (isValidChainTerminator(operator, lastOperand.comparisonType)) {
+          break;
+        }
+        subChain.pop();
+      }
+    }
+
     if (subChain.length + (lastChain ? 1 : 0) > 1) {
       const subChainFlat = subChain.flat();
       const maybeNullishNodes = lastChain

--- a/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain-or-eqeqeq-null.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain-or-eqeqeq-null.test.ts
@@ -297,109 +297,33 @@ declare const foo: { bar: () => { baz: number } | null | undefined };
 foo.bar === null || foo.bar?.() === null || foo.bar?.().baz;
       `,
     },
-  ],
-  // but if the type is just `| null` - then it covers the cases and is
-  // a valid conversion
-  invalid: [
+    // a chain that *ends* on `=== null` can't be converted either - the chain
+    // short-circuits to `true` when the operand is `null`, whereas the optional
+    // chain compares `undefined === null` and evaluates to `false`
+    // https://github.com/typescript-eslint/typescript-eslint/issues/11840
     {
       code: `
 declare const foo: { bar: number } | null;
 foo === null || foo.bar === null;
       `,
-      errors: [
-        {
-          column: 1,
-          endColumn: 33,
-          endLine: 3,
-          line: 3,
-          messageId: 'preferOptionalChain',
-          suggestions: [
-            {
-              messageId: 'optionalChainSuggest',
-              output: `
-declare const foo: { bar: number } | null;
-foo?.bar === null;
-      `,
-            },
-          ],
-        },
-      ],
-      output: null,
     },
     {
       code: `
 declare const foo: { bar: { baz: number } | null };
 foo.bar === null || foo.bar.baz === null;
       `,
-      errors: [
-        {
-          column: 1,
-          endColumn: 41,
-          endLine: 3,
-          line: 3,
-          messageId: 'preferOptionalChain',
-          suggestions: [
-            {
-              messageId: 'optionalChainSuggest',
-              output: `
-declare const foo: { bar: { baz: number } | null };
-foo.bar?.baz === null;
-      `,
-            },
-          ],
-        },
-      ],
-      output: null,
     },
     {
       code: `
 declare const foo: (() => number) | null;
 foo === null || foo() === null;
       `,
-      errors: [
-        {
-          column: 1,
-          endColumn: 31,
-          endLine: 3,
-          line: 3,
-          messageId: 'preferOptionalChain',
-          suggestions: [
-            {
-              messageId: 'optionalChainSuggest',
-              output: `
-declare const foo: (() => number) | null;
-foo?.() === null;
-      `,
-            },
-          ],
-        },
-      ],
-      output: null,
     },
     {
       code: `
 declare const foo: { bar: (() => number) | null };
 foo.bar === null || foo.bar() === null;
       `,
-      errors: [
-        {
-          column: 1,
-          endColumn: 39,
-          endLine: 3,
-          line: 3,
-          messageId: 'preferOptionalChain',
-          suggestions: [
-            {
-              messageId: 'optionalChainSuggest',
-              output: `
-declare const foo: { bar: (() => number) | null };
-foo.bar?.() === null;
-      `,
-            },
-          ],
-        },
-      ],
-      output: null,
     },
     {
       code: `
@@ -409,25 +333,6 @@ foo === null ||
   foo.bar.baz === null ||
   foo.bar.baz.buzz === null;
       `,
-      errors: [
-        {
-          column: 1,
-          endColumn: 28,
-          endLine: 6,
-          line: 3,
-          messageId: 'preferOptionalChain',
-          suggestions: [
-            {
-              messageId: 'optionalChainSuggest',
-              output: `
-declare const foo: { bar: { baz: { buzz: number } | null } | null } | null;
-foo?.bar?.baz?.buzz === null;
-      `,
-            },
-          ],
-        },
-      ],
-      output: null,
     },
     {
       code: `
@@ -436,77 +341,18 @@ declare const foo: {
 };
 foo.bar === null || foo.bar.baz === null || foo.bar.baz.buzz === null;
       `,
-      errors: [
-        {
-          column: 1,
-          endColumn: 70,
-          endLine: 5,
-          line: 5,
-          messageId: 'preferOptionalChain',
-          suggestions: [
-            {
-              messageId: 'optionalChainSuggest',
-              output: `
-declare const foo: {
-  bar: { baz: { buzz: number } | null } | null;
-};
-foo.bar?.baz?.buzz === null;
-      `,
-            },
-          ],
-        },
-      ],
-      output: null,
     },
     {
       code: `
 declare const foo: { bar: { baz: { buzz: number } } | null } | null;
 foo === null || foo.bar === null || foo.bar.baz.buzz === null;
       `,
-      errors: [
-        {
-          column: 1,
-          endColumn: 62,
-          endLine: 3,
-          line: 3,
-          messageId: 'preferOptionalChain',
-          suggestions: [
-            {
-              messageId: 'optionalChainSuggest',
-              output: `
-declare const foo: { bar: { baz: { buzz: number } } | null } | null;
-foo?.bar?.baz.buzz === null;
-      `,
-            },
-          ],
-        },
-      ],
-      output: null,
     },
     {
       code: `
 declare const foo: { bar: { baz: { buzz: number } } | null };
 foo.bar === null || foo.bar.baz.buzz === null;
       `,
-      errors: [
-        {
-          column: 1,
-          endColumn: 46,
-          endLine: 3,
-          line: 3,
-          messageId: 'preferOptionalChain',
-          suggestions: [
-            {
-              messageId: 'optionalChainSuggest',
-              output: `
-declare const foo: { bar: { baz: { buzz: number } } | null };
-foo.bar?.baz.buzz === null;
-      `,
-            },
-          ],
-        },
-      ],
-      output: null,
     },
     {
       code: `
@@ -517,25 +363,6 @@ foo === null ||
   foo.bar.baz === null ||
   foo.bar.baz.buzz === null;
       `,
-      errors: [
-        {
-          column: 1,
-          endColumn: 28,
-          endLine: 7,
-          line: 3,
-          messageId: 'preferOptionalChain',
-          suggestions: [
-            {
-              messageId: 'optionalChainSuggest',
-              output: `
-declare const foo: { bar: { baz: { buzz: number } | null } | null } | null;
-foo?.bar?.baz?.buzz === null;
-      `,
-            },
-          ],
-        },
-      ],
-      output: null,
     },
     {
       code: `
@@ -545,25 +372,6 @@ foo.bar === null ||
   foo.bar.baz === null ||
   foo.bar.baz.buzz === null;
       `,
-      errors: [
-        {
-          column: 1,
-          endColumn: 28,
-          endLine: 6,
-          line: 3,
-          messageId: 'preferOptionalChain',
-          suggestions: [
-            {
-              messageId: 'optionalChainSuggest',
-              output: `
-declare const foo: { bar: { baz: { buzz: number } | null } | null } | null;
-foo.bar?.baz?.buzz === null;
-      `,
-            },
-          ],
-        },
-      ],
-      output: null,
     },
     {
       code: `
@@ -576,28 +384,6 @@ foo === null ||
   foo[bar].baz === null ||
   foo[bar].baz.buzz === null;
       `,
-      errors: [
-        {
-          column: 1,
-          endColumn: 29,
-          endLine: 9,
-          line: 6,
-          messageId: 'preferOptionalChain',
-          suggestions: [
-            {
-              messageId: 'optionalChainSuggest',
-              output: `
-declare const bar: string;
-declare const foo: {
-  [k: string]: { baz: { buzz: number } | null } | null;
-} | null;
-foo?.[bar]?.baz?.buzz === null;
-      `,
-            },
-          ],
-        },
-      ],
-      output: null,
     },
     {
       code: `
@@ -607,28 +393,6 @@ declare const foo: {
 } | null;
 foo === null || foo[bar].baz === null || foo[bar].baz.buzz === null;
       `,
-      errors: [
-        {
-          column: 1,
-          endColumn: 68,
-          endLine: 6,
-          line: 6,
-          messageId: 'preferOptionalChain',
-          suggestions: [
-            {
-              messageId: 'optionalChainSuggest',
-              output: `
-declare const bar: string;
-declare const foo: {
-  [k: string]: { baz: { buzz: number } | null } | null;
-} | null;
-foo?.[bar].baz?.buzz === null;
-      `,
-            },
-          ],
-        },
-      ],
-      output: null,
     },
     {
       code: `
@@ -636,26 +400,6 @@ declare const bar: { baz: string };
 declare const foo: { [k: string]: { buzz: number } | null } | null;
 foo === null || foo[bar.baz] === null || foo[bar.baz].buzz === null;
       `,
-      errors: [
-        {
-          column: 1,
-          endColumn: 68,
-          endLine: 4,
-          line: 4,
-          messageId: 'preferOptionalChain',
-          suggestions: [
-            {
-              messageId: 'optionalChainSuggest',
-              output: `
-declare const bar: { baz: string };
-declare const foo: { [k: string]: { buzz: number } | null } | null;
-foo?.[bar.baz]?.buzz === null;
-      `,
-            },
-          ],
-        },
-      ],
-      output: null,
     },
     {
       code: `
@@ -667,27 +411,6 @@ foo === null ||
   foo.bar.baz === null ||
   foo.bar.baz.buzz() === null;
       `,
-      errors: [
-        {
-          column: 1,
-          endColumn: 30,
-          endLine: 8,
-          line: 5,
-          messageId: 'preferOptionalChain',
-          suggestions: [
-            {
-              messageId: 'optionalChainSuggest',
-              output: `
-declare const foo: {
-  bar: { baz: { buzz: () => number } | null } | null;
-} | null;
-foo?.bar?.baz?.buzz() === null;
-      `,
-            },
-          ],
-        },
-      ],
-      output: null,
     },
     {
       code: `
@@ -702,29 +425,6 @@ foo === null ||
   foo.bar.baz.buzz === null ||
   foo.bar.baz.buzz() === null;
       `,
-      errors: [
-        {
-          column: 1,
-          endColumn: 30,
-          endLine: 11,
-          line: 7,
-          messageId: 'preferOptionalChain',
-          suggestions: [
-            {
-              messageId: 'optionalChainSuggest',
-              output: `
-declare const foo: {
-  bar: {
-    baz: { buzz: (() => number) | null } | null;
-  } | null;
-} | null;
-foo?.bar?.baz?.buzz?.() === null;
-      `,
-            },
-          ],
-        },
-      ],
-      output: null,
     },
     {
       code: `
@@ -736,77 +436,18 @@ foo.bar === null ||
   foo.bar.baz.buzz === null ||
   foo.bar.baz.buzz() === null;
       `,
-      errors: [
-        {
-          column: 1,
-          endColumn: 30,
-          endLine: 8,
-          line: 5,
-          messageId: 'preferOptionalChain',
-          suggestions: [
-            {
-              messageId: 'optionalChainSuggest',
-              output: `
-declare const foo: {
-  bar: { baz: { buzz: (() => number) | null } | null } | null;
-};
-foo.bar?.baz?.buzz?.() === null;
-      `,
-            },
-          ],
-        },
-      ],
-      output: null,
     },
     {
       code: `
 declare const foo: { bar: { baz: { buzz: () => number } } | null } | null;
 foo === null || foo.bar === null || foo.bar.baz.buzz() === null;
       `,
-      errors: [
-        {
-          column: 1,
-          endColumn: 64,
-          endLine: 3,
-          line: 3,
-          messageId: 'preferOptionalChain',
-          suggestions: [
-            {
-              messageId: 'optionalChainSuggest',
-              output: `
-declare const foo: { bar: { baz: { buzz: () => number } } | null } | null;
-foo?.bar?.baz.buzz() === null;
-      `,
-            },
-          ],
-        },
-      ],
-      output: null,
     },
     {
       code: `
 declare const foo: { bar: { baz: { buzz: () => number } } | null };
 foo.bar === null || foo.bar.baz.buzz() === null;
       `,
-      errors: [
-        {
-          column: 1,
-          endColumn: 48,
-          endLine: 3,
-          line: 3,
-          messageId: 'preferOptionalChain',
-          suggestions: [
-            {
-              messageId: 'optionalChainSuggest',
-              output: `
-declare const foo: { bar: { baz: { buzz: () => number } } | null };
-foo.bar?.baz.buzz() === null;
-      `,
-            },
-          ],
-        },
-      ],
-      output: null,
     },
     {
       code: `
@@ -818,27 +459,6 @@ foo === null ||
   foo.bar.baz.buzz === null ||
   foo.bar.baz.buzz() === null;
       `,
-      errors: [
-        {
-          column: 1,
-          endColumn: 30,
-          endLine: 8,
-          line: 5,
-          messageId: 'preferOptionalChain',
-          suggestions: [
-            {
-              messageId: 'optionalChainSuggest',
-              output: `
-declare const foo: {
-  bar: { baz: { buzz: (() => number) | null } } | null;
-} | null;
-foo?.bar?.baz.buzz?.() === null;
-      `,
-            },
-          ],
-        },
-      ],
-      output: null,
     },
     {
       code: `
@@ -851,27 +471,6 @@ foo.bar === null ||
   foo.bar().baz.buzz === null ||
   foo.bar().baz.buzz() === null;
       `,
-      errors: [
-        {
-          column: 1,
-          endColumn: 32,
-          endLine: 9,
-          line: 5,
-          messageId: 'preferOptionalChain',
-          suggestions: [
-            {
-              messageId: 'optionalChainSuggest',
-              output: `
-declare const foo: {
-  bar: () => { baz: { buzz: (() => number) | null } | null } | null;
-};
-foo.bar?.()?.baz?.buzz?.() === null;
-      `,
-            },
-          ],
-        },
-      ],
-      output: null,
     },
     {
       code: `
@@ -884,28 +483,6 @@ foo === null ||
   foo.bar.baz === null ||
   foo.bar.baz[buzz]() === null;
       `,
-      errors: [
-        {
-          column: 1,
-          endColumn: 31,
-          endLine: 9,
-          line: 6,
-          messageId: 'preferOptionalChain',
-          suggestions: [
-            {
-              messageId: 'optionalChainSuggest',
-              output: `
-declare const buzz: string;
-declare const foo: {
-  bar: { baz: { [k: string]: () => number } | null } | null;
-} | null;
-foo?.bar?.baz?.[buzz]() === null;
-      `,
-            },
-          ],
-        },
-      ],
-      output: null,
     },
     {
       code: `
@@ -921,30 +498,6 @@ foo === null ||
   foo.bar.baz[buzz] === null ||
   foo.bar.baz[buzz]() === null;
       `,
-      errors: [
-        {
-          column: 1,
-          endColumn: 31,
-          endLine: 12,
-          line: 8,
-          messageId: 'preferOptionalChain',
-          suggestions: [
-            {
-              messageId: 'optionalChainSuggest',
-              output: `
-declare const buzz: string;
-declare const foo: {
-  bar: {
-    baz: { [k: string]: (() => number) | null } | null;
-  } | null;
-} | null;
-foo?.bar?.baz?.[buzz]?.() === null;
-      `,
-            },
-          ],
-        },
-      ],
-      output: null,
     },
     {
       code: `
@@ -960,30 +513,6 @@ foo === null ||
   foo?.bar.baz[buzz] === null ||
   foo?.bar.baz[buzz]() === null;
       `,
-      errors: [
-        {
-          column: 1,
-          endColumn: 32,
-          endLine: 12,
-          line: 8,
-          messageId: 'preferOptionalChain',
-          suggestions: [
-            {
-              messageId: 'optionalChainSuggest',
-              output: `
-declare const buzz: string;
-declare const foo: {
-  bar: {
-    baz: { [k: string]: (() => number) | null } | null;
-  } | null;
-} | null;
-foo?.bar?.baz?.[buzz]?.() === null;
-      `,
-            },
-          ],
-        },
-      ],
-      output: null,
     },
     {
       code: `
@@ -991,76 +520,79 @@ declare const buzz: string;
 declare const foo: { bar: { baz: { [k: string]: number } | null } } | null;
 foo === null || foo?.bar.baz === null || foo?.bar.baz[buzz] === null;
       `,
-      errors: [
-        {
-          column: 1,
-          endColumn: 69,
-          endLine: 4,
-          line: 4,
-          messageId: 'preferOptionalChain',
-          suggestions: [
-            {
-              messageId: 'optionalChainSuggest',
-              output: `
-declare const buzz: string;
-declare const foo: { bar: { baz: { [k: string]: number } | null } } | null;
-foo?.bar.baz?.[buzz] === null;
-      `,
-            },
-          ],
-        },
-      ],
-      output: null,
     },
     {
       code: `
 declare const foo: (() => { bar: number } | null) | null;
 foo === null || foo?.() === null || foo?.().bar === null;
       `,
-      errors: [
-        {
-          column: 1,
-          endColumn: 57,
-          endLine: 3,
-          line: 3,
-          messageId: 'preferOptionalChain',
-          suggestions: [
-            {
-              messageId: 'optionalChainSuggest',
-              output: `
-declare const foo: (() => { bar: number } | null) | null;
-foo?.()?.bar === null;
-      `,
-            },
-          ],
-        },
-      ],
-      output: null,
     },
     {
       code: `
 declare const foo: { bar: () => { baz: number } | null };
 foo.bar === null || foo.bar?.() === null || foo.bar?.().baz === null;
       `,
+    },
+  ],
+  // `=== null` operands are still convertible when something else ends the
+  // chain, because then the ending comparison decides the value
+  invalid: [
+    {
+      code: `
+declare const foo: { bar: number | undefined } | null;
+foo === null || foo.bar === undefined;
+      `,
       errors: [
         {
           column: 1,
-          endColumn: 69,
+          endColumn: 38,
           endLine: 3,
           line: 3,
           messageId: 'preferOptionalChain',
-          suggestions: [
-            {
-              messageId: 'optionalChainSuggest',
-              output: `
-declare const foo: { bar: () => { baz: number } | null };
-foo.bar?.()?.baz === null;
-      `,
-            },
-          ],
         },
       ],
-      output: null,
+      output: `
+declare const foo: { bar: number | undefined } | null;
+foo?.bar === undefined;
+      `,
+    },
+    {
+      code: `
+declare const foo: { bar: { baz: number } | null } | null;
+foo === null || foo.bar === null || foo.bar.baz == null;
+      `,
+      errors: [
+        {
+          column: 1,
+          endColumn: 56,
+          endLine: 3,
+          line: 3,
+          messageId: 'preferOptionalChain',
+        },
+      ],
+      output: `
+declare const foo: { bar: { baz: number } | null } | null;
+foo?.bar?.baz == null;
+      `,
+    },
+    {
+      code: `
+declare const foo: { bar: number } | null;
+foo === null || !foo.bar;
+      `,
+      errors: [
+        {
+          column: 1,
+          endColumn: 25,
+          endLine: 3,
+          line: 3,
+          messageId: 'preferOptionalChain',
+        },
+      ],
+      output: `
+declare const foo: { bar: number } | null;
+!foo?.bar;
+      `,
     },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain.test.ts
@@ -919,7 +919,10 @@ null != foo &&
 null != foo?.bar?.baz;
       `,
     },
-    // We should retain the split strict equals check if it's the last operand
+    // the chain can't end on the `!== null` half of a split strict equals
+    // check - `undefined !== null` is `true`, where the chain short-circuited
+    // to `false` - so the chain stops at the operand before it
+    // https://github.com/typescript-eslint/typescript-eslint/issues/11840
     {
       code: `
 null != foo &&
@@ -931,22 +934,19 @@ null != foo &&
       errors: [
         {
           column: 1,
-          endColumn: 23,
-          endLine: 5,
+          endColumn: 33,
+          endLine: 3,
           line: 2,
           messageId: 'preferOptionalChain',
-          suggestions: [
-            {
-              messageId: 'optionalChainSuggest',
-              output: `
-null !== foo?.bar?.baz &&
-  'undefined' !== typeof foo.bar.baz;
-      `,
-            },
-          ],
+          suggestions: null,
         },
       ],
-      output: null,
+      output: `
+'undefined' !== typeof foo?.bar &&
+  null !== foo.bar &&
+  null !== foo.bar.baz &&
+  'undefined' !== typeof foo.bar.baz;
+      `,
     },
     {
       code: `
@@ -959,22 +959,19 @@ foo != null &&
       errors: [
         {
           column: 1,
-          endColumn: 23,
-          endLine: 5,
+          endColumn: 33,
+          endLine: 3,
           line: 2,
           messageId: 'preferOptionalChain',
-          suggestions: [
-            {
-              messageId: 'optionalChainSuggest',
-              output: `
-foo?.bar?.baz !== null &&
-  typeof foo.bar.baz !== 'undefined';
-      `,
-            },
-          ],
+          suggestions: null,
         },
       ],
-      output: null,
+      output: `
+typeof foo?.bar !== 'undefined' &&
+  foo.bar !== null &&
+  foo.bar.baz !== null &&
+  typeof foo.bar.baz !== 'undefined';
+      `,
     },
     {
       code: `
@@ -987,22 +984,19 @@ null != foo &&
       errors: [
         {
           column: 1,
-          endColumn: 23,
-          endLine: 5,
+          endColumn: 33,
+          endLine: 3,
           line: 2,
           messageId: 'preferOptionalChain',
-          suggestions: [
-            {
-              messageId: 'optionalChainSuggest',
-              output: `
-null !== foo?.bar?.baz &&
-  undefined !== foo.bar.baz;
-      `,
-            },
-          ],
+          suggestions: null,
         },
       ],
-      output: null,
+      output: `
+'undefined' !== typeof foo?.bar &&
+  null !== foo.bar &&
+  null !== foo.bar.baz &&
+  undefined !== foo.bar.baz;
+      `,
     },
     {
       code: `
@@ -1015,22 +1009,19 @@ foo != null &&
       errors: [
         {
           column: 1,
-          endColumn: 23,
-          endLine: 5,
+          endColumn: 33,
+          endLine: 3,
           line: 2,
           messageId: 'preferOptionalChain',
-          suggestions: [
-            {
-              messageId: 'optionalChainSuggest',
-              output: `
-foo?.bar?.baz !== null &&
-  foo.bar.baz !== undefined;
-      `,
-            },
-          ],
+          suggestions: null,
         },
       ],
-      output: null,
+      output: `
+typeof foo?.bar !== 'undefined' &&
+  foo.bar !== null &&
+  foo.bar.baz !== null &&
+  foo.bar.baz !== undefined;
+      `,
     },
     {
       code: `
@@ -2050,6 +2041,19 @@ declare const x: 0n | { a: string };
     `
 declare const x: void | (() => void);
 x && x();
+    `,
+    // a chain that ends on a strict null comparison isn't convertible - it
+    // short-circuits to `true`, where `foo?.bar === null` compares
+    // `undefined === null` and evaluates to `false`
+    // https://github.com/typescript-eslint/typescript-eslint/issues/11840
+    `
+declare const foo: { bar: number | null } | undefined;
+foo === undefined || foo.bar === null;
+    `,
+    `
+declare const foo: { bar: number | null } | undefined;
+declare const unrelated: boolean;
+foo !== undefined && foo.bar !== null && unrelated;
     `,
   ],
 });


### PR DESCRIPTION
Fixes #~11840~.

A logical chain short-circuits once an operand is nullish; the optional chain
that replaces it does not, and instead compares `undefined` against the
right-hand side of the final comparison. So the two disagree whenever the chain
ends on `=== null` (`||`) or `!== null` (`&&`):

```ts
declare const foo: { bar: number | null } | undefined;
foo === undefined || foo.bar === null; // true when foo is undefined
foo?.bar === null;                     // undefined === null -> false
```

The change stops such an operand from terminating a chain. Leading operands that
still convert safely are reported as before; if nothing is left, no report is
made.

This narrows the rule for the `|| ... === null` family, so a large block of
cases in `prefer-optional-chain-or-eqeqeq-null.test.ts` moves from `invalid` to
`valid`. Happy to discuss whether that boundary is where you want it.

Full `prefer-optional-chain` suite passes: 1109 tests across 14 files.