### PR TITLE
feat(eslint-plugin): [no-unnecessary-condition] report type predicates that can never match

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
@@ -188,7 +188,22 @@ function assertIsString(value: unknown): asserts value is string {
 }
 
 assertIsString(s); // Unnecessary; s is always a string.
+
+declare const n: number;
+
+// Unnecessary; n can never be a string.
+if (isString(n)) {
+}
 ```
+
+A type predicate is reported both when it can never narrow anything away, because the
+argument already has the checked type, and when it can never succeed, because the argument
+and the checked type have no value in common.
+
+Only types that cannot overlap are reported for the latter. Two unrelated object types are
+left alone, since a third type can extend both, and so is a primitive checked against an
+object type: TypeScript narrows `string` by `x is { a: number }` to `string & { a: number }`,
+which is inhabitable, rather than to `never`.
 
 Whether this option makes sense for your project may vary.
 Some projects may intentionally use type predicates to ensure that runtime values do indeed match the types according to TypeScript, especially in test code.

--- a/packages/eslint-plugin/src/rules/naming-convention-utils/shared.ts
+++ b/packages/eslint-plugin/src/rules/naming-convention-utils/shared.ts
@@ -16,7 +16,9 @@ export function selectorTypeToMessageString(
 
 export function isMetaSelector(
   selector: IndividualAndMetaSelectorsString | MetaSelectors | Selectors,
-): selector is MetaSelectorsString {
+): selector is MetaSelectors | MetaSelectorsString {
+  // `MetaSelectors` is a numeric enum, so its reverse mapping makes this true
+  // for the enum's values as well as for its keys.
   return selector in MetaSelectors;
 }
 

--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -118,6 +118,80 @@ function booleanComparison(
       return left >= right;
   }
 }
+
+/**
+ * Types we can say nothing useful about, so any comparison against them has to
+ * be assumed to overlap.
+ */
+const unknowableFlags =
+  ts.TypeFlags.Any |
+  ts.TypeFlags.Never |
+  ts.TypeFlags.TypeParameter |
+  ts.TypeFlags.TypeVariable |
+  ts.TypeFlags.Unknown;
+
+/**
+ * Types for which a lack of assignability in *both* directions is enough to
+ * prove that no single value inhabits both.
+ *
+ * Object types are deliberately excluded. Two unrelated object types still
+ * overlap, because a third type can extend both, and so does a primitive
+ * checked against an object type: TypeScript narrows `string` by
+ * `x is { a: number }` to the inhabitable `string & { a: number }` rather than
+ * to `never`.
+ */
+const provablyDisjointFlags =
+  ts.TypeFlags.BigIntLike |
+  ts.TypeFlags.BooleanLike |
+  ts.TypeFlags.EnumLike |
+  ts.TypeFlags.ESSymbolLike |
+  ts.TypeFlags.Null |
+  ts.TypeFlags.NumberLike |
+  ts.TypeFlags.StringLike |
+  ts.TypeFlags.Undefined |
+  ts.TypeFlags.Void;
+
+function typesCanOverlap(
+  checker: ts.TypeChecker,
+  a: ts.Type,
+  b: ts.Type,
+): boolean {
+  if (
+    tsutils.isTypeFlagSet(a, unknowableFlags) ||
+    tsutils.isTypeFlagSet(b, unknowableFlags)
+  ) {
+    return true;
+  }
+
+  if (checker.isTypeAssignableTo(a, b) || checker.isTypeAssignableTo(b, a)) {
+    return true;
+  }
+
+  return !(
+    tsutils.isTypeFlagSet(a, provablyDisjointFlags) &&
+    tsutils.isTypeFlagSet(b, provablyDisjointFlags)
+  );
+}
+
+/**
+ * Whether no value could satisfy both types, which makes a type guard between
+ * them always false.
+ */
+function typesAreDisjoint(
+  checker: ts.TypeChecker,
+  argumentType: ts.Type,
+  predicateType: ts.Type,
+): boolean {
+  const predicateParts = tsutils.unionConstituents(predicateType);
+
+  return tsutils
+    .unionConstituents(argumentType)
+    .every(argumentPart =>
+      predicateParts.every(
+        predicatePart => !typesCanOverlap(checker, argumentPart, predicatePart),
+      ),
+    );
+}
 // #endregion
 
 type LegacyAllowConstantLoopConditions = boolean;
@@ -153,7 +227,8 @@ export type MessageId =
   | 'noOverlapBooleanExpression'
   | 'noStrictNullCheck'
   | 'suggestRemoveOptionalChain'
-  | 'typeGuardAlreadyIsType';
+  | 'typeGuardAlreadyIsType'
+  | 'typeGuardNeverIsType';
 
 export default createRule<Options, MessageId>({
   name: 'no-unnecessary-condition',
@@ -188,6 +263,8 @@ export default createRule<Options, MessageId>({
       suggestRemoveOptionalChain: 'Remove unnecessary optional chain',
       typeGuardAlreadyIsType:
         'Unnecessary conditional, expression already has the type being checked by the {{typeGuardOrAssertionFunction}}.',
+      typeGuardNeverIsType:
+        'Unnecessary conditional, expression can never have the type being checked by the {{typeGuardOrAssertionFunction}}.',
     },
     schema: [
       {
@@ -619,6 +696,22 @@ export default createRule<Options, MessageId>({
             context.report({
               node: typeGuardAssertedArgument.argument,
               messageId: 'typeGuardAlreadyIsType',
+              data: {
+                typeGuardOrAssertionFunction: typeGuardAssertedArgument.asserts
+                  ? 'assertion function'
+                  : 'type guard',
+              },
+            });
+          } else if (
+            typesAreDisjoint(
+              checker,
+              typeOfArgument,
+              typeGuardAssertedArgument.type,
+            )
+          ) {
+            context.report({
+              node: typeGuardAssertedArgument.argument,
+              messageId: 'typeGuardNeverIsType',
               data: {
                 typeGuardOrAssertionFunction: typeGuardAssertedArgument.asserts
                   ? 'assertion function'

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unnecessary-condition.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unnecessary-condition.shot
@@ -144,6 +144,13 @@ function assertIsString(value: unknown): asserts value is string {
 assertIsString(s); // Unnecessary; s is always a string.
                ~ Unnecessary conditional, expression already has the type being checked by the assertion function.
 
+declare const n: number;
+
+// Unnecessary; n can never be a string.
+if (isString(n)) {
+             ~ Unnecessary conditional, expression can never have the type being checked by the type guard.
+}
+
 
 
 const array: string[] = [];

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -1278,6 +1278,73 @@ if (isNarrower(w)) {
       `,
       options: [{ checkTypePredicates: true }],
     },
