### PR TITLE
chore: [release] filter out AI agents from changelog

### DIFF
--- a/tools/release/changelog-renderer.js
+++ b/tools/release/changelog-renderer.js
@@ -5,9 +5,14 @@ const {
   default: DefaultChangelogRenderer,
 } = require('nx/release/changelog-renderer');
 
-const EXCLUDED_AUTHORS = ['Claude', 'Cursor', 'Amp'].map(
-  name => new RegExp(`^${name}\\b`),
-);
+const EXCLUDED_AUTHORS = [
+  'Amp',
+  'chatgpt',
+  'Claude',
+  'Codex',
+  'Copilot',
+  'Cursor',
+].map(name => new RegExp(`^${name}\\b`));
 
 module.exports = class CustomChangelogRenderer extends (
   DefaultChangelogRenderer

--- a/tools/release/changelog-renderer.js
+++ b/tools/release/changelog-renderer.js
@@ -5,6 +5,10 @@ const {
   default: DefaultChangelogRenderer,
 } = require('nx/release/changelog-renderer');
 
+const EXCLUDED_AUTHORS = ['Claude', 'Cursor', 'Amp'].map(
+  name => new RegExp(`^${name}\\b`),
+);
+
 module.exports = class CustomChangelogRenderer extends (
   DefaultChangelogRenderer
 ) {
@@ -20,5 +24,18 @@ module.exports = class CustomChangelogRenderer extends (
       `${githubLink}\n\n` +
       `You can read about our [versioning strategy](https://typescript-eslint.io/users/versioning) and [releases](https://typescript-eslint.io/users/releases) on our website.`
     );
+  }
+
+  async renderAuthors() {
+    const defaultAuthors = await super.renderAuthors();
+
+    const filteredAuthors = defaultAuthors.filter(author => {
+      // Authors are returned with a leading dash (i.e. `- User Name @handle`).
+      const normalizedAuthor = author.replace(/^-/, '').trim();
+
+      return !EXCLUDED_AUTHORS.some(pattern => pattern.test(normalizedAuthor));
+    });
+
+    return filteredAuthors;
   }
 };


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [X] Addresses an existing open issue: fixes #12759
- [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [X] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

Authors array before filtering: 
```TS
[
  '',
  '### ❤️ Thank You',
  '',
  '- Claude Opus 5',
  '- Claude Opus 5 (1M context)',
  '- Cursor @cursoragent',
  '- Evyatar Daud @StyleShit',
  '- Hugo @hugop95',
  '- Josh Goldberg ✨',
  '- Thiago Barbosa',
  '- Younsang Na @nayounsang'
]
```

After filtering:
```TS
[
  '',
  '### ❤️ Thank You',
  '',
  '- Evyatar Daud @StyleShit',
  '- Hugo @hugop95',
  '- Josh Goldberg ✨',
  '- Thiago Barbosa',
  '- Younsang Na @nayounsang'
]
```

The regex filtering is not ideal, but I can't really think of a better solution. We don't get metadata for the authors, just an array of raw strings.

It'll filter out someone called "Claude {last name}" 😅 