### PR TITLE
fix(eslint-plugin): [no-useless-default-assignment] avoid false positives on tuples with a rest element

### DIFF
--- a/packages/eslint-plugin/src/rules/no-useless-default-assignment.ts
+++ b/packages/eslint-plugin/src/rules/no-useless-default-assignment.ts
@@ -225,8 +225,18 @@ export default createRule<Options, MessageId>({
         if (elementIndex < 0 || elementIndex >= tupleArgs.length) {
           return;
         }
-        const elementType = tupleArgs[elementIndex];
-        if (!canBeUndefined(elementType)) {
+        const { fixedLength, minLength } = sourceType.target;
+
+        if (elementIndex >= minLength) {
+          return;
+        }
+
+        const elementTypes =
+          elementIndex < fixedLength
+            ? [tupleArgs[elementIndex]]
+            : tupleArgs.slice(fixedLength);
+
+        if (!elementTypes.some(canBeUndefined)) {
           reportUselessDefaultAssignment(node, 'property');
         }
       }

--- a/packages/eslint-plugin/tests/rules/no-useless-default-assignment.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-useless-default-assignment.test.ts
@@ -378,6 +378,25 @@ const fn: Fn = (value = 'default') => {
   invalid: [
     {
       code: `
+declare const mixed: [boolean, ...number[], string];
+const [a, b = 0] = mixed;
+      `,
+      errors: [
+        {
+          column: 15,
+          data: { type: 'property' },
+          endColumn: 16,
+          line: 3,
+          messageId: 'uselessDefaultAssignment',
+        },
+      ],
+      output: `
+declare const mixed: [boolean, ...number[], string];
+const [a, b] = mixed;
+      `,
+    },
+    {
+      code: `
 function Bar({ foo = '' }: { foo: string }) {
   return foo;
 }

--- a/packages/eslint-plugin/tests/rules/no-useless-default-assignment.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-useless-default-assignment.test.ts
@@ -386,6 +386,7 @@ const [a, b = 0] = mixed;
           column: 15,
           data: { type: 'property' },
           endColumn: 16,
+          endLine: 3,
           line: 3,
           messageId: 'uselessDefaultAssignment',
         },

--- a/packages/eslint-plugin/tests/rules/no-useless-default-assignment.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-useless-default-assignment.test.ts
@@ -226,6 +226,30 @@ useCallback((value: number[] = []) => {});
 declare const tuple: [string];
 const [a, b = 'default'] = tuple;
     `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/12767
+    `
+declare const commands: [string, ...string[]];
+const [cmd, arg = 'run'] = commands;
+    `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/12767
+    `
+declare const commands: readonly [string, ...string[]];
+const [cmd, arg = 'run'] = commands;
+    `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/12767
+    `
+function run([cmd, arg = 'run']: [string, ...string[]]) {}
+    `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/12767
+    `
+declare const mixed: [boolean, ...number[], string];
+const [a, b, c = 0] = mixed;
+    `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/12767
+    `
+declare const items: [...string[], string | undefined];
+const [first = 'fallback'] = items;
+    `,
     // https://github.com/typescript-eslint/typescript-eslint/issues/11911
     `
 const run = (cb: (...args: unknown[]) => void) => cb();


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #12767 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview
The rule reported defaults that are actually reachable when the source is a tuple with a rest element:

```ts
declare const commands: [string, ...string[]];
const [cmd, arg = 'run'] = commands; // `= 'run'` was reported
```

`commands` may be `['build']`, in which case `arg` is missing and the default is used. Applying the fixer changes behavior.

### Root cause

The array branch mapped each destructured index onto the type argument at the same index:

```ts
const elementType = tupleArgs[elementIndex];
```

That mapping only holds when there is no rest element. `typeArguments` lists what the type annotation spells out, not the slots that exist at runtime.

### The fix

The check is now split in two:

1. `minLength` is how many elements are always there: required elements on both sides of the rest element, optional and rest **excluded**. Every index below it is guaranteed to hold a value. At or past it the element may be missing at runtime, so the default should be kept.
  ```
  `[string, ...string[], number]` has a `minLength` of 2.
  ```
   
2. `fixedLength` is how many elements come before the rest element, optional ones **included**. `[string, string?]` has a `fixedLength` of 2. Only indices below it line up one-to-one with a type argument.
From the rest element onwards the value may come from the rest element or from any element after it, so the position no longer picks out a single type argument.
```
In `[boolean, ...number[], string]` both index 1 and index 2 are `string | number`.
```

That is why every candidate from `fixedLength` onwards is checked, and the default is only reported when none of them can be `undefined`. It also covers a tuple whose element is present but nullable:

```ts
declare const items: [...string[], string | undefined];
const [first = 'fallback'] = items; // no longer reported
```

Tests were added in the preceding commits: five valid cases, plus one invalid case pinning down that an always-present element in a tuple with a rest element is still reported.
💖