### PR TITLE
test(eslint-plugin): [no-unnecessary-condition] add tests for optional chains on nested void values

### DIFF
--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -1130,6 +1130,20 @@ type fn = () => void;
 declare function foo(): void | fn;
 const bar = foo()?.();
     `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/9754
+    `
+declare function maybe<T>(v: T): T | void;
+const a = maybe({ key1: { key2: maybe({ i: 1 }) } })?.key1.key2?.i;
+    `,
+    `
+type Foo = { bar: { baz: number } | void } | null;
+declare const foo: Foo;
+foo?.bar?.baz;
+    `,
+    `
+declare function maybeFn(): { fn: (() => number) | void } | undefined;
+maybeFn()?.fn?.();
+    `,
     {
       code: `
 class ConsistentRand {

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -1130,7 +1130,6 @@ type fn = () => void;
 declare function foo(): void | fn;
 const bar = foo()?.();
     `,
-    // https://github.com/typescript-eslint/typescript-eslint/issues/9754
     `
 declare function maybe<T>(v: T): T | void;
 const a = maybe({ key1: { key2: maybe({ i: 1 }) } })?.key1.key2?.i;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9754
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

While preparing a fix for #9754, I found that its false positives no longer reproduce on `main`. They were fixed incidentally by #9937 (for #8974), which added `ts.TypeFlags.Void` to the shared `isNullableType` in `type-utils` — the same predicate `no-unnecessary-condition` uses for its own-nullability checks on optional chains.

I verified each reproduction from the issue thread against `main` by running the built rule with type information (each snippet type-checked in isolation):

| Reproduction | Result on `main` |
|---|---|
| `maybe({ key1: { key2: maybe({ i: 1 }) } })?.key1.key2?.i` (original report) | no error ✅ |
| `maybeGenerator()?.g().next().value?.i` ([comment](https://github.com/typescript-eslint/typescript-eslint/issues/9754#issuecomment-2275077798)) | no error ✅ |
| nested `void` property off a nullish root ([minimal playground](https://github.com/typescript-eslint/typescript-eslint/issues/9754#issuecomment-2275144881)) | no error ✅ |
| control: same shapes without `void` | still reported ✅ |

However, #9937 only added regression tests for *single-step* chains (`foo()?.key`, `foo()?.()`). The distinguishing shapes from #9754 — multi-step chains where a **nested** property may be `void`, hanging off a **nullish root** — are untested, so the behavior could silently regress.

This PR adds three valid-case regression tests covering those shapes, so #9754 can be closed with its scenarios pinned down.

Note on the remaining discussion in the thread: the broader "treat `void` like `any` everywhere" idea would also change conditional-context behavior (e.g. the existing invalid test `declare const b1: void; b1 && b2` → `alwaysFalsy`). Since the practical problem — the fixer producing code that fails to compile — is resolved by the current `isNullableType` behavior, this PR intentionally leaves that design decision alone.