+    {
+      // the argument may or may not be a number, which is the whole point of
+      // the type guard.
+      code: `
+declare function isNumber(x: unknown): x is number;
+declare const s: string | number;
+if (isNumber(s)) {
+}
+      `,
+      options: [{ checkTypePredicates: true }],
+    },
+    {
+      // two unrelated object types still overlap, since a third type can
+      // extend both.
+      code: `
+interface A {
+  a: string;
+}
+interface B {
+  b: number;
+}
+declare function isB(x: unknown): x is B;
+declare const a: A;
+if (isB(a)) {
+}
+      `,
+      options: [{ checkTypePredicates: true }],
+    },
+    {
+      // narrows to `string & { a: number }`, which is inhabitable, not `never`.
+      code: `
+declare function isBoxed(x: unknown): x is { a: number };
+declare const s: string;
+if (isBoxed(s)) {
+}
+      `,
+      options: [{ checkTypePredicates: true }],
+    },
+    {
+      code: `
+declare function isNumber(x: unknown): x is number;
+declare const a: any;
+if (isNumber(a)) {
+}
+      `,
+      options: [{ checkTypePredicates: true }],
+    },
+    {
+      code: `
+declare function isNumber(x: unknown): x is number;
+function f<T>(t: T) {
+  if (isNumber(t)) {
+  }
+}
+      `,
+      options: [{ checkTypePredicates: true }],
+    },
+    {
+      // should not report because option is disabled.
+      code: `
+declare function isNumber(x: unknown): x is number;
+declare const s: string;
+if (isNumber(s)) {
+}
+      `,
+      options: [{ checkTypePredicates: false }],
+    },
     `
 type A = { [name in Lowercase<string>]?: A };
 declare const a: A;
@@ -3841,6 +3908,69 @@ if (isNarrower(w)) {
         {
           line: 11,
           messageId: 'typeGuardAlreadyIsType',
+        },
+      ],
+      options: [{ checkTypePredicates: true }],
+    },
+    {
+      // string and number have no overlap, so the guard is always false.
+      code: `
+declare function isNumber(x: unknown): x is number;
+declare const s: string;
+if (isNumber(s)) {
+}
+      `,
+      errors: [
+        {
+          line: 4,
+          messageId: 'typeGuardNeverIsType',
+        },
+      ],
+      options: [{ checkTypePredicates: true }],
+    },
+    {
+      code: `
+declare function assertsNumber(x: unknown): asserts x is number;
+declare const s: string;
+assertsNumber(s);
+      `,
+      errors: [
+        {
+          line: 4,
+          messageId: 'typeGuardNeverIsType',
+        },
+      ],
+      options: [{ checkTypePredicates: true }],
+    },
+    {
+      // distinct literal types of the same primitive.
+      code: `
+declare function isFoo(x: unknown): x is 'foo';
+declare const s: 'bar';
+if (isFoo(s)) {
+}
+      `,
+      errors: [
+        {
+          line: 4,
+          messageId: 'typeGuardNeverIsType',
+        },
+      ],
+      options: [{ checkTypePredicates: true }],
+    },
+    {
+      // no constituent of the argument overlaps any constituent of the
+      // predicate.
+      code: `
+declare function isStringOrNumber(x: unknown): x is string | number;
+declare const b: boolean | bigint;
+if (isStringOrNumber(b)) {
+}
+      `,
+      errors: [
+        {
+          line: 4,
+          messageId: 'typeGuardNeverIsType',
         },
       ],
       options: [{ checkTypePredicates: true }],

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -3922,6 +3922,9 @@ if (isNumber(s)) {
       `,
       errors: [
         {
+          column: 14,
+          endColumn: 15,
+          endLine: 4,
           line: 4,
           messageId: 'typeGuardNeverIsType',
         },
@@ -3936,6 +3939,9 @@ assertsNumber(s);
       `,
       errors: [
         {
+          column: 15,
+          endColumn: 16,
+          endLine: 4,
           line: 4,
           messageId: 'typeGuardNeverIsType',
         },
@@ -3952,6 +3958,9 @@ if (isFoo(s)) {
       `,
       errors: [
         {
+          column: 11,
+          endColumn: 12,
+          endLine: 4,
           line: 4,
           messageId: 'typeGuardNeverIsType',
         },
@@ -3969,6 +3978,9 @@ if (isStringOrNumber(b)) {
       `,
       errors: [
         {
+          column: 22,
+          endColumn: 23,
+          endLine: 4,
           line: 4,
           messageId: 'typeGuardNeverIsType',
         },


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #~10997~
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

`checkTypePredicates` currently reports a guard whose argument *already* has the checked type. This adds the mirror case that @kirkwaiblinger narrowed the issue down to — a guard that can never succeed, because the argument type and the predicate type have no value in common:

```ts
declare const s: string;
declare function isNumber(x: unknown): x is number;

if (isNumber(s)) {
  s;
  //^? never
}
```

New message id: `typeGuardNeverIsType`.

The interesting part is deciding disjointness without introducing false positives. Assignability in either direction proves an overlap, but the *absence* of assignability does not prove disjointness. So the check reports only when every pair of union constituents is provably disjoint, and I limited "provably" to primitive-like types — string/number/bigint/boolean/symbol/enum/null/undefined/void and their literals.

Object types are deliberately left out, both against each other and against primitives:

- `interface A { a: string }` and `interface B { b: number }` have no assignability relation either way, yet a third type can extend both.
- `string` narrowed by `x is { a: number }` gives `string & { a: number }`, which is inhabitable — not `never`.

`any`, `unknown`, `never` and naked type parameters bail out.

Tests cover both directions. I confirmed the four new invalid cases fail without the rule change, so they are not passing vacuously. The repo lints itself with `checkTypePredicates: true` and stays clean under the new report.