### PR TITLE
test(eslint-plugin): [no-floating-promises] reactivate skipped `node:test` specifier test

### DIFF
--- a/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
@@ -795,8 +795,6 @@ it('...', () => {});
       ],
     },
     {
-      // TODO: Skipped pending resolution of https://github.com/typescript-eslint/typescript-eslint/issues/11504
-      skip: true,
       code: `
 import { it } from 'node:test';
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #12757
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

The `node:test` case in `no-floating-promises.test.ts` was skipped pending #11504, which is fixed and closed. Dropping `skip: true` takes the file from 180 passed / 1 skipped to 181 passed.

I checked that the test still means something rather than merely passing: changing the specifier's `name` to one that does not match makes it fail, so it does exercise the `typeOrValueSpecifier` matching that #11504 was about.
