### PR TITLE
docs: add blog post about test coverage

### DIFF
--- a/packages/website/blog/2026-08-25-tips-for-increasing-lint-rule-test-coverage.md
+++ b/packages/website/blog/2026-08-25-tips-for-increasing-lint-rule-test-coverage.md
@@ -7,12 +7,11 @@ title: Tips For Increasing Lint Rule Test Coverage
 ---
 
 Someone probably linked you here from a pull request review that flagged uncovered lines in a lint rule.
-Sorry about that.
 It's one of the most common changes we request, and rather than retype the same explanation every time, we wrote it down.
 
-[We aim for 100% code coverage](/contributing/pull-requests#code-coverage), but chasing a number isn't the point.
-In a lint rule, an uncovered line is rarely just a missing test.
-It's usually a branch you wrote for an AST shape you never actually fed to the rule, which means nobody has checked whether that branch does the right thing.
+[We aim for 100% code coverage when possible](/contributing/pull-requests#code-coverage) because lint rules are extremely tricky, nuanced pieces of code.
+When a lint rule's source has an uncovered line, it's more than it "just" missing test coverage.
+It can also mean that rule logic written for an AST shape is not exercised, which means nothing has checked whether that branch does the right thing.
 Often it doesn't.
 
 Every coverage gap we've reviewed has come down to one of three answers:
@@ -23,10 +22,15 @@ Every coverage gap we've reviewed has come down to one of three answers:
 
 <!--truncate-->
 
+:::tip
+New to writing lint rules?
+See our [Custom Rules documentation](/developers/custom-rules) to get started.
+:::
+
 ## A Rule To Work With
 
 Say we're writing `no-underscore-members`, a rule that reports class methods whose name starts with an underscore.
-A first draft:
+Here's a first draft of just the rule visitors:
 
 ```ts
 MethodDefinition(node) {
@@ -55,13 +59,38 @@ ruleTester.run('no-underscore-members', rule, {
 ```
 
 Both outcomes of `startsWith('_')` are covered.
-The `return` above them never runs once, and that's what the coverage report will point at.
+The `return` above them never runs once, and that's what the coverage report will point at:
+
+<!-- prettier-ignore -->
+```ts
+MethodDefinition(node) {
+  // Partially covered line
+  if (node.key.type !== AST_NODE_TYPES.Identifier) {
+    // Uncovered line
+    return;
+  }
+
+  // Covered line
+  if (node.key.name.startsWith('_')) {
+    // Covered line
+    context.report({ messageId: 'noUnderscore', node: node.key });
+  }
+},
+```
+
+:::info Legend
+**Green** - Line is _fully_ covered by tests
+
+**Yellow** - Line is _partially_ covered by tests (usually in conditional branches where only some outcomes are exercised)
+
+**Red** - Line is _not_ covered by tests
+:::
 
 ## The Code Is Reachable, So A Unit Test Should Exercise It
 
 The first question worth asking about an uncovered branch is whether a user can get there.
 
-For `node.key.type !== AST_NODE_TYPES.Identifier`, they can, without trying hard:
+For `node.key.type !== AST_NODE_TYPES.Identifier`, they can, each of the following pieces of code would hit the uncovered branch:
 
 <!-- prettier-ignore -->
 ```ts
@@ -74,11 +103,11 @@ class Example {
 }
 ```
 
-That early `return` isn't defensive coding.
-It's the rule quietly ignoring `'_update'()`, `['_update']()`, and `#_update()`, which are the same method with different punctuation around the name.
+The rule's early `return` causes its logic to ignore any AST node that's not an identifier.
+`'_update'()`, `['_update']()`, and `#_update()` are all non-identifier forms that declare the same method.
 The coverage report found a bug.
 
-When the type checker complains that `.name` doesn't exist on `node.key`, it's tempting to make the complaint go away:
+When the type checker reports that `.name` doesn't exist on `node.key`, it's tempting to make the complaint go away:
 
 ```ts
 // Please don't.
@@ -89,7 +118,7 @@ That fixes the coverage number, but leads us into a worse bug.
 `.name` is `undefined` for a string literal key, causing `name.startsWith` to throw - e.g., the rule now _crashes_ on code it used to quietly ignore!
 
 Handle the shapes instead.
-Switching on `node.key.type` gives you the right field for each one, and `node.computed` says whether that name belongs to the method or to a variable somewhere else:
+Switching on `node.key.type` gives the right field for each one, and `node.computed` says whether that name belongs to the method or to a variable somewhere else:
 
 ```ts
 function getStaticName(node: TSESTree.MethodDefinition): string | null {
@@ -109,6 +138,10 @@ function getStaticName(node: TSESTree.MethodDefinition): string | null {
   }
 }
 ```
+
+:::tip
+In real world scenarios, helpers like `getStaticStringValue` and `ASTUtils.getStaticValue` are often used to handle these cases.
+:::
 
 Every one of those branches needs a test, and every one of those tests describes real code someone will eventually write:
 
@@ -159,7 +192,7 @@ Without the coverage report, it would have stayed an accident.
 :::tip
 Not sure which shapes a node can take?
 Paste code into [our playground](/play) and read the AST tab.
-It's faster than following type definitions around, and it shows exactly what the parser produces.
+That tab shows what each of the the ESLint, TypeScript, and typescript-eslint parsers produce.
 :::
 
 ## The Code Can Be Refactored To Not Include That Case
@@ -184,19 +217,21 @@ MethodDefinition(node) {
 
 ```ts
 function getReplacementName(node: TSESTree.MethodDefinition) {
+  // Covered line
   const name = getStaticName(node);
 
+  // Partially covered line
   if (name == null) {
-    //  ~~~~~~~~~~~
-    // Uncovered: the visitor only reports when getStaticName returned a name
+    // Uncovered line
     return 'a name without the underscore';
   }
 
+  // Covered line
   return name.slice(1);
 }
 ```
 
-No test can reach that `if`.
+No test can reach the `null` branch of this `if`.
 `getReplacementName` runs only after the visitor has already confirmed there's a name.
 Writing one would mean calling the helper directly, which tests a situation the rule can't produce.
 
@@ -207,8 +242,8 @@ The `!` operator would make the coverage report happy:
 const name = getStaticName(node)!;
 ```
 
-It's true today and unenforced tomorrow.
-The next person to call `getReplacementName` from somewhere else gets `undefined.slice`, with nothing in the code explaining what they broke.
+This might be safe for now, but as the rule changes over time it's risky in code.
+The next change that adds a call to `getReplacementName` from somewhere else might get a nullish `name` and cause a crash.
 
 The actual problem is that `getStaticName` runs twice.
 Each call forces the surrounding code to answer "and what if there's no static name?", so asking twice means answering twice.
@@ -220,7 +255,10 @@ MethodDefinition(node) {
 
   if (name?.startsWith('_')) {
     context.report({
-      data: { replacement: name.slice(1) },
+      // Remove this line
+      data: { replacement: getReplacementName(node) },
+      // Add this line
+      data: { replacement: getReplacementName(name) },
       messageId: 'noUnderscore',
       node: node.key,
     });
@@ -228,13 +266,33 @@ MethodDefinition(node) {
 },
 ```
 
-The helper is gone, the branch is gone, and the rule got shorter.
-Duplicated work is behind most genuinely unreachable branches we see in rules, and deduplicating it usually improves the code on its own merits.
+```ts
+// Remove this line
+function getReplacementName(node: TSESTree.MethodDefinition) {
+// Add this line
+function getReplacementName(name: string) {
+  /* Removed lines start */
+  const name = getStaticName(node);
+
+  if (name == null) {
+    return 'a name without the underscore';
+  }
+
+  /* Removed lines end */
+  return name.slice(1);
+}
+```
+
+The branch is gone, the helper has been simplified, and the rule got shorter.
+Duplicated work is behind most genuinely unreachable branches we see in rules, and deduplicating it usually improves the code.
 
 ## This Is A Difficult-To-Represent Edge Case In Types
 
-This is the rare one.
+This one is the least common.
 Most gaps are one of the first two, so reach for this only after ruling those out.
+
+An edge case in types is when a specific case can't be represented in types,
+or when there are gaps in the [control flow analysis](https://github.com/microsoft/TypeScript/issues/9998).
 
 Token lookups are the case that comes up most.
 `getFirstToken` returns `TSESTree.Token | null` for every node, including nodes that cannot exist without a first token.
@@ -268,7 +326,7 @@ const letToken = nullThrows(
 );
 ```
 
-Both are single expressions, so neither adds a branch to your rule or anything for the coverage report to complain about.
+Both are single expressions, so neither adds a branch to the rule or anything for the coverage report to warn about.
 
 ### Optional Chaining vs Non-Null Assertion
 
@@ -291,14 +349,14 @@ const grandparent = node.parent.parent!;
 `!` states the type _is wrong_; `?.` _pretends it is right_.
 
 :::danger
-An assertion is the answer only when you've confirmed the shape you're ruling out is impossible.
+An assertion is the answer only when it's confirmed the shape being ruled out is impossible.
 Check in [the playground](/play) before deciding.
 A rule that asserts its way past a shape users can write is worse than one that never handled the shape at all, because now it crashes instead of staying quiet.
 :::
 
-## Finding The Gaps Yourself
+## Finding The Gaps Before Review
 
-You don't have to wait for review to see any of this.
+There is no need to wait for the review to see any of this.
 To generate a report for one package:
 
 ```shell
@@ -306,15 +364,15 @@ npx nx test eslint-plugin --coverage
 ```
 
 That writes `packages/eslint-plugin/coverage/lcov-report/index.html`.
-Open it in a browser, find your rule, and uncovered branches are highlighted in the source.
-Pass a test file path to narrow the run down to the rule you're working on:
+Open it in a browser, find the rule, and uncovered branches are highlighted in the source.
+Pass a test file path to narrow the run down to the specific rule:
 
 ```shell
 npx nx test eslint-plugin --coverage tests/rules/no-underscore-members.test.ts
 ```
 
 `pnpm test-coverage` from the repo root does the same for every package, though it takes considerably longer.
-On the pull request itself, the `codecov` bot comments with links to line-by-line coverage for each file you touched.
+On the pull request itself, the `codecov` bot comments with links to line-by-line coverage for each touched file.
 
 ## Ask Us For Help
 

--- a/packages/website/blog/2026-08-25-tips-for-increasing-lint-rule-test-coverage.md
+++ b/packages/website/blog/2026-08-25-tips-for-increasing-lint-rule-test-coverage.md
@@ -296,35 +296,66 @@ Most gaps are one of the first two, so reach for this only after ruling those ou
 Token lookups, are a case that often comes up.
 `getFirstToken`, for example, returns `TSESTree.Token | null` for every node, including nodes that cannot exist without the token being looked for.
 
-Token lookups are the case that comes up most.
-`getFirstToken` returns `TSESTree.Token | null` for every node, including nodes that cannot exist without a first token.
-
-Take a different rule, one that rewrites a `let` that's never reassigned into a `const`:
+Assume we're adding a suggestion to `no-underscore-members` for methods that declare an accessibility, so `protected _update()` will become `private update()`:
 
 ```ts
-fix(fixer) {
-  const letToken = context.sourceCode.getFirstToken(declaration);
-  //    ~~~~~~~~ TSESTree.Token | null
+MethodDefinition(node) {
+  const name = getStaticName(node);
 
-  return fixer.replaceText(letToken, 'const');
-  //                       ~~~~~~~~
-  // Argument of type 'Token | null' is not assignable to parameter of type 'Token'.
+  if (name?.startsWith('_')) {
+    /* Added lines start */
+    const suggest = node.accessibility
+      ? [
+          {
+            messageId: 'usePrivate' as const,
+            fix(fixer: TSESLint.RuleFixer) {
+              const accessibilityToken = context.sourceCode.getFirstToken(node, {
+                filter: token => token.value === node.accessibility,
+              });
+
+              return [
+                fixer.replaceText(accessibilityToken, 'private'),
+                //                ~~~~~~~~~~~~~~~~~~
+                // Argument of type 'Token | null' is not assignable to parameter of type 'Token'.
+                fixer.replaceText(node.key, getReplacementName(name)),
+              ];
+            },
+          },
+        ]
+      : undefined;
+
+    /* Added lines end */
+    context.report({
+      data: { replacement: getReplacementName(name) },
+      messageId: 'noUnderscore',
+      node: node.key,
+      // Add this line
+      suggest,
+    });
+  }
 },
 ```
 
-A `VariableDeclaration` always starts with `var`, `let`, or `const`.
-There is no source text that parses into one without that token, so an `if (letToken == null)` guard would sit there uncovered forever, and no test could rescue it.
+:::caution Note
+This is a naive fixer for demonstration purposes, which doesn't account for all edge cases.
+:::
+
+The ternary condition guarantees that `accessibilityToken` will be non-null whenever it is used inside the fixer. There is no source text that leads to this suggestion without that token, so an `if (accessibilityToken == null)` guard would sit there uncovered forever, and no test could exercise it.
 
 Either a `!` or [`nullThrows`](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/utils/src/eslint-utils/nullThrows.ts) will do:
 
 ```ts
-const letToken = context.sourceCode.getFirstToken(declaration)!;
+const accessibilityToken = context.sourceCode.getFirstToken(node, {
+  filter: token => token.value === accessibility,
+})!;
 ```
 
 ```ts
-const letToken = nullThrows(
-  context.sourceCode.getFirstToken(declaration),
-  NullThrowsReasons.MissingToken('let', 'variable declaration'),
+const accessibilityToken = nullThrows(
+  context.sourceCode.getFirstToken(node, {
+    filter: token => token.value === accessibility,
+  }),
+  NullThrowsReasons.MissingToken(`${accessibility} keyword`, node.type),
 );
 ```
 

--- a/packages/website/blog/2026-08-25-tips-for-increasing-lint-rule-test-coverage.md
+++ b/packages/website/blog/2026-08-25-tips-for-increasing-lint-rule-test-coverage.md
@@ -288,11 +288,13 @@ Duplicated work is behind most genuinely unreachable branches we see in rules, a
 
 ## This Is A Difficult-To-Represent Edge Case In Types
 
+An edge case in types is when a specific case can't be represented in types,
+or when it's guaranteed that a specific case will never occur at runtime.
 This one is the least common.
 Most gaps are one of the first two, so reach for this only after ruling those out.
 
-An edge case in types is when a specific case can't be represented in types,
-or when it's guaranteed that a specific case will never occur at runtime.
+Token lookups, are a case that often comes up.
+`getFirstToken`, for example, returns `TSESTree.Token | null` for every node, including nodes that cannot exist without the token being looked for.
 
 Token lookups are the case that comes up most.
 `getFirstToken` returns `TSESTree.Token | null` for every node, including nodes that cannot exist without a first token.
@@ -338,7 +340,7 @@ For example, the type of `node.parent.parent` is `Node | undefined` only because
 const grandparent = node.parent?.parent;
 ```
 
-The `undefined` now spreads to every line that touches `grandparent`, causing us to write defensive code that clutters our coverage report.
+The `undefined` now spreads to every line that touches `grandparent`, causing us to write defensive code that clutters the coverage report.
 In such cases, reach for `!` rather than `?.`:
 
 ```ts
@@ -346,7 +348,7 @@ In such cases, reach for `!` rather than `?.`:
 const grandparent = node.parent.parent!;
 ```
 
-`!` states the type _is wrong_; `?.` _pretends it is right_.
+_`!` states the type is wrong; `?.` pretends it is right._
 
 :::danger
 An assertion is the answer only when it's confirmed the shape being ruled out is impossible.

--- a/packages/website/blog/2026-08-25-tips-for-increasing-lint-rule-test-coverage.md
+++ b/packages/website/blog/2026-08-25-tips-for-increasing-lint-rule-test-coverage.md
@@ -1,0 +1,326 @@
+---
+authors: [StyleShit, joshuakgoldberg]
+description: An uncovered line in a lint rule is usually a bug report in disguise. Here are the three things to do about it.
+slug: tips-for-increasing-lint-rule-test-coverage
+tags: [code coverage, contributing, rule tester, testing]
+title: Tips For Increasing Lint Rule Test Coverage
+---
+
+Someone probably linked you here from a pull request review that flagged uncovered lines in a lint rule.
+Sorry about that.
+It's one of the most common changes we request, and rather than retype the same explanation every time, we wrote it down.
+
+[We aim for 100% code coverage](/contributing/pull-requests#code-coverage), but chasing a number isn't the point.
+In a lint rule, an uncovered line is rarely just a missing test.
+It's usually a branch you wrote for an AST shape you never actually fed to the rule, which means nobody has checked whether that branch does the right thing.
+Often it doesn't.
+
+Every coverage gap we've reviewed has come down to one of three answers:
+
+- [The code is reachable, so a unit test should exercise it](#the-code-is-reachable-so-a-unit-test-should-exercise-it)
+- [The code can be refactored to not include that case](#the-code-can-be-refactored-to-not-include-that-case)
+- [This is a difficult-to-represent edge case in types](#this-is-a-difficult-to-represent-edge-case-in-types)
+
+<!--truncate-->
+
+## A Rule To Work With
+
+Say we're writing `no-underscore-members`, a rule that reports class methods whose name starts with an underscore.
+A first draft:
+
+```ts
+MethodDefinition(node) {
+  if (node.key.type !== AST_NODE_TYPES.Identifier) {
+    return;
+  }
+
+  if (node.key.name.startsWith('_')) {
+    context.report({ messageId: 'noUnderscore', node: node.key });
+  }
+},
+```
+
+And a first set of tests:
+
+```ts
+ruleTester.run('no-underscore-members', rule, {
+  invalid: [
+    {
+      code: 'class Example { _update() {} }',
+      errors: [{ messageId: 'noUnderscore' }],
+    },
+  ],
+  valid: ['class Example { update() {} }'],
+});
+```
+
+Both outcomes of `startsWith('_')` are covered.
+The `return` above them never runs once, and that's what the coverage report will point at.
+
+## The Code Is Reachable, So A Unit Test Should Exercise It
+
+The first question worth asking about an uncovered branch is whether a user can get there.
+
+For `node.key.type !== AST_NODE_TYPES.Identifier`, they can, without trying hard:
+
+<!-- prettier-ignore -->
+```ts
+class Example {
+  '_update'() {}   // Literal
+  1() {}           // Literal
+  #_update() {}    // PrivateIdentifier
+  ['_update']() {} // Literal, computed
+  [update]() {}    // Identifier, computed
+}
+```
+
+That early `return` isn't defensive coding.
+It's the rule quietly ignoring `'_update'()`, `['_update']()`, and `#_update()`, which are the same method with different punctuation around the name.
+The coverage report found a bug.
+
+When the type checker complains that `.name` doesn't exist on `node.key`, it's tempting to make the complaint go away:
+
+```ts
+// Please don't.
+const name = (node.key as TSESTree.Identifier).name;
+```
+
+That fixes the coverage number, but leads us into a worse bug.
+`.name` is `undefined` for a string literal key, causing `name.startsWith` to throw - e.g., the rule now _crashes_ on code it used to quietly ignore!
+
+Handle the shapes instead.
+Switching on `node.key.type` gives you the right field for each one, and `node.computed` says whether that name belongs to the method or to a variable somewhere else:
+
+```ts
+function getStaticName(node: TSESTree.MethodDefinition): string | null {
+  switch (node.key.type) {
+    case AST_NODE_TYPES.Identifier:
+      // A computed `[_update]() {}` names a variable, not the method.
+      return node.computed ? null : node.key.name;
+
+    case AST_NODE_TYPES.Literal:
+      return typeof node.key.value === 'string' ? node.key.value : null;
+
+    case AST_NODE_TYPES.PrivateIdentifier:
+      return node.key.name;
+
+    default:
+      return null;
+  }
+}
+```
+
+Every one of those branches needs a test, and every one of those tests describes real code someone will eventually write:
+
+```ts
+ruleTester.run('no-underscore-members', rule, {
+  invalid: [
+    {
+      code: 'class Example { _update() {} }',
+      errors: [{ messageId: 'noUnderscore' }],
+    },
+    {
+      code: "class Example { '_update'() {} }",
+      errors: [{ messageId: 'noUnderscore' }],
+    },
+    {
+      code: 'class Example { #_update() {} }',
+      errors: [{ messageId: 'noUnderscore' }],
+    },
+    {
+      code: "class Example { ['_update']() {} }",
+      errors: [{ messageId: 'noUnderscore' }],
+    },
+  ],
+  valid: [
+    'class Example { update() {} }',
+    'class Example { 1() {} }',
+    `
+      declare const update: string;
+      class Example {
+        [update]() {}
+      }
+    `,
+    `
+      declare function getName(): string;
+      class Example {
+        [getName()]() {}
+      }
+    `,
+  ],
+});
+```
+
+Those last two `valid` cases are worth examining more closely.
+A computed key built from a variable or a function call has no name the rule can read, so the rule skips it.
+That's a deliberate decision about rule behavior, and now there's a test holding us to it.
+Without the coverage report, it would have stayed an accident.
+
+:::tip
+Not sure which shapes a node can take?
+Paste code into [our playground](/play) and read the AST tab.
+It's faster than following type definitions around, and it shows exactly what the parser produces.
+:::
+
+## The Code Can Be Refactored To Not Include That Case
+
+Sometimes the branch really is unreachable, and the fix is to delete it rather than test it.
+
+Suppose the rule's message names the replacement, so `_update` reports as `Rename this to 'update'`:
+
+```ts
+MethodDefinition(node) {
+  const name = getStaticName(node);
+
+  if (name?.startsWith('_')) {
+    context.report({
+      data: { replacement: getReplacementName(node) },
+      messageId: 'noUnderscore',
+      node: node.key,
+    });
+  }
+},
+```
+
+```ts
+function getReplacementName(node: TSESTree.MethodDefinition) {
+  const name = getStaticName(node);
+
+  if (name == null) {
+    //  ~~~~~~~~~~~
+    // Uncovered: the visitor only reports when getStaticName returned a name
+    return 'a name without the underscore';
+  }
+
+  return name.slice(1);
+}
+```
+
+No test can reach that `if`.
+`getReplacementName` runs only after the visitor has already confirmed there's a name.
+Writing one would mean calling the helper directly, which tests a situation the rule can't produce.
+
+The `!` operator would make the coverage report happy:
+
+```ts
+// Also please don't.
+const name = getStaticName(node)!;
+```
+
+It's true today and unenforced tomorrow.
+The next person to call `getReplacementName` from somewhere else gets `undefined.slice`, with nothing in the code explaining what they broke.
+
+The actual problem is that `getStaticName` runs twice.
+Each call forces the surrounding code to answer "and what if there's no static name?", so asking twice means answering twice.
+Answer it once, then pass the answer along:
+
+```ts
+MethodDefinition(node) {
+  const name = getStaticName(node);
+
+  if (name?.startsWith('_')) {
+    context.report({
+      data: { replacement: name.slice(1) },
+      messageId: 'noUnderscore',
+      node: node.key,
+    });
+  }
+},
+```
+
+The helper is gone, the branch is gone, and the rule got shorter.
+Duplicated work is behind most genuinely unreachable branches we see in rules, and deduplicating it usually improves the code on its own merits.
+
+## This Is A Difficult-To-Represent Edge Case In Types
+
+This is the rare one.
+Most gaps are one of the first two, so reach for this only after ruling those out.
+
+Token lookups are the case that comes up most.
+`getFirstToken` returns `TSESTree.Token | null` for every node, including nodes that cannot exist without a first token.
+
+Take a different rule, one that rewrites a `let` that's never reassigned into a `const`:
+
+```ts
+fix(fixer) {
+  const letToken = context.sourceCode.getFirstToken(declaration);
+  //    ~~~~~~~~ TSESTree.Token | null
+
+  return fixer.replaceText(letToken, 'const');
+  //                       ~~~~~~~~
+  // Argument of type 'Token | null' is not assignable to parameter of type 'Token'.
+},
+```
+
+A `VariableDeclaration` always starts with `var`, `let`, or `const`.
+There is no source text that parses into one without that token, so an `if (letToken == null)` guard would sit there uncovered forever, and no test could rescue it.
+
+Either a `!` or [`nullThrows`](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/utils/src/eslint-utils/nullThrows.ts) will do:
+
+```ts
+const letToken = context.sourceCode.getFirstToken(declaration)!;
+```
+
+```ts
+const letToken = nullThrows(
+  context.sourceCode.getFirstToken(declaration),
+  NullThrowsReasons.MissingToken('let', 'variable declaration'),
+);
+```
+
+Both are single expressions, so neither adds a branch to your rule or anything for the coverage report to complain about.
+
+### Optional Chaining vs Non-Null Assertion
+
+If we're already talking about type assertions, it's worth noting that the same gap in coverage sometimes arrives as an optional chain instead of an `if`.
+
+For example, the type of `node.parent.parent` is `Node | undefined` only because the first `.parent` might be a `Program`, so a rule that never reaches a `Program` still gets written defensively:
+
+```ts
+const grandparent = node.parent?.parent;
+```
+
+The `undefined` now spreads to every line that touches `grandparent`, causing us to write defensive code that clutters our coverage report.
+In such cases, reach for `!` rather than `?.`:
+
+```ts
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+const grandparent = node.parent.parent!;
+```
+
+`!` states the type _is wrong_; `?.` _pretends it is right_.
+
+:::danger
+An assertion is the answer only when you've confirmed the shape you're ruling out is impossible.
+Check in [the playground](/play) before deciding.
+A rule that asserts its way past a shape users can write is worse than one that never handled the shape at all, because now it crashes instead of staying quiet.
+:::
+
+## Finding The Gaps Yourself
+
+You don't have to wait for review to see any of this.
+To generate a report for one package:
+
+```shell
+npx nx test eslint-plugin --coverage
+```
+
+That writes `packages/eslint-plugin/coverage/lcov-report/index.html`.
+Open it in a browser, find your rule, and uncovered branches are highlighted in the source.
+Pass a test file path to narrow the run down to the rule you're working on:
+
+```shell
+npx nx test eslint-plugin --coverage tests/rules/no-underscore-members.test.ts
+```
+
+`pnpm test-coverage` from the repo root does the same for every package, though it takes considerably longer.
+On the pull request itself, the `codecov` bot comments with links to line-by-line coverage for each file you touched.
+
+## Ask Us For Help
+
+Working out how to reach a branch can be genuinely hard, especially in rules that use type information.
+If you're stuck, say so on the pull request.
+Tell us what you tried and what the rule did instead, and we'll dig in with you.
+
+Nobody has ever annoyed us by asking.
+Thanks for sending the pull request in, and for sticking with it this far. 💙

--- a/packages/website/blog/2026-08-25-tips-for-increasing-lint-rule-test-coverage.md
+++ b/packages/website/blog/2026-08-25-tips-for-increasing-lint-rule-test-coverage.md
@@ -292,7 +292,7 @@ This one is the least common.
 Most gaps are one of the first two, so reach for this only after ruling those out.
 
 An edge case in types is when a specific case can't be represented in types,
-or when there are gaps in the [control flow analysis](https://github.com/microsoft/TypeScript/issues/9998).
+or when it's guaranteed that a specific case will never occur at runtime.
 
 Token lookups are the case that comes up most.
 `getFirstToken` returns `TSESTree.Token | null` for every node, including nodes that cannot exist without a first token.

--- a/packages/website/blog/authors.yml
+++ b/packages/website/blog/authors.yml
@@ -9,3 +9,9 @@ joshuakgoldberg:
   name: Josh Goldberg
   title: typescript-eslint Maintainer
   url: https://github.com/JoshuaKGoldberg
+
+StyleShit:
+  image_url: /img/team/StyleShit.jpg
+  name: Evyatar Daud
+  title: typescript-eslint Committer
+  url: https://github.com/StyleShit

--- a/packages/website/docusaurus.config.mts
+++ b/packages/website/docusaurus.config.mts
@@ -221,6 +221,24 @@ const themeConfig: AlgoliaThemeConfig & ThemeCommonConfig = {
         className: 'code-block-added-line',
         line: 'Add this line',
       },
+      {
+        block: { end: 'Covered lines end', start: 'Covered lines start' },
+        className: 'code-block-covered-line',
+        line: 'Covered line',
+      },
+      {
+        block: {
+          end: 'Partially covered lines end',
+          start: 'Partially covered lines start',
+        },
+        className: 'code-block-partially-covered-line',
+        line: 'Partially covered line',
+      },
+      {
+        block: { end: 'Uncovered lines end', start: 'Uncovered lines start' },
+        className: 'code-block-uncovered-line',
+        line: 'Uncovered line',
+      },
     ],
     theme: {
       plain: {},

--- a/packages/website/src/css/custom.css
+++ b/packages/website/src/css/custom.css
@@ -211,6 +211,16 @@ h6 {
   background-color: #00ff9510;
 }
 
+.code-block-partially-covered-line::before {
+  content: '!';
+  display: inline-block;
+  width: 0;
+  position: relative;
+  left: -0.7em;
+  color: rgb(166 124 0);
+  font-weight: 700;
+}
+
 .code-block-partially-covered-line {
   background-color: #ffcc0030;
   display: block;
@@ -224,6 +234,15 @@ h6 {
 
 [data-theme='dark'] .code-block-partially-covered-line {
   background-color: #ffcc0018;
+}
+
+.code-block-uncovered-line::before {
+  content: 'x';
+  display: inline-block;
+  width: 0;
+  position: relative;
+  left: -0.7em;
+  color: red;
 }
 
 .code-block-uncovered-line {

--- a/packages/website/src/css/custom.css
+++ b/packages/website/src/css/custom.css
@@ -200,6 +200,43 @@ h6 {
   background-color: #00ff9510;
 }
 
+.code-block-covered-line {
+  background-color: #00ff9520;
+  display: block;
+  margin: 0 calc(-1 * var(--ifm-pre-padding));
+  padding: 0 var(--ifm-pre-padding);
+}
+
+[data-theme='dark'] .code-block-covered-line {
+  background-color: #00ff9510;
+}
+
+.code-block-partially-covered-line {
+  background-color: #ffcc0030;
+  display: block;
+  margin: 0 calc(-1 * var(--ifm-pre-padding));
+  padding: 0 var(--ifm-pre-padding);
+}
+
+[data-theme='dark'] .code-block-partially-covered-line::before {
+  color: rgb(240 190 60);
+}
+
+[data-theme='dark'] .code-block-partially-covered-line {
+  background-color: #ffcc0018;
+}
+
+.code-block-uncovered-line {
+  background-color: #ff000020;
+  display: block;
+  margin: 0 calc(-1 * var(--ifm-pre-padding));
+  padding: 0 var(--ifm-pre-padding);
+}
+
+[data-theme='dark'] .code-block-uncovered-line {
+  background-color: #ff000015;
+}
+
 .markdown a {
   text-decoration: underline;
 }


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [X] Addresses an existing open issue: fixes #10388
- [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [X] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

I stole multiple things from both #12719, and https://github.com/JoshuaKGoldberg/dot-com/blob/d7d2f348ecf38fb2e3012fb06c85db16f1267cdf/src/content/blog/so-youve-got-a-gap-in-code-coverage-for-a-lint-rule/index.mdx?plain=1

Therefore:
Co-authored-by: @JoshuaKGoldberg 

<sup>Also added  you as an author of the blog post itself, if you don't mind</sup>
