### PR TITLE
fix(eslint-plugin): [no-useless-default-assignment] allow defaults on tuple positions that can be absent at runtime

### DIFF
--- a/packages/eslint-plugin/src/rules/no-useless-default-assignment.ts
+++ b/packages/eslint-plugin/src/rules/no-useless-default-assignment.ts
@@ -225,6 +225,25 @@ export default createRule<Options, MessageId>({
         if (elementIndex < 0 || elementIndex >= tupleArgs.length) {
           return;
         }
+
+        // A variadic tuple element makes positions at or after it depend
+        // on the array's runtime length: an element can be absent even
+        // when its declared type excludes `undefined`, so its default
+        // value is reachable. Bail out instead of reporting a false
+        // positive.
+        const tupleTarget =
+          (sourceType as ts.TupleTypeReference).target ??
+          (sourceType as ts.TupleType);
+        if (
+          tupleTarget.elementFlags.some(
+            flag =>
+              flag & ts.ElementFlags.Rest || flag & ts.ElementFlags.Variadic,
+          ) ||
+          elementIndex >= tupleTarget.minLength
+        ) {
+          return;
+        }
+
         const elementType = tupleArgs[elementIndex];
         if (!canBeUndefined(elementType)) {
           reportUselessDefaultAssignment(node, 'property');

--- a/packages/eslint-plugin/tests/rules/no-useless-default-assignment.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-useless-default-assignment.test.ts
@@ -226,6 +226,16 @@ useCallback((value: number[] = []) => {});
 declare const tuple: [string];
 const [a, b = 'default'] = tuple;
     `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/12767
+    `
+declare const commands: [string, ...string[]];
+const [cmd, arg = 'run'] = commands;
+    `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/12767
+    `
+declare const items: [...string[], string | undefined];
+const [first = 'fallback'] = items;
+    `,
     // https://github.com/typescript-eslint/typescript-eslint/issues/11911
     `
 const run = (cb: (...args: unknown[]) => void) => cb();


### PR DESCRIPTION
## Summary

For array destructuring against a tuple type, the rule compared the element's declared type against `undefined` without accounting for variadic tuples. For `[string, ...string[]]`, the element at index 1 resolves to the rest array's type, so `const [cmd, arg = 'run'] = commands` was reported as a useless default even though `commands` can legitimately hold a single element and leave `arg` undefined at runtime. The same applied to leading-variadic tuples like `[...string[], string | undefined]`, where destructured positions shift.

The rule now bails out when the tuple contains a rest or variadic element, or when the destructured position is at or beyond the tuple's minimum length, since in those cases the default is reachable. Fixed tuples are unaffected.

## Testing

Added both cases from #12767 to the rule's valid cases; they failed before this change and pass now. All 87 tests of the rule pass, `tsc --noEmit` is clean for the package, and prettier reports no issues on the changed files.

## Checklist

- bug reproduced before fix
- root cause identified
- bug fixed
- tests passed
