### PR TITLE
feat(utils): anchor public types on @eslint/core for defineConfig compatibility

### DIFF
--- a/docs/packages/TypeScript_ESLint.mdx
+++ b/docs/packages/TypeScript_ESLint.mdx
@@ -16,15 +16,15 @@ This package is the main entrypoint that you can use to consume our tooling with
 
 This package exports the following:
 
-| Name                  | Description                                                                                       |
-| --------------------- | ------------------------------------------------------------------------------------------------- |
-| `config` (deprecated) | A utility function for creating type-safe flat configs -- see [`config(...)`](#config-deprecated) |
-| `configs`             | [Shared ESLint (flat) configs](../users/Shared_Configurations.mdx)                                |
-| `extensions`          | File extension arrays for JavaScript/TypeScript files -- see [`extensions`](#extensions)          |
-| `globs`               | Predefined glob patterns for JavaScript/TypeScript files -- see [`globs`](#globs)                 |
-| `parser`              | A re-export of [`@typescript-eslint/parser`](./Parser.mdx)                                        |
-| `plugin`              | A re-export of [`@typescript-eslint/eslint-plugin`](./ESLint_Plugin.mdx)                          |
-| `FlatConfig`          | A re-export of the type from [`@typescript-eslint/utils`](./Utils.mdx)                            |
+| Name                  | Description                                                                                                                                               |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `config` (deprecated) | A utility function for creating type-safe flat configs -- see [`config(...)`](#config-deprecated)                                                         |
+| `configs`             | [Shared ESLint (flat) configs](../users/Shared_Configurations.mdx)                                                                                        |
+| `extensions`          | File extension arrays for JavaScript/TypeScript files -- see [`extensions`](#extensions)                                                                  |
+| `globs`               | Predefined glob patterns for JavaScript/TypeScript files -- see [`globs`](#globs)                                                                         |
+| `parser`              | A re-export of [`@typescript-eslint/parser`](./Parser.mdx)                                                                                                |
+| `plugin`              | A re-export of [`@typescript-eslint/eslint-plugin`](./ESLint_Plugin.mdx)                                                                                  |
+| `FlatConfig`          | A re-export of the type from [`@typescript-eslint/utils`](./Utils.mdx), anchored on `@eslint/core` -- see [Migrating to v9](../users/Migrating_To_v9.mdx) |
 
 ## Installation
 
@@ -218,6 +218,11 @@ export default [
 We _**strongly**_ recommend using this utility to improve the config authoring experience — however it is entirely optional.
 By choosing not to use it you lose editor autocomplete and type checking for config files.
 Otherwise it _will not_ impact your ability to use our tooling.
+:::
+
+:::note
+Since the types were re-anchored on `@eslint/core`, `defineConfig()` and `tseslint.config()` accept all `typescript-eslint` exports (plugin, parser, configs, and `RuleCreator` outputs) without casts or `@ts-expect-error` workarounds.
+See [Migrating to v9](../users/Migrating_To_v9.mdx) if you are upgrading from v8.
 :::
 
 #### Flat config `extends`

--- a/docs/users/Migrating_To_v9.mdx
+++ b/docs/users/Migrating_To_v9.mdx
@@ -1,0 +1,105 @@
+---
+id: migrating-to-v9
+title: Migrating to v9
+description: How to migrate your code to the typescript-eslint v9 type contracts
+---
+
+typescript-eslint v9 re-anchors the public typing surface of `@typescript-eslint/utils` and `typescript-eslint` onto [`@eslint/core`](https://github.com/eslint/rewrite/tree/main/packages/core), and removes typings for context members that were deleted in ESLint 10.
+This guide covers what you need to do if you authored rules, plugins, or type annotations against the v8 types.
+
+## Removing `@ts-expect-error` workarounds for `defineConfig` {#removing-workarounds}
+
+If your config used a `@ts-expect-error` directive (or `any` cast) to pass a `typescript-eslint` plugin, parser, config, or a rule created with `RuleCreator` into `defineConfig()` ([#11543](https://github.com/typescript-eslint/typescript-eslint/issues/11543)), remove the directive: the values now type-check as-is in both `defineConfig()` and `tseslint.config()`.
+
+```js
+// @ts-check
+
+import { defineConfig } from 'eslint/config';
+import { ESLintUtils } from '@typescript-eslint/utils';
+
+const createRule = ESLintUtils.RuleCreator(
+  ruleName => `https://example.com/rules/${ruleName}`,
+);
+
+const rule = createRule({
+  name: 'no-foo',
+  meta: {
+    type: 'suggestion',
+    docs: { description: 'Disallow foo identifiers.' },
+    messages: { avoidFoo: 'Avoid foo.' },
+    schema: [],
+  },
+  create(context) {
+    return {
+      Identifier(node) {
+        if (node.name === 'foo') {
+          context.report({ messageId: 'avoidFoo', node });
+        }
+      },
+    };
+  },
+});
+
+export default defineConfig({
+  plugins: {
+    example: {
+      // v8 required a workaround directive or cast here; v9 does not
+      rules: { 'no-foo': rule },
+    },
+  },
+});
+```
+
+If you remove the directive and see a `TS2578: Unused '@ts-expect-error' directive` error, the workaround is no longer needed — this is expected, and is the signal that your setup is fixed.
+
+## Configs compose in both entries {#configs}
+
+`tseslint.configs.*` values (and your own configs typed as `TSESLint.FlatConfig.Config` / `ConfigArray`) can be passed to both `defineConfig()` and `tseslint.config()` — as values, inside `extends` arrays, and via spread.
+No `as` casts are required anymore.
+
+## Rule context members removed with ESLint 10 {#context-members}
+
+The typings for the following rule context members, deleted from ESLint's runtime in v10, are removed from `RuleContext` and `CodePath` ([#11371](https://github.com/typescript-eslint/typescript-eslint/issues/11371)):
+
+| Removed member                       | Replacement                                         |
+| ------------------------------------ | --------------------------------------------------- |
+| `context.parserOptions`              | `context.languageOptions.parserOptions`             |
+| `context.parserPath`                 | `context.languageOptions.parser?.meta?.name`        |
+| `context.parserServices`             | `context.sourceCode.parserServices`                 |
+| `context.getAncestors()`             | `context.sourceCode.getAncestors(node)`             |
+| `context.getDeclaredVariables(node)` | `context.sourceCode.getDeclaredVariables(node)`     |
+| `context.getCwd()`                   | `context.cwd`                                       |
+| `context.getFilename()`              | `context.filename`                                  |
+| `context.getPhysicalFilename()`      | `context.physicalFilename`                          |
+| `context.getScope()`                 | `context.sourceCode.getScope(node)`                 |
+| `context.getSourceCode()`            | `context.sourceCode`                                |
+| `context.markVariableAsUsed(name)`   | `context.sourceCode.markVariableAsUsed(name, node)` |
+| `codePath.currentSegments`           | (no replacement; removed upstream)                  |
+
+The replacement properties (`cwd`, `filename`, `physicalFilename`, `sourceCode`) and the `languageOptions` hub remain fully typed.
+
+## Direct `FlatConfig` type annotations {#annotations}
+
+The `TSESLint.FlatConfig.*` type names are preserved and re-anchored onto `@eslint/core`, so annotations such as:
+
+```ts
+import type { FlatConfig } from '@typescript-eslint/utils/ts-eslint';
+
+const plugin: FlatConfig.Plugin = { rules: {} };
+const parser: FlatConfig.Parser = { parseForESLint: () => ({ ast: {} }) };
+```
+
+keep working, and the annotated values are now accepted by `defineConfig()` and `tseslint.config()` without casts.
+
+If your plugin previously worked around this incompatibility with its own forked rule creator or boundary casts (as `eslint-plugin-import-x`, `angular-eslint`, and others did), you can now retire that workaround: a plugin built with `RuleCreator` and annotated with `TSESLint.FlatConfig.*` types is accepted directly.
+
+Two boundaries to be aware of:
+
+- **Plugins and configs typed against `@types/eslint` v8 (or very old `@typescript-eslint/utils` versions) are no longer assignable** to the flat config plugin types. If you consume such third-party values inside a typed flat config, either update the dependency or keep a local cast. This is a direct consequence of anchoring onto the current `@eslint/core` contract.
+- Annotating a parser with a **strict `Linter.LanguageOptions['parser']` type** and passing a `LooseParserModule`-style parser into it is not supported — the strict parser plane only exists inside `Linter.LanguageOptions`, not in config positions. Annotate with `FlatConfig.Parser` instead.
+
+## Type guarantee and supported ESLint versions {#peer-range}
+
+The runtime `eslint` peer range is unchanged (`^8.57.0 || ^9.0.0 || ^10.0.0`).
+However, the _type_ layer now describes the current flat config contract (as defined by `@eslint/core` and ESLint 10), and no longer guarantees type-level compatibility with `@types/eslint` v8-style plugin shapes.
+The type contract follows the [ESLint supported versions](https://eslint.org/version-support/): ESLint 8 reached end-of-life in October 2024 and ESLint 9 reaches end-of-life in August 2026.

--- a/packages/eslint-plugin/rules.d.ts
+++ b/packages/eslint-plugin/rules.d.ts
@@ -38,6 +38,7 @@ This is likely not portable. A type annotation is necessary. ts(2742)
 
 import type {
   RuleModuleWithMetaDocs,
+  RuleModuleWithMetaDocsAndCoreVisitor,
   RuleRecommendation,
   RuleRecommendationAcrossConfigs,
 } from '@typescript-eslint/utils/ts-eslint';
@@ -69,9 +70,14 @@ type ESLintPluginRuleModule = RuleModuleWithMetaDocs<
   ESLintPluginDocs
 >;
 
+/*
+The rules record is typed with a core-compatible view of RuleModuleWithMetaDocs
+so that the plugin is assignable to flat config plugins positions without casts
+(https://github.com/typescript-eslint/typescript-eslint/issues/11543).
+*/
 type TypeScriptESLintRules = Record<
   string,
-  RuleModuleWithMetaDocs<string, unknown[], ESLintPluginDocs>
+  RuleModuleWithMetaDocsAndCoreVisitor<string, unknown[], ESLintPluginDocs>
 >;
 
 declare const rules: TypeScriptESLintRules;

--- a/packages/eslint-plugin/src/raw-plugin.ts
+++ b/packages/eslint-plugin/src/raw-plugin.ts
@@ -70,8 +70,7 @@ const plugin = {
   rules,
 } satisfies Linter.Plugin;
 
-// @ts-expect-error -- upstream type incompatibility stuff
-const flatPlugin = plugin as FlatConfig.Plugin;
+const flatPlugin: FlatConfig.Plugin = plugin;
 
 // included due to https://github.com/eslint/eslint/issues/19513
 const flatConfigs = {

--- a/packages/eslint-plugin/tests/worksWithStringlyTypedExtends.test.ts
+++ b/packages/eslint-plugin/tests/worksWithStringlyTypedExtends.test.ts
@@ -8,7 +8,6 @@ describe("The plugin object should work with eslint defineConfig's stringly type
       defineConfig({
         extends: ['ts/flat/strict'],
         plugins: {
-          // @ts-expect-error -- types aren't compatible.
           ts: plugin,
         },
       });
@@ -20,7 +19,6 @@ describe("The plugin object should work with eslint defineConfig's stringly type
       defineConfig({
         extends: ['ts/strict'],
         plugins: {
-          // @ts-expect-error -- types aren't compatible.
           ts: plugin,
         },
       });

--- a/packages/integration-tests/fixtures/flat-config-types-@types__eslint-v8/eslint.config.js
+++ b/packages/integration-tests/fixtures/flat-config-types-@types__eslint-v8/eslint.config.js
@@ -15,6 +15,20 @@ const compat = new FlatCompat({
   allConfig: {},
 });
 
+// third-party values typed against @types/eslint v8 are no longer assignable
+// to the re-anchored flat config plugin types
+/** @type {any} */
+const v8TypedJsRecommended = js.configs.recommended;
+/** @type {any} */
+const v8TypedStylisticRecommendedFlat =
+  stylisticPlugin.configs['recommended-flat'];
+/** @type {any} */
+const v8TypedStylisticPlugin = stylisticPlugin;
+/** @type {any} */
+const v8TypedVitestPlugin = vitestPlugin;
+/** @type {any} */
+const v8TypedVitestRecommended = vitestPlugin.configs.recommended;
+
 // this config is run through eslint as part of the integration test
 // so it needs to be a correct config
 export default tseslint.config(
@@ -26,12 +40,12 @@ export default tseslint.config(
     plugins: {
       ['@typescript-eslint']: tseslint.plugin,
       ['deprecation']: deprecationPlugin,
-      ['vitest']: vitestPlugin,
+      ['vitest']: v8TypedVitestPlugin,
     },
   },
-  js.configs.recommended,
+  v8TypedJsRecommended,
   ...tseslint.configs.recommended,
-  stylisticPlugin.configs['recommended-flat'],
+  v8TypedStylisticRecommendedFlat,
 );
 
 // wrapped in a function so they aren't executed at lint time
@@ -39,26 +53,29 @@ function _otherCases() {
   // these are just tests for the types and are not seen by eslint so they can be whatever
   tseslint.config({
     plugins: {
+      // third-party values typed against @types/eslint v8 are no longer
+      // assignable to the re-anchored flat config plugin types
+      /** @type {any} */
       ['@stylistic']: stylisticPlugin,
       ['@typescript-eslint']: tseslint.plugin,
       ['deprecation']: deprecationPlugin,
-      ['vitest']: vitestPlugin,
+      ['vitest']: v8TypedVitestPlugin,
     },
   });
   tseslint.config(
-    js.configs.recommended,
+    v8TypedJsRecommended,
     ...tseslint.configs.recommended,
-    stylisticPlugin.configs['recommended-flat'],
-    vitestPlugin.configs.recommended,
+    v8TypedStylisticRecommendedFlat,
+    v8TypedVitestRecommended,
   );
   tseslint.config(
     // @ts-expect-error
     compat.config(deprecationPlugin.configs.recommended),
-    vitestPlugin.configs.recommended,
+    v8TypedVitestRecommended,
   );
   tseslint.config(
     // @ts-expect-error
     deprecationPlugin.configs.recommended,
-    vitestPlugin.configs.recommended,
+    v8TypedVitestRecommended,
   );
 }

--- a/packages/integration-tests/fixtures/flat-config-types-@types__eslint-v9/eslint.config.js
+++ b/packages/integration-tests/fixtures/flat-config-types-@types__eslint-v9/eslint.config.js
@@ -25,6 +25,7 @@ export default tseslint.config(
   {
     plugins: {
       ['@typescript-eslint']: tseslint.plugin,
+      // @ts-expect-error -- plugins typed with pre-re-anchoring @typescript-eslint/utils types are no longer assignable to the flat config plugin types
       ['deprecation']: deprecationPlugin,
       ['vitest']: vitestPlugin,
     },
@@ -41,6 +42,7 @@ function _otherCases() {
     plugins: {
       ['@stylistic']: stylisticPlugin,
       ['@typescript-eslint']: tseslint.plugin,
+      // @ts-expect-error -- plugins typed with pre-re-anchoring @typescript-eslint/utils types are no longer assignable to the flat config plugin types
       ['deprecation']: deprecationPlugin,
       ['vitest']: vitestPlugin,
     },

--- a/packages/integration-tests/fixtures/ts-eslint-11543/eslint.config.js
+++ b/packages/integration-tests/fixtures/ts-eslint-11543/eslint.config.js
@@ -1,0 +1,108 @@
+// @ts-check
+
+import { ESLintUtils } from '@typescript-eslint/utils';
+import { defineConfig } from 'eslint/config';
+import tseslint from 'typescript-eslint';
+
+const createRule = ESLintUtils.RuleCreator(
+  ruleName => `https://example.com/rules/${ruleName}`,
+);
+
+// mini-fixture: a third-party plugin rule authored with RuleCreator (#11543, consumer class 4)
+const noFoo = createRule({
+  name: 'no-foo',
+  meta: {
+    type: 'suggestion',
+    docs: { description: 'Disallow foo identifiers.' },
+    messages: { avoidFoo: 'Avoid foo.' },
+    schema: [],
+  },
+  create(context) {
+    return {
+      Identifier(node) {
+        if (node.name === 'foo') {
+          context.report({ messageId: 'avoidFoo', node });
+        }
+      },
+    };
+  },
+});
+
+// inferred plugin object, no type annotations (CL-12 failure form 1)
+const inferredPlugin = {
+  meta: { name: 'example', version: '1.0.0' },
+  rules: {
+    'no-foo': noFoo,
+  },
+};
+
+// this config is run through eslint as part of the integration test
+// so it needs to be a correct config
+export default defineConfig(
+  {
+    // config with just ignores is the replacement for `.eslintignore`
+    ignores: ['**/build/**', '**/dist/**'],
+  },
+  {
+    plugins: {
+      example: inferredPlugin,
+    },
+    rules: {
+      'example/no-foo': 'error',
+    },
+  },
+);
+
+// wrapped in a function so they aren't executed at lint time
+function _otherCases() {
+  // these are just tests for the types and are not seen by eslint so they can be whatever
+
+  // the #11543 workaround (@ts-expect-error on the plugin position) is no
+  // longer needed: the inferred plugin passes without any directive
+  defineConfig({
+    plugins: {
+      example: inferredPlugin,
+    },
+  });
+
+  // both entries accept the plugin
+  tseslint.config({
+    plugins: {
+      example: inferredPlugin,
+    },
+  });
+
+  // wide-typed rules record (CL-12 failure form 2)
+  /**
+   * @type {Record<
+   *   string,
+   *   import('@typescript-eslint/utils/ts-eslint').AnyRuleModuleWithMetaDocs
+   * >}
+   */
+  const wideRules = {
+    'no-foo-wide': {
+      create: () => ({}),
+      meta: {
+        docs: { description: 'wide' },
+        messages: { avoidFoo: 'Avoid foo.' },
+        schema: [],
+        type: 'suggestion',
+      },
+    },
+  };
+  defineConfig({
+    plugins: {
+      wide: {
+        rules: wideRules,
+      },
+    },
+  });
+
+  // configs compose through both helpers, including extends and spread
+  defineConfig(...tseslint.configs.recommended, {
+    extends: [tseslint.configs.eslintRecommended, ...tseslint.configs.strict],
+  });
+  tseslint.config(...tseslint.configs.recommended, {
+    extends: [tseslint.configs.eslintRecommended],
+  });
+}

--- a/packages/integration-tests/fixtures/ts-eslint-11543/package.json
+++ b/packages/integration-tests/fixtures/ts-eslint-11543/package.json
@@ -1,0 +1,8 @@
+{
+  "type": "module",
+  "devDependencies": {
+    "@typescript-eslint/utils": "latest",
+    "eslint": "latest",
+    "typescript-eslint": "latest"
+  }
+}

--- a/packages/integration-tests/fixtures/ts-eslint-11543/ts2578.config.js
+++ b/packages/integration-tests/fixtures/ts-eslint-11543/ts2578.config.js
@@ -1,0 +1,42 @@
+// @ts-check
+
+import { ESLintUtils } from '@typescript-eslint/utils';
+import { defineConfig } from 'eslint/config';
+
+const createRule = ESLintUtils.RuleCreator(
+  ruleName => `https://example.com/rules/${ruleName}`,
+);
+
+const noFoo = createRule({
+  name: 'no-foo',
+  meta: {
+    type: 'suggestion',
+    docs: { description: 'Disallow foo identifiers.' },
+    messages: { avoidFoo: 'Avoid foo.' },
+    schema: [],
+  },
+  create(context) {
+    return {
+      Identifier(node) {
+        if (node.name === 'foo') {
+          context.report({ messageId: 'avoidFoo', node });
+        }
+      },
+    };
+  },
+});
+
+// The #11543 workaround wave put @ts-expect-error directives on plugin
+// positions like this one. With the types fixed, the directive is no longer
+// fulfilled, so tsc reports TS2578 for it — which is exactly what the
+// sibling test asserts.
+export default defineConfig({
+  plugins: {
+    example: {
+      rules: {
+        // @ts-expect-error -- https://github.com/typescript-eslint/typescript-eslint/issues/11543
+        'no-foo': noFoo,
+      },
+    },
+  },
+});

--- a/packages/integration-tests/tests/__snapshots__/flat-config-types-@types__eslint-v8.test.ts.snap
+++ b/packages/integration-tests/tests/__snapshots__/flat-config-types-@types__eslint-v8.test.ts.snap
@@ -3,17 +3,28 @@
 exports[`flat-config-types-@types__eslint-v8 > eslint > should work successfully 1`] = `
 [
   {
-    "errorCount": 3,
+    "errorCount": 4,
     "fatalErrorCount": 0,
     "filePath": "<root>/eslint.config.js",
     "fixableErrorCount": 0,
     "fixableWarningCount": 0,
     "messages": [
       {
+        "column": 7,
+        "endColumn": 29,
+        "endLine": 25,
+        "line": 25,
+        "message": "'v8TypedStylisticPlugin' is assigned a value but never used.",
+        "messageId": "unusedVar",
+        "nodeType": "Identifier",
+        "ruleId": "@typescript-eslint/no-unused-vars",
+        "severity": 2,
+      },
+      {
         "column": 10,
         "endColumn": 21,
-        "endLine": 38,
-        "line": 38,
+        "endLine": 51,
+        "line": 51,
         "message": "'_otherCases' is defined but never used.",
         "messageId": "unusedVar",
         "nodeType": "Identifier",
@@ -23,8 +34,8 @@ exports[`flat-config-types-@types__eslint-v8 > eslint > should work successfully
       {
         "column": 5,
         "endColumn": 24,
-        "endLine": 55,
-        "line": 55,
+        "endLine": 71,
+        "line": 71,
         "message": "Include a description after the "@ts-expect-error" directive to explain why the @ts-expect-error is necessary. The description must be 3 characters or longer.",
         "messageId": "tsDirectiveCommentRequiresDescription",
         "nodeType": "Line",
@@ -34,8 +45,8 @@ exports[`flat-config-types-@types__eslint-v8 > eslint > should work successfully
       {
         "column": 5,
         "endColumn": 24,
-        "endLine": 60,
-        "line": 60,
+        "endLine": 76,
+        "line": 76,
         "message": "Include a description after the "@ts-expect-error" directive to explain why the @ts-expect-error is necessary. The description must be 3 characters or longer.",
         "messageId": "tsDirectiveCommentRequiresDescription",
         "nodeType": "Line",
@@ -60,6 +71,19 @@ const compat = new FlatCompat({
   allConfig: {},
 })
 
+// third-party values typed against @types/eslint v8 are no longer assignable
+// to the re-anchored flat config plugin types
+/** @type {any} */
+const v8TypedJsRecommended = js.configs.recommended
+/** @type {any} */
+const v8TypedStylisticRecommendedFlat = stylisticPlugin.configs['recommended-flat']
+/** @type {any} */
+const v8TypedStylisticPlugin = stylisticPlugin
+/** @type {any} */
+const v8TypedVitestPlugin = vitestPlugin
+/** @type {any} */
+const v8TypedVitestRecommended = vitestPlugin.configs.recommended
+
 // this config is run through eslint as part of the integration test
 // so it needs to be a correct config
 export default tseslint.config(
@@ -71,12 +95,12 @@ export default tseslint.config(
     plugins: {
       ['@typescript-eslint']: tseslint.plugin,
       ['deprecation']: deprecationPlugin,
-      ['vitest']: vitestPlugin,
+      ['vitest']: v8TypedVitestPlugin,
     },
   },
-  js.configs.recommended,
+  v8TypedJsRecommended,
   ...tseslint.configs.recommended,
-  stylisticPlugin.configs['recommended-flat'],
+  v8TypedStylisticRecommendedFlat,
 )
 
 // wrapped in a function so they aren't executed at lint time
@@ -84,27 +108,30 @@ function _otherCases() {
   // these are just tests for the types and are not seen by eslint so they can be whatever
   tseslint.config({
     plugins: {
+      // third-party values typed against @types/eslint v8 are no longer
+      // assignable to the re-anchored flat config plugin types
+      /** @type {any} */
       ['@stylistic']: stylisticPlugin,
       ['@typescript-eslint']: tseslint.plugin,
       ['deprecation']: deprecationPlugin,
-      ['vitest']: vitestPlugin,
+      ['vitest']: v8TypedVitestPlugin,
     },
   })
   tseslint.config(
-    js.configs.recommended,
+    v8TypedJsRecommended,
     ...tseslint.configs.recommended,
-    stylisticPlugin.configs['recommended-flat'],
-    vitestPlugin.configs.recommended,
+    v8TypedStylisticRecommendedFlat,
+    v8TypedVitestRecommended,
   )
   tseslint.config(
     // @ts-expect-error
     compat.config(deprecationPlugin.configs.recommended),
-    vitestPlugin.configs.recommended,
+    v8TypedVitestRecommended,
   )
   tseslint.config(
     // @ts-expect-error
     deprecationPlugin.configs.recommended,
-    vitestPlugin.configs.recommended,
+    v8TypedVitestRecommended,
   )
 }
 ",

--- a/packages/integration-tests/tests/__snapshots__/flat-config-types-@types__eslint-v9.test.ts.snap
+++ b/packages/integration-tests/tests/__snapshots__/flat-config-types-@types__eslint-v9.test.ts.snap
@@ -12,8 +12,8 @@ exports[`flat-config-types-@types__eslint-v9 > eslint > should work successfully
       {
         "column": 10,
         "endColumn": 21,
-        "endLine": 38,
-        "line": 38,
+        "endLine": 39,
+        "line": 39,
         "message": "'_otherCases' is defined but never used.",
         "messageId": "unusedVar",
         "nodeType": "Identifier",
@@ -23,8 +23,8 @@ exports[`flat-config-types-@types__eslint-v9 > eslint > should work successfully
       {
         "column": 5,
         "endColumn": 24,
-        "endLine": 55,
-        "line": 55,
+        "endLine": 57,
+        "line": 57,
         "message": "Include a description after the "@ts-expect-error" directive to explain why the @ts-expect-error is necessary. The description must be 3 characters or longer.",
         "messageId": "tsDirectiveCommentRequiresDescription",
         "nodeType": "Line",
@@ -34,8 +34,8 @@ exports[`flat-config-types-@types__eslint-v9 > eslint > should work successfully
       {
         "column": 5,
         "endColumn": 24,
-        "endLine": 60,
-        "line": 60,
+        "endLine": 62,
+        "line": 62,
         "message": "Include a description after the "@ts-expect-error" directive to explain why the @ts-expect-error is necessary. The description must be 3 characters or longer.",
         "messageId": "tsDirectiveCommentRequiresDescription",
         "nodeType": "Line",
@@ -70,6 +70,7 @@ export default tseslint.config(
   {
     plugins: {
       ['@typescript-eslint']: tseslint.plugin,
+      // @ts-expect-error -- plugins typed with pre-re-anchoring @typescript-eslint/utils types are no longer assignable to the flat config plugin types
       ['deprecation']: deprecationPlugin,
       ['vitest']: vitestPlugin,
     },
@@ -86,6 +87,7 @@ function _otherCases() {
     plugins: {
       ['@stylistic']: stylisticPlugin,
       ['@typescript-eslint']: tseslint.plugin,
+      // @ts-expect-error -- plugins typed with pre-re-anchoring @typescript-eslint/utils types are no longer assignable to the flat config plugin types
       ['deprecation']: deprecationPlugin,
       ['vitest']: vitestPlugin,
     },

--- a/packages/integration-tests/tests/__snapshots__/ts-eslint-11543.test.ts.snap
+++ b/packages/integration-tests/tests/__snapshots__/ts-eslint-11543.test.ts.snap
@@ -1,0 +1,17 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ts-eslint-11543 > eslint > should work successfully 1`] = `
+[
+  {
+    "errorCount": 0,
+    "fatalErrorCount": 0,
+    "filePath": "<root>/eslint.config.js",
+    "fixableErrorCount": 0,
+    "fixableWarningCount": 0,
+    "messages": [],
+    "suppressedMessages": [],
+    "usedDeprecatedRules": [],
+    "warningCount": 0,
+  },
+]
+`;

--- a/packages/integration-tests/tests/ts-eslint-11543.test.ts
+++ b/packages/integration-tests/tests/ts-eslint-11543.test.ts
@@ -1,0 +1,41 @@
+import {
+  eslintIntegrationTest,
+  typescriptIntegrationTest,
+} from '../tools/integration-test-base';
+
+for (const additionalFlags of [
+  [],
+  ['--strictNullChecks'],
+  ['--strictNullChecks', '--exactOptionalPropertyTypes'],
+]) {
+  typescriptIntegrationTest(
+    `typescript${
+      additionalFlags.length ? ` with ${additionalFlags.join(', ')}` : ''
+    } without #11543 workarounds`,
+    __filename,
+    ['--allowJs', '--esModuleInterop', ...additionalFlags, 'eslint.config.js'],
+    out => {
+      const lines = out.split('\n').filter(
+        line =>
+          line &&
+          // error TS18028: Private identifiers are only available when targeting ECMAScript 2015 and higher.
+          // this is fine for us to ignore in this context
+          !line.includes('error TS18028'),
+      );
+
+      // The types should not error (https://github.com/typescript-eslint/typescript-eslint/issues/11543)
+      expect(lines).toHaveLength(0);
+    },
+  );
+}
+
+typescriptIntegrationTest(
+  'typescript reports TS2578 for the now-unneeded #11543 workaround directive',
+  __filename,
+  ['--allowJs', '--esModuleInterop', 'ts2578.config.js'],
+  out => {
+    expect(out).toContain('error TS2578');
+  },
+);
+
+eslintIntegrationTest(__filename, 'eslint.config.js');

--- a/packages/rule-tester/src/RuleTester.ts
+++ b/packages/rule-tester/src/RuleTester.ts
@@ -432,8 +432,7 @@ export class RuleTester extends TestFramework {
       create(context): RuleListener {
         freezeDeeply(context.options);
         freezeDeeply(context.settings);
-        // eslint-disable-next-line @typescript-eslint/no-deprecated -- For compatibility with ESLint 8
-        freezeDeeply(context.parserOptions);
+        freezeDeeply((context as { parserOptions?: object }).parserOptions);
 
         return (typeof rule === 'function' ? rule : rule.create)(context);
       },

--- a/packages/typescript-eslint/src/compatibility-types.ts
+++ b/packages/typescript-eslint/src/compatibility-types.ts
@@ -1,25 +1,20 @@
 /*
- * This file contains types that are intentionally wide/inaccurate, that exist
- * for the purpose of satisfying both `defineConfig()` and `tseslint.config()`.
- * See https://github.com/typescript-eslint/typescript-eslint/issues/10899
+ * Types for values that need to satisfy both `defineConfig()` and
+ * `tseslint.config()`.
+ *
+ * These used to be intentionally wide/inaccurate to paper over the gap between
+ * our types and ESLint's (see
+ * https://github.com/typescript-eslint/typescript-eslint/issues/10899).
+ * Our flat-config types are now anchored on `@eslint/core`, so the compatible
+ * types are aliases of the re-anchored types (see
+ * https://github.com/typescript-eslint/typescript-eslint/issues/11543).
  */
+import type { TSESLint } from '@typescript-eslint/utils';
 
-export interface CompatibleParser {
-  parseForESLint(text: string): {
-    ast: unknown;
-    scopeManager: unknown;
-  };
-}
+export type CompatibleParser = TSESLint.FlatConfig.Parser;
 
-export interface CompatibleConfig {
-  name?: string;
-  rules?: object;
-}
+export type CompatibleConfig = TSESLint.FlatConfig.Config;
 
-export type CompatibleConfigArray = CompatibleConfig[];
+export type CompatibleConfigArray = TSESLint.FlatConfig.ConfigArray;
 
-export interface CompatiblePlugin {
-  meta: {
-    name: string;
-  };
-}
+export type CompatiblePlugin = TSESLint.FlatConfig.Plugin;

--- a/packages/typescript-eslint/src/index.ts
+++ b/packages/typescript-eslint/src/index.ts
@@ -26,12 +26,7 @@ import pluginBase from '@typescript-eslint/eslint-plugin';
 import rawPlugin from '@typescript-eslint/eslint-plugin/use-at-your-own-risk/raw-plugin';
 import { addCandidateTSConfigRootDir } from '@typescript-eslint/typescript-estree';
 
-import type {
-  CompatibleConfig,
-  CompatibleConfigArray,
-  CompatibleParser,
-  CompatiblePlugin,
-} from './compatibility-types';
+import type { CompatibleParser, CompatiblePlugin } from './compatibility-types';
 
 import { config } from './config-helper';
 import { getTSConfigRootDirFromStack } from './getTSConfigRootDirFromStack';
@@ -40,7 +35,7 @@ import { extensions, globs } from './globs';
 export type { FlatConfig } from '@typescript-eslint/utils/ts-eslint';
 
 export const parser: CompatibleParser =
-  rawPlugin.parser as CompatibleParser satisfies FlatConfig.Parser;
+  rawPlugin.parser satisfies FlatConfig.Parser;
 
 /*
 we could build a plugin object here without the `configs` key - but if we do
@@ -65,30 +60,27 @@ use our new package); however legacy configs consumed via `@eslint/eslintrc`
 would never be able to satisfy this constraint and thus users would be blocked
 from using them.
 */
-export const plugin: CompatiblePlugin =
-  pluginBase satisfies FlatConfig.Plugins['string'];
+export const plugin: CompatiblePlugin = pluginBase satisfies FlatConfig.Plugin;
 
 export const configs = createConfigsGetters({
   /**
    * Enables each the rules provided as a part of typescript-eslint. Note that many rules are not applicable in all codebases, or are meant to be configured.
    * @see {@link https://typescript-eslint.io/users/configs#all}
    */
-  all: rawPlugin.flatConfigs['flat/all'] as CompatibleConfigArray,
+  all: rawPlugin.flatConfigs['flat/all'],
 
   /**
    * A minimal ruleset that sets only the required parser and plugin options needed to run typescript-eslint.
    * We don't recommend using this directly; instead, extend from an earlier recommended rule.
    * @see {@link https://typescript-eslint.io/users/configs#base}
    */
-  base: rawPlugin.flatConfigs['flat/base'] as CompatibleConfig,
+  base: rawPlugin.flatConfigs['flat/base'],
 
   /**
    * A utility ruleset that will disable type-aware linting and all type-aware rules available in our project.
    * @see {@link https://typescript-eslint.io/users/configs#disable-type-checked}
    */
-  disableTypeChecked: rawPlugin.flatConfigs[
-    'flat/disable-type-checked'
-  ] as CompatibleConfig,
+  disableTypeChecked: rawPlugin.flatConfigs['flat/disable-type-checked'],
 
   /**
    * This is a compatibility ruleset that:
@@ -96,77 +88,64 @@ export const configs = createConfigsGetters({
    * - enables rules that make sense due to TS's typechecking / transpilation.
    * @see {@link https://typescript-eslint.io/users/configs/#eslint-recommended}
    */
-  eslintRecommended: rawPlugin.flatConfigs[
-    'flat/eslint-recommended'
-  ] as CompatibleConfig,
+  eslintRecommended: rawPlugin.flatConfigs['flat/eslint-recommended'],
 
   /**
    * Recommended rules for code correctness that you can drop in without additional configuration.
    * @see {@link https://typescript-eslint.io/users/configs#recommended}
    */
-  recommended: rawPlugin.flatConfigs[
-    'flat/recommended'
-  ] as CompatibleConfigArray,
+  recommended: rawPlugin.flatConfigs['flat/recommended'],
 
   /**
    * Contains all of `recommended` along with additional recommended rules that require type information.
    * @see {@link https://typescript-eslint.io/users/configs#recommended-type-checked}
    */
-  recommendedTypeChecked: rawPlugin.flatConfigs[
-    'flat/recommended-type-checked'
-  ] as CompatibleConfigArray,
+  recommendedTypeChecked:
+    rawPlugin.flatConfigs['flat/recommended-type-checked'],
 
   /**
    * A version of `recommended` that only contains type-checked rules and disables of any corresponding core ESLint rules.
    * @see {@link https://typescript-eslint.io/users/configs#recommended-type-checked-only}
    */
-  recommendedTypeCheckedOnly: rawPlugin.flatConfigs[
-    'flat/recommended-type-checked-only'
-  ] as CompatibleConfigArray,
+  recommendedTypeCheckedOnly:
+    rawPlugin.flatConfigs['flat/recommended-type-checked-only'],
 
   /**
    * Contains all of `recommended`, as well as additional strict rules that can also catch bugs.
    * @see {@link https://typescript-eslint.io/users/configs#strict}
    */
-  strict: rawPlugin.flatConfigs['flat/strict'] as CompatibleConfigArray,
+  strict: rawPlugin.flatConfigs['flat/strict'],
 
   /**
    * Contains all of `recommended`, `recommended-type-checked`, and `strict`, along with additional strict rules that require type information.
    * @see {@link https://typescript-eslint.io/users/configs#strict-type-checked}
    */
-  strictTypeChecked: rawPlugin.flatConfigs[
-    'flat/strict-type-checked'
-  ] as CompatibleConfigArray,
+  strictTypeChecked: rawPlugin.flatConfigs['flat/strict-type-checked'],
 
   /**
    * A version of `strict` that only contains type-checked rules and disables of any corresponding core ESLint rules.
    * @see {@link https://typescript-eslint.io/users/configs#strict-type-checked-only}
    */
-  strictTypeCheckedOnly: rawPlugin.flatConfigs[
-    'flat/strict-type-checked-only'
-  ] as CompatibleConfigArray,
+  strictTypeCheckedOnly: rawPlugin.flatConfigs['flat/strict-type-checked-only'],
 
   /**
    * Rules considered to be best practice for modern TypeScript codebases, but that do not impact program logic.
    * @see {@link https://typescript-eslint.io/users/configs#stylistic}
    */
-  stylistic: rawPlugin.flatConfigs['flat/stylistic'] as CompatibleConfigArray,
+  stylistic: rawPlugin.flatConfigs['flat/stylistic'],
 
   /**
    * Contains all of `stylistic`, along with additional stylistic rules that require type information.
    * @see {@link https://typescript-eslint.io/users/configs#stylistic-type-checked}
    */
-  stylisticTypeChecked: rawPlugin.flatConfigs[
-    'flat/stylistic-type-checked'
-  ] as CompatibleConfigArray,
+  stylisticTypeChecked: rawPlugin.flatConfigs['flat/stylistic-type-checked'],
 
   /**
    * A version of `stylistic` that only contains type-checked rules and disables of any corresponding core ESLint rules.
    * @see {@link https://typescript-eslint.io/users/configs#stylistic-type-checked-only}
    */
-  stylisticTypeCheckedOnly: rawPlugin.flatConfigs[
-    'flat/stylistic-type-checked-only'
-  ] as CompatibleConfigArray,
+  stylisticTypeCheckedOnly:
+    rawPlugin.flatConfigs['flat/stylistic-type-checked-only'],
 }) satisfies Record<string, FlatConfig.Config | FlatConfig.ConfigArray>;
 
 function createConfigsGetters<T extends object>(values: T): T {

--- a/packages/typescript-eslint/tests/type-compatibility.test-d.ts
+++ b/packages/typescript-eslint/tests/type-compatibility.test-d.ts
@@ -1,8 +1,122 @@
+import type {
+  AnyRuleModuleWithMetaDocs,
+  EcmaVersion,
+  FlatConfig,
+  Parser,
+  ParserOptions,
+  RuleModuleWithMetaDocs,
+  SourceType,
+} from '@typescript-eslint/utils/ts-eslint';
+
+import { ESLintUtils } from '@typescript-eslint/utils';
 import { defineConfig } from 'eslint/config';
 
 import tseslint from '../src/index';
 
 /* eslint @typescript-eslint/no-deprecated: ["error", { "allow": [{ "from": "file", "name": "config", "path": "packages/typescript-eslint/src/config-helper.ts" }] }] */
+
+const createRule = ESLintUtils.RuleCreator(
+  ruleName => `https://example.com/rules/${ruleName}`,
+);
+
+const ruleWithDocs = createRule<
+  [{ alias: 'always' | 'never' }],
+  'avoidFoo' | 'suggestBar'
+>({
+  create(context) {
+    return {
+      Identifier(node) {
+        if (node.name === 'foo') {
+          context.report({ messageId: 'avoidFoo', node });
+        }
+      },
+    };
+  },
+  meta: {
+    docs: { description: 'Disallow foo identifiers.' },
+    hasSuggestions: true,
+    messages: { avoidFoo: 'Avoid foo.', suggestBar: 'Use bar instead.' },
+    schema: [],
+    type: 'suggestion',
+  },
+  name: 'no-foo',
+});
+
+const ruleWithReadonlyOptions = createRule<
+  readonly [{ readonly alias: 'always' | 'never' }],
+  'avoidFoo'
+>({
+  create(context) {
+    return {
+      Identifier(node) {
+        if (node.name === 'foo') {
+          context.report({ messageId: 'avoidFoo', node });
+        }
+      },
+    };
+  },
+  meta: {
+    docs: { description: 'Disallow foo identifiers.' },
+    messages: { avoidFoo: 'Avoid foo.' },
+    schema: [],
+    type: 'suggestion',
+  },
+  name: 'no-foo-readonly',
+});
+
+// Parameterisation probes for P-assign (generic identity of createNamedRule):
+// empty tuple / literal union elements / nested object elements.
+const ruleEmptyOptions = createRule<[], 'avoidFoo'>({
+  create: () => ({}),
+  meta: {
+    docs: { description: 'Disallow foo identifiers.' },
+    messages: { avoidFoo: 'Avoid foo.' },
+    schema: [],
+    type: 'suggestion',
+  },
+  name: 'no-foo-empty',
+});
+
+const ruleLiteralUnionOptions = createRule<['a' | 'b'], 'avoidFoo'>({
+  create: () => ({}),
+  meta: {
+    docs: { description: 'Disallow foo identifiers.' },
+    messages: { avoidFoo: 'Avoid foo.' },
+    schema: [],
+    type: 'suggestion',
+  },
+  name: 'no-foo-union',
+});
+
+const ruleNestedOptions = createRule<[{ inner: { deep: string } }], 'avoidFoo'>(
+  {
+    create: () => ({}),
+    meta: {
+      docs: { description: 'Disallow foo identifiers.' },
+      messages: { avoidFoo: 'Avoid foo.' },
+      schema: [],
+      type: 'suggestion',
+    },
+    name: 'no-foo-nested',
+  },
+);
+
+// The #11543 ecosystem pattern: a third-party plugin built from RuleCreator
+// outputs without any annotations (both CL-12 failure forms must pass).
+const inferredPlugin = {
+  meta: { name: 'example', version: '1.0.0' },
+  rules: {
+    'no-foo': ruleWithDocs,
+    'no-foo-readonly': ruleWithReadonlyOptions,
+  },
+};
+
+// The wide-typed record form (CL-12 failure form 2): rules annotated with the
+// wide public module type instead of inferred per-rule types.
+declare const wideTypedRule: RuleModuleWithMetaDocs<string, unknown[]>;
+const wideRules: Record<string, AnyRuleModuleWithMetaDocs> = {
+  'no-foo-wide': wideTypedRule,
+};
 
 describe('test for compatibility with config helpers', () => {
   test('exported plugin is compatible with tseslint.config()', () => {
@@ -47,5 +161,166 @@ describe('test for compatibility with config helpers', () => {
     defineConfig(tseslint.configs.recommendedTypeChecked);
     defineConfig(tseslint.configs.strict);
     defineConfig(tseslint.configs.eslintRecommended);
+  });
+});
+
+describe('RuleCreator outputs are compatible with config helpers (#11543)', () => {
+  test('RuleCreator output is compatible with defineConfig() rules position', () => {
+    defineConfig({
+      plugins: {
+        example: {
+          rules: {
+            'no-foo': ruleWithDocs,
+            'no-foo-readonly': ruleWithReadonlyOptions,
+          },
+        },
+      },
+      rules: { 'example/no-foo': 'error' },
+    });
+  });
+
+  test('RuleCreator output is compatible with tseslint.config() rules position', () => {
+    tseslint.config({
+      plugins: {
+        example: {
+          rules: {
+            'no-foo': ruleWithDocs,
+            'no-foo-readonly': ruleWithReadonlyOptions,
+          },
+        },
+      },
+      rules: { 'example/no-foo': 'error' },
+    });
+  });
+
+  test('inferred plugin from RuleCreator outputs is compatible with defineConfig()', () => {
+    defineConfig(
+      { plugins: { example: inferredPlugin } },
+      { rules: { 'example/no-foo': 'error' } },
+    );
+  });
+
+  test('inferred plugin from RuleCreator outputs is compatible with tseslint.config()', () => {
+    tseslint.config(
+      { plugins: { example: inferredPlugin } },
+      { rules: { 'example/no-foo': 'error' } },
+    );
+  });
+
+  test('widely-typed rules record is compatible with defineConfig()', () => {
+    defineConfig({
+      plugins: {
+        example: {
+          rules: wideRules,
+        },
+      },
+    });
+  });
+
+  test('parameterised RuleCreator instantiations are compatible with defineConfig()', () => {
+    defineConfig({
+      plugins: {
+        example: {
+          rules: {
+            'no-foo-empty': ruleEmptyOptions,
+            'no-foo-nested': ruleNestedOptions,
+            'no-foo-union': ruleLiteralUnionOptions,
+          },
+        },
+      },
+    });
+  });
+});
+
+describe('exported configs compose with config helpers', () => {
+  test('configs are compatible with defineConfig() via spread', () => {
+    defineConfig(
+      ...tseslint.configs.recommended,
+      ...tseslint.configs.recommendedTypeChecked,
+    );
+  });
+
+  test('configs are compatible with tseslint.config() via spread', () => {
+    tseslint.config(
+      ...tseslint.configs.recommended,
+      ...tseslint.configs.recommendedTypeChecked,
+    );
+  });
+
+  test('configs are compatible with defineConfig() via extends', () => {
+    defineConfig({
+      extends: [
+        tseslint.configs.eslintRecommended,
+        ...tseslint.configs.recommendedTypeChecked,
+      ],
+    });
+  });
+
+  test('configs are compatible with tseslint.config() via extends', () => {
+    tseslint.config({
+      extends: [
+        tseslint.configs.eslintRecommended,
+        ...tseslint.configs.recommendedTypeChecked,
+      ],
+    });
+  });
+});
+
+describe('direct TSESLint.FlatConfig annotations are compatible with config helpers', () => {
+  const annotatedPlugin: FlatConfig.Plugin = { rules: {} };
+  const annotatedParser: FlatConfig.Parser = {
+    parseForESLint: () => ({ ast: {} }),
+  };
+  const annotatedConfig: FlatConfig.Config = {
+    languageOptions: { parser: annotatedParser },
+  };
+
+  test('annotated values are compatible with defineConfig()', () => {
+    defineConfig({
+      plugins: { annotated: annotatedPlugin },
+      ...annotatedConfig,
+    });
+  });
+
+  test('annotated values are compatible with tseslint.config()', () => {
+    tseslint.config({
+      plugins: { annotated: annotatedPlugin },
+      ...annotatedConfig,
+    });
+  });
+});
+
+describe('FlatConfig.LanguageOptions is assignable to the core Record plane', () => {
+  test('language options values are assignable to Record<string, unknown>', () => {
+    expectTypeOf<FlatConfig.LanguageOptions>().toExtend<
+      Record<string, unknown>
+    >();
+
+    const languageOptions: FlatConfig.LanguageOptions = {
+      ecmaVersion: 'latest',
+      globals: { window: 'readonly' },
+      sourceType: 'module',
+    };
+    const record: Record<string, unknown> = languageOptions;
+    expectTypeOf(record).toExtend<Record<string, unknown>>();
+
+    // tseslint refinements are preserved on the hub; expected shapes come
+    // from the origin type definitions, not from the hub itself, so an
+    // accidental widening during re-anchoring fails here
+    expectTypeOf(languageOptions.ecmaVersion).toEqualTypeOf<
+      EcmaVersion | undefined
+    >();
+    expectTypeOf(languageOptions.parser).toEqualTypeOf<
+      Parser.LooseParserModule | undefined
+    >();
+    expectTypeOf(languageOptions.parserOptions).toEqualTypeOf<
+      ParserOptions | undefined
+    >();
+    expectTypeOf(languageOptions.sourceType).toEqualTypeOf<
+      SourceType | undefined
+    >();
+    expectTypeOf(languageOptions.globals).toEqualTypeOf<
+      FlatConfig.GlobalsConfig | undefined
+    >();
   });
 });

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -62,6 +62,7 @@
   },
   "dependencies": {
     "@eslint-community/eslint-utils": "^4.9.1",
+    "@eslint/core": "^1.2.1",
     "@typescript-eslint/scope-manager": "workspace:*",
     "@typescript-eslint/types": "workspace:*",
     "@typescript-eslint/typescript-estree": "workspace:*"

--- a/packages/utils/src/eslint-utils/RuleCreator.ts
+++ b/packages/utils/src/eslint-utils/RuleCreator.ts
@@ -1,8 +1,13 @@
+import type * as core from '@eslint/core';
+
 import type {
+  MutableOptions,
   RuleContext,
   RuleListener,
+  RuleListenerWithCoreVisitor,
   RuleMetaData,
   RuleMetaDataDocs,
+  RuleMetaDataWithMutableDefaults,
   RuleModule,
 } from '../ts-eslint/Rule';
 
@@ -49,12 +54,30 @@ export interface RuleWithMetaAndName<
   name: string;
 }
 
-type RuleModuleWithName<
+export interface RuleModuleCoreView<
   MessageIds extends string,
   Options extends readonly unknown[] = [],
   Docs = unknown,
-  ExtendedRuleListener extends RuleListener = RuleListener,
-> = RuleModule<MessageIds, Options, Docs, ExtendedRuleListener> & {
+> {
+  /* eslint-disable @typescript-eslint/unified-signatures -- the overload pair is load-bearing: a single union parameter would leak the union into literal implementations and break contextual typing of rule visitors */
+  create(context: core.RuleContext): RuleListenerWithCoreVisitor;
+  create(
+    context: Readonly<RuleContext<MessageIds, Options>>,
+  ): RuleListenerWithCoreVisitor;
+  /* eslint-enable @typescript-eslint/unified-signatures */
+  /**
+   * @deprecated Use meta.defaultOptions instead
+   * Default options the rule will be run with
+   */
+  defaultOptions?: MutableOptions<Options>;
+  meta: RuleMetaDataWithMutableDefaults<MessageIds, Docs, Options>;
+  name?: string;
+}
+export type RuleModuleWithName<
+  MessageIds extends string,
+  Options extends readonly unknown[] = [],
+  Docs = unknown,
+> = RuleModuleCoreView<MessageIds, Options, Docs> & {
   name: string;
 };
 
@@ -106,24 +129,34 @@ function createRule<
   defaultOptions,
   meta,
   name,
-}: Readonly<RuleWithMeta<Options, MessageIds, PluginDocs>>): RuleModule<
+}: Readonly<RuleWithMeta<Options, MessageIds, PluginDocs>>): RuleModuleCoreView<
   MessageIds,
   Options,
   PluginDocs
 > {
   const resolvedDefaultOptions = (meta.defaultOptions ??
     defaultOptions ??
-    []) as Readonly<Options>;
+    []) as MutableOptions<Options>;
   return {
-    create(context: Readonly<RuleContext<MessageIds, Options>>): RuleListener {
+    create(
+      context: core.RuleContext | Readonly<RuleContext<MessageIds, Options>>,
+    ): RuleListenerWithCoreVisitor {
       const optionsWithDefault = applyDefault(
         resolvedDefaultOptions,
         context.options,
       );
-      return create(context, optionsWithDefault);
+      return create(
+        context as Readonly<RuleContext<MessageIds, Options>>,
+        optionsWithDefault,
+      ) as RuleListenerWithCoreVisitor satisfies RuleListener;
     },
     defaultOptions,
-    meta,
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- the cast strips the readonly modifier from defaultOptions; the lint rule does not model readonly-only differences
+    meta: meta as unknown as RuleMetaDataWithMutableDefaults<
+      MessageIds,
+      PluginDocs,
+      Options
+    > satisfies RuleMetaData<MessageIds, PluginDocs, Options>,
     name,
   };
 }

--- a/packages/utils/src/eslint-utils/getParserServices.ts
+++ b/packages/utils/src/eslint-utils/getParserServices.ts
@@ -61,9 +61,7 @@ export function getParserServices(
   context: Readonly<TSESLint.RuleContext<string, unknown[]>>,
   allowWithoutFullTypeInformation = false,
 ): ParserServices {
-  const parser =
-    // eslint-disable-next-line @typescript-eslint/no-deprecated -- For compatibility with ESLint 8
-    context.parserPath || context.languageOptions.parser?.meta?.name;
+  const parser = context.languageOptions.parser?.meta?.name;
 
   // This check is unnecessary if the user is using the latest version of our parser.
   //

--- a/packages/utils/src/ts-eslint/Config.ts
+++ b/packages/utils/src/ts-eslint/Config.ts
@@ -1,9 +1,14 @@
 /* eslint-disable  @typescript-eslint/consistent-indexed-object-style,  @typescript-eslint/no-namespace */
 
+import type * as core from '@eslint/core';
+
 import type { Parser as ParserType } from './Parser';
 import type * as ParserOptionsTypes from './ParserOptions';
 import type { Processor as ProcessorType } from './Processor';
-import type { LooseRuleDefinition, SharedConfigurationSettings } from './Rule';
+import type {
+  LooseRuleDefinitionObject,
+  SharedConfigurationSettings,
+} from './Rule';
 
 /** @internal */
 export namespace SharedConfig {
@@ -95,7 +100,7 @@ export namespace ClassicConfig {
     /**
      * The path to a parser or the package name of a parser.
      */
-    parser?: string | null;
+    parser?: string;
     /**
      * The parser options.
      */
@@ -156,7 +161,7 @@ export namespace FlatConfig {
   export type SourceType = 'commonjs' | ParserOptionsTypes.SourceType;
 
   export interface SharedConfigs {
-    [key: string]: Config | ConfigArray;
+    [key: string]: Config | ConfigArray | core.LegacyConfigObject;
   }
   export interface Plugin {
     /**
@@ -172,14 +177,14 @@ export namespace FlatConfig {
      * The definition of plugin processors.
      * Users can stringly reference the processor using the key in their config (i.e., `"pluginName/processorName"`).
      */
-    processors?: Partial<Record<string, Processor>> | undefined;
+    processors?: Record<string, Processor> | undefined;
     /**
      * The definition of plugin rules.
      * The key must be the name of the rule that users will use
      * Users can stringly reference the rule using the key they registered the plugin under combined with the rule name.
      * i.e. for the user config `plugins: { foo: pluginReference }` - the reference would be `"foo/ruleName"`.
      */
-    rules?: Record<string, LooseRuleDefinition> | undefined;
+    rules?: Record<string, LooseRuleDefinitionObject> | undefined;
   }
   export interface Plugins {
     /**
@@ -216,6 +221,13 @@ export namespace FlatConfig {
   }
 
   export interface LanguageOptions {
+    /**
+     * Plugin-defined options for the language.
+     * Allows any plugin-specific keys; `@eslint/core`'s `LanguageOptions` is
+     * `Record<string, unknown>`, and this index signature keeps values of this
+     * type assignable to core config positions without casts.
+     */
+    [key: string]: unknown;
     /**
      * The version of ECMAScript to support.
      * May be any year (i.e., `2022`) or version (i.e., `5`).

--- a/packages/utils/src/ts-eslint/Rule.ts
+++ b/packages/utils/src/ts-eslint/Rule.ts
@@ -1,9 +1,9 @@
+import type * as core from '@eslint/core';
+
 import type { JSONSchema4 } from '../json-schema';
-import type { ParserServices, TSESTree } from '../ts-estree';
+import type { TSESTree } from '../ts-estree';
 import type { AST } from './AST';
 import type { FlatConfig } from './Config';
-import type { Linter } from './Linter';
-import type { Scope } from './Scope';
 import type { SourceCode } from './SourceCode';
 
 export type RuleRecommendation = 'recommended' | 'strict' | 'stylistic';
@@ -279,6 +279,14 @@ export interface SharedConfigurationSettings {
   [name: string]: unknown;
 }
 
+/**
+ * The language options as seen by a rule: the flat-config language options
+ * with `parserOptions` guaranteed to be present.
+ */
+export interface RuleContextLanguageOptions extends FlatConfig.LanguageOptions {
+  parserOptions: FlatConfig.ParserOptions;
+}
+
 export interface RuleContext<
   MessageIds extends string,
   Options extends readonly unknown[],
@@ -290,61 +298,17 @@ export interface RuleContext<
   /**
    * The language options configured for this run
    */
-  languageOptions: FlatConfig.LanguageOptions & {
-    parserOptions: FlatConfig.ParserOptions;
-  };
+  languageOptions: RuleContextLanguageOptions;
   /**
    * An array of the configured options for this rule.
    * This array does not include the rule severity.
    */
   options: Options;
   /**
-   * The parser options configured for this run
-   * @deprecated This was deprecated in ESLint 9 and removed in ESLint 10.
-   */
-  parserOptions: Linter.ParserOptions;
-  /**
-   * The name of the parser from configuration, if in eslintrc (legacy) config.
-   * @deprecated This was deprecated in ESLint 9 and removed in ESLint 10.
-   */
-  parserPath: string | undefined;
-  /**
-   * An object containing parser-provided services for rules
-   *
-   * @deprecated in favor of `SourceCode#parserServices`
-   */
-  parserServices?: ParserServices;
-  /**
    * The shared settings from configuration.
    * We do not have any shared settings in this plugin.
    */
   settings: SharedConfigurationSettings;
-
-  // Deprecated members
-
-  /**
-   * Returns an array of the ancestors of the currently-traversed node, starting at
-   * the root of the AST and continuing through the direct parent of the current node.
-   * This array does not include the currently-traversed node itself.
-   *
-   * @deprecated in favor of `SourceCode#getAncestors`
-   */
-  getAncestors(): TSESTree.Node[];
-
-  /**
-   * Returns a list of variables declared by the given node.
-   * This information can be used to track references to variables.
-   *
-   * @deprecated in favor of `SourceCode#getDeclaredVariables`
-   */
-  getDeclaredVariables(node: TSESTree.Node): readonly Scope.Variable[];
-
-  /**
-   * Returns the current working directory passed to Linter.
-   * It is a path to a directory that should be considered as the current working directory.
-   * @deprecated in favor of `RuleContext#cwd`
-   */
-  getCwd(): string;
 
   /**
    * The current working directory passed to Linter.
@@ -353,22 +317,9 @@ export interface RuleContext<
   cwd: string;
 
   /**
-   * Returns the filename associated with the source.
-   *
-   * @deprecated in favor of `RuleContext#filename`
-   */
-  getFilename(): string;
-
-  /**
    * The filename associated with the source.
    */
   filename: string;
-
-  /**
-   * Returns the full path of the file on disk without any code block information (unlike `getFilename()`).
-   * @deprecated in favor of `RuleContext#physicalFilename`
-   */
-  getPhysicalFilename(): string;
 
   /**
    * The full path of the file on disk without any code block information (unlike `filename`).
@@ -376,34 +327,10 @@ export interface RuleContext<
   physicalFilename: string;
 
   /**
-   * Returns the scope of the currently-traversed node.
-   * This information can be used track references to variables.
-   *
-   * @deprecated in favor of `SourceCode#getScope`
-   */
-  getScope(): Scope.Scope;
-
-  /**
-   * Returns a SourceCode object that you can use to work with the source that
-   * was passed to ESLint.
-   *
-   * @deprecated in favor of `RuleContext#sourceCode`
-   */
-  getSourceCode(): Readonly<SourceCode>;
-
-  /**
    * A SourceCode object that you can use to work with the source that
    * was passed to ESLint.
    */
   sourceCode: Readonly<SourceCode>;
-
-  /**
-   * Marks a variable with the given name in the current scope as used.
-   * This affects the no-unused-vars rule.
-   *
-   * @deprecated in favor of `SourceCode#markVariableAsUsed`
-   */
-  markVariableAsUsed(name: string): boolean;
 
   /**
    * Reports a problem in the code.
@@ -423,13 +350,6 @@ export interface RuleContext<
 export interface CodePath {
   /** Code paths of functions this code path contains. */
   childCodePaths: CodePath[];
-
-  /**
-   * Segments of the current traversal position.
-   *
-   * @deprecated
-   */
-  currentSegments: CodePathSegment[];
 
   /** The final segments which includes both returned and thrown. */
   finalSegments: CodePathSegment[];
@@ -777,15 +697,53 @@ export interface RuleModuleWithMetaDocs<
   ExtendedRuleListener extends RuleListener = RuleListener,
 > extends RuleModule<MessageIds, Options, Docs, ExtendedRuleListener> {
   /**
+   * Function which returns an object with methods that ESLint calls to “visit”
+   * nodes while traversing the abstract syntax tree.
+   *
+   * The return type is narrowed to a core-compatible view so that rules
+   * annotated with this type are assignable to `@eslint/core`'s
+   * `RuleDefinition` (flat config plugins positions).
+   */
+  create(
+    context: Readonly<RuleContext<MessageIds, Options>>,
+  ): ExtendedRuleListener & core.RuleVisitor;
+  /**
    * Metadata about the rule
    */
   meta: RuleMetaDataWithDocs<MessageIds, Docs, Options>;
 }
 
-export type AnyRuleModuleWithMetaDocs = RuleModuleWithMetaDocs<
-  string,
-  unknown[]
->;
+/**
+ * A wide view of {@link RuleModuleWithMetaDocs} that is assignable to
+ * `@eslint/core`'s `RuleDefinition`: annotating a rules record with this type
+ * keeps it usable in `defineConfig()` / `tseslint.config()` plugins positions.
+ */
+export type AnyRuleModuleWithMetaDocs = Omit<
+  RuleModuleWithMetaDocs<string, unknown[]>,
+  'create'
+> & {
+  create(
+    context: core.RuleContext | Readonly<RuleContext<string, unknown[]>>,
+  ): RuleListenerWithCoreVisitor;
+};
+
+/**
+ * A `RuleModuleWithMetaDocs` view whose overloaded `create` makes it assignable
+ * to `@eslint/core`'s `RuleDefinition` (flat config plugins positions) while
+ * remaining assignable to plain `RuleModule` positions.
+ */
+export interface RuleModuleWithMetaDocsAndCoreVisitor<
+  MessageIds extends string = string,
+  Options extends readonly unknown[] = unknown[],
+  Docs = unknown,
+  /* eslint-disable @typescript-eslint/unified-signatures -- the overload pair is load-bearing: a single union parameter would leak the union into literal implementations */
+> extends RuleModuleWithMetaDocs<MessageIds, Options, Docs> {
+  create(context: core.RuleContext): RuleListenerWithCoreVisitor;
+  create(
+    context: Readonly<RuleContext<MessageIds, Options>>,
+  ): RuleListenerWithCoreVisitor;
+}
+/* eslint-enable @typescript-eslint/unified-signatures */
 
 /**
  * A loose definition of the RuleModule type for use with configs. This type is
@@ -801,11 +759,17 @@ export type AnyRuleModuleWithMetaDocs = RuleModuleWithMetaDocs<
  */
 export type LooseRuleDefinition =
   // TODO - remove RuleCreateFunction once we no longer support ESLint 8
-  | LooseRuleCreateFunction
-  | {
-      create: LooseRuleCreateFunction;
-      meta?: object | undefined;
-    };
+  LooseRuleCreateFunction | LooseRuleDefinitionObject;
+
+/**
+ * The object variant of {@link LooseRuleDefinition}: the only variant that is
+ * assignable to `@eslint/core`'s `RuleDefinition` (the flat-config `rules`
+ * record requires an object with a `create` method).
+ */
+export interface LooseRuleDefinitionObject {
+  create: LooseRuleCreateFunction;
+  meta?: object;
+}
 /*
 eslint-disable-next-line @typescript-eslint/no-explicit-any --
 intentionally using `any` to allow bi-directional assignment (unknown and
@@ -814,12 +778,12 @@ never only allow unidirectional)
 export type LooseRuleCreateFunction = (context: any) => Record<
   string,
   /*
-  eslint-disable-next-line @typescript-eslint/no-unsafe-function-type --
-  intentionally use Function here to give us the basic "is a function" validation
-  without enforcing specific argument types so that different AST types can still
-  be passed to configs
+  eslint-disable-next-line @typescript-eslint/no-explicit-any --
+  intentionally use a generic function signature with `any` args to give us the
+  basic "is a function" validation without enforcing specific argument types so
+  that different AST types can still be passed to configs
   */
-  Function | undefined
+  ((...args: any[]) => void) | undefined
 >;
 
 export type RuleCreateFunction<
@@ -830,3 +794,32 @@ export type AnyRuleCreateFunction = RuleCreateFunction<
   string,
   readonly unknown[]
 >;
+
+/**
+ * A `RuleListener` view that is also assignable to `@eslint/core`'s
+ * `RuleVisitor` positions. The strict `RuleListener` semantics are preserved;
+ * the intersection only adds the core-compatible index signature.
+ */
+export type RuleListenerWithCoreVisitor = RuleListener & core.RuleVisitor;
+
+/**
+ * A mutable view of a (possibly readonly) options tuple.
+ * `@eslint/core`'s `RuleDefinition.meta.defaultOptions` uses mutable arrays,
+ * while our `RuleMetaData` keeps options readonly.
+ */
+export type MutableOptions<Options extends readonly unknown[]> = {
+  -readonly [K in keyof Options]: Options[K];
+};
+
+/**
+ * `RuleMetaData` with a mutable view of `defaultOptions`, making rule metadata
+ * assignable to `@eslint/core`'s `RulesMeta` (which uses mutable arrays)
+ * without weakening the readonly guarantee of {@link RuleMetaData} itself.
+ */
+export interface RuleMetaDataWithMutableDefaults<
+  MessageIds extends string,
+  PluginDocs = unknown,
+  Options extends readonly unknown[] = [],
+> extends RuleMetaData<MessageIds, PluginDocs, Options> {
+  defaultOptions?: MutableOptions<Options>;
+}

--- a/packages/utils/tests/eslint-utils/getParserServices.test.ts
+++ b/packages/utils/tests/eslint-utils/getParserServices.test.ts
@@ -8,7 +8,14 @@ import { ESLintUtils } from '../../src';
 type UnknownRuleContext = Readonly<TSESLint.RuleContext<string, unknown[]>>;
 
 const defaults = {
-  parserPath: '@typescript-eslint/parser/dist/index.js',
+  languageOptions: {
+    parser: {
+      meta: {
+        name: '@typescript-eslint/parser/dist/index.js',
+      },
+    } as FlatConfig.Parser,
+    parserOptions: {},
+  },
   sourceCode: {
     parserServices: {
       esTreeNodeToTSNodeMap: new Map<TSESTree.Node, ts.Node>(),
@@ -63,7 +70,6 @@ describe(ESLintUtils.getParserServices, () => {
         } as FlatConfig.Parser,
         parserOptions: {},
       },
-      parserPath: undefined,
       sourceCode: {
         ...defaults.sourceCode,
         parserServices: {
@@ -81,7 +87,6 @@ describe(ESLintUtils.getParserServices, () => {
   it('throws a standard error with an unknown parser when parserOptions.esTreeNodeToTSNodeMap is missing and the parser is missing', () => {
     const context = createMockRuleContext({
       languageOptions: { parserOptions: {} },
-      parserPath: undefined,
       sourceCode: {
         ...defaults.sourceCode,
         parserServices: {
@@ -102,7 +107,6 @@ describe(ESLintUtils.getParserServices, () => {
         parser: {} as FlatConfig.Parser,
         parserOptions: {},
       },
-      parserPath: undefined,
       sourceCode: {
         ...defaults.sourceCode,
         parserServices: {
@@ -119,7 +123,14 @@ describe(ESLintUtils.getParserServices, () => {
 
   it('throws an augment error when parserOptions.esTreeNodeToTSNodeMap is missing and the parser is unknown', () => {
     const context = createMockRuleContext({
-      parserPath: '@babel/parser.js',
+      languageOptions: {
+        parser: {
+          meta: {
+            name: '@babel/parser.js',
+          },
+        } as FlatConfig.Parser,
+        parserOptions: {},
+      },
       sourceCode: {
         ...defaults.sourceCode,
         parserServices: {

--- a/packages/utils/tests/ts-eslint/Rule.test-d.ts
+++ b/packages/utils/tests/ts-eslint/Rule.test-d.ts
@@ -1,6 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/types';
 
-import type { RuleListener } from '../../src/ts-eslint';
+import type { CodePath, RuleContext, RuleListener } from '../../src/ts-eslint';
 
 type RuleListenerKeysWithoutIndexSignature = {
   [K in keyof RuleListener as string extends K ? never : K]: K;
@@ -29,4 +29,42 @@ test('type tests', () => {
   expectTypeOf<RuleListenerSelectors>().exclude<AllSelectors>().toBeNever();
 
   expectTypeOf<AllSelectors>().exclude<RuleListenerSelectors>().toBeNever();
+});
+
+declare const context: RuleContext<'messageId', [{ option: string }]>;
+declare const codePath: CodePath;
+
+test('removed ESLint 10 RuleContext members are no longer accessible (#11371)', () => {
+  // @ts-expect-error -- parserOptions was removed in ESLint 10
+  void context.parserOptions;
+  // @ts-expect-error -- parserPath was removed in ESLint 10
+  void context.parserPath;
+  // @ts-expect-error -- parserServices was removed in ESLint 10
+  void context.parserServices;
+  // @ts-expect-error -- getAncestors was removed in ESLint 10
+  void context.getAncestors;
+  // @ts-expect-error -- getDeclaredVariables was removed in ESLint 10
+  void context.getDeclaredVariables;
+  // @ts-expect-error -- getCwd was removed in ESLint 10
+  void context.getCwd;
+  // @ts-expect-error -- getFilename was removed in ESLint 10
+  void context.getFilename;
+  // @ts-expect-error -- getPhysicalFilename was removed in ESLint 10
+  void context.getPhysicalFilename;
+  // @ts-expect-error -- getScope was removed in ESLint 10
+  void context.getScope;
+  // @ts-expect-error -- getSourceCode was removed in ESLint 10
+  void context.getSourceCode;
+  // @ts-expect-error -- markVariableAsUsed was removed in ESLint 10
+  void context.markVariableAsUsed;
+  // @ts-expect-error -- CodePath#currentSegments was removed in ESLint 10
+  void codePath.currentSegments;
+
+  // live replacement members remain present
+  expectTypeOf(context).toHaveProperty('cwd');
+  expectTypeOf(context).toHaveProperty('filename');
+  expectTypeOf(context).toHaveProperty('physicalFilename');
+  expectTypeOf(context).toHaveProperty('sourceCode');
+  expectTypeOf(context).toHaveProperty('report');
+  expectTypeOf(context).toHaveProperty('languageOptions');
 });

--- a/packages/website/sidebars/sidebar.base.js
+++ b/packages/website/sidebars/sidebar.base.js
@@ -74,6 +74,7 @@ module.exports = {
       items: [
         'users/configs',
         'users/dependency-versions',
+        'users/migrating-to-v9',
         'users/releases',
         'users/versioning',
         'users/what-about-formatting',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -924,6 +924,9 @@ importers:
       '@eslint-community/eslint-utils':
         specifier: ^4.9.1
         version: 4.10.1(eslint@10.8.1(jiti@2.7.0))
+      '@eslint/core':
+        specifier: ^1.2.1
+        version: 1.2.1
       '@typescript-eslint/scope-manager':
         specifier: workspace:*
         version: link:../scope-manager


### PR DESCRIPTION
BREAKING CHANGE: the public authoring types of `@typescript-eslint/utils` and `typescript-eslint` are re-anchored on `@eslint/core`; the twelve rule-context typings ESLint 10 removed at runtime are deleted. See the Breaking changes table below and `docs/users/Migrating_To_v9.mdx`.

## PR Checklist

- [x] Addresses an existing open issue: fixes #11543, closes #11371
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

Plugins built with `ESLintUtils.RuleCreator` work perfectly at runtime — and fail type-checking the moment they enter `defineConfig()`. The reason is a split that has been growing for years: `@typescript-eslint/utils` maintains its own flat-config type universe (`TSESLint.FlatConfig.*`), which drifted away from the types ESLint ships and consumes today. Both definitions are individually reasonable; together they disagree, and plugin authors pay for it — usually with `@ts-expect-error` comments or a forked rule creator.

This PR closes the split at the root. The public authoring types — `RuleCreator` outputs, `FlatConfig.Plugin/Parser/Config`, and the configs `typescript-eslint` exports — are re-anchored on `@eslint/core`, the runtime-agnostic protocol package ESLint itself is built on. Along the way it removes the typings of the twelve rule-context members that ESLint 10 already deleted at runtime (#11371): eleven `RuleContext` members plus `CodePath#currentSegments` — a superset of the in-flight #11386, with thanks to @cseas whose approved PR covers four of them.

This is a type-only change, with one observable runtime string: the `getParserServices` error message on eslint 8/9 eslintrc setups, where the removed `parserPath` fallback previously named the parser (it now reads `'(unknown)'`). Everything else — including the `RuleTester` deep-freeze behaviour — is unchanged, and the full unit suites pass, matching `main`'s results (the test updates they require are part of this PR).

### Why this solution

- **A "better bridge type" between the two universes does not exist.** The definitions diverged on shape, not on fixable details — any type satisfying both is either empty or too vague to be useful (the #10899 exploration kept arriving at bridge types too vague to be useful). The durable fix is one authority, not a smarter translator.
- **`@eslint/core` is where the ecosystem is heading.** ESLint's own config entry points already consume these types, and anchoring on `core` as a regular dependency means our types resolve from our own `node_modules` — consumers on any supported eslint major get one consistent answer.
- **It follows the direction this repo already set.** The change moves the type half of #11939 forward: the `Rule`/`Config` type layer no longer derives its shapes from peer-`eslint` types (`Rule.ts` drops its `Linter`/`Scope` imports). The runtime `eslint` imports that #11939 also targets (the `Linter`/`SourceCode`/`RuleTester` class extends) are untouched. It extends the ghost-typings cleanup of #11386, and executes the plan agreed in the #11543 discussion.
- **Precision is not sacrificed.** `RuleCreator`'s input side, readonly `meta.defaultOptions`, and the strict `RuleListener` stay exactly as they are. The re-anchor needs exactly two narrow `satisfies`-guarded casts at the export boundary — a single `as unknown as … satisfies` on `meta` (readonly tuple → mutable default options) and a single `as … satisfies` on the `create` return; everything else is structural.

### How to read this PR

**The contract** (start here): `packages/utils/src/ts-eslint/Config.ts` — `LanguageOptions` gains an index signature; this is the keystone that makes configs, plugin objects and parser values assignable to `@eslint/core` positions. `packages/utils/src/ts-eslint/Rule.ts` — `RuleContext` re-anchored, the twelve ghost members removed. `packages/utils/src/eslint-utils/RuleCreator.ts` — the rule exit type follows core; contains the two sanctioned `satisfies`-guarded casts. `packages/typescript-eslint/src/index.ts` + `compatibility-types.ts` — most of the #11475 scaffolding retires: our own exports now pass both entries natively.

**The proof**: `packages/typescript-eslint/tests/type-compatibility.test-d.ts` (+275 lines, 19 tests) — everything consumers do with plugins, configs and parser values × `defineConfig()` and `tseslint.config()`, including `extends` and spread composition; if you read one file in this PR, read this one. `packages/integration-tests/{fixtures,tests}/ts-eslint-11543*` — a mini plugin built on `RuleCreator` compiles with zero type errors (the harness ignores one unrelated ES-target error), and a negative arm asserts the old `@ts-expect-error …/issues/11543` workaround now surfaces as `TS2578`. `packages/utils/tests/ts-eslint/Rule.test-d.ts` — assigning each removed member is now a compile error (12 negatives). `docs/users/Migrating_To_v9.mdx` — the migration guide: a replacement table for all twelve members (signatures checked against `SourceCode`), the two typing boundaries, and the peer-range note.

**Smaller fixes the re-anchor forced**: `getParserServices` — the parser-name fallback read a member that no longer exists in types; it now reads `languageOptions.parser?.meta?.name`. `RuleTester` — the deep-freeze wrapper touched `context.parserOptions` via one local cast, type-only, freeze behaviour preserved for eslint 8/9 runtimes. `worksWithStringlyTypedExtends.test.ts` — two `@ts-expect-error` that documented the old incompatibility became unused and are removed. The `@types/eslint` v8/v9 integration stand and `rules.d.ts` are kept in sync with the new plugin type.

**Cosmetic**: sidebar entry for the guide; `@eslint/core` in `utils` deps + lockfile.

## Breaking changes

| Change | Migration |
| --- | --- |
| 12 removed `RuleContext`/`CodePath` members | `docs/users/Migrating_To_v9.mdx` — replacements: `cwd`, `filename`, `physicalFilename`, `sourceCode`, `languageOptions` |
| `FlatConfig.Plugin.rules` accepts object-form rule definitions only | annotate rule records with values created via `RuleCreator`, or `AnyRuleModuleWithMetaDocs` |
| `FlatConfig.Plugin.processors` no longer `Partial<…>` | unchanged for object literals; `Partial`-typed values need a cast |
| `ClassicConfig.Config.parser` no longer `string \| null` | omit `null` (core `LegacyConfigObject` parity) |
| plugins/configs typed against `@types/eslint` v8 shapes no longer assignable to flat config plugin types | update the dependency or keep a local cast (documented in the guide) |
| type layer no longer guarantees `@types/eslint` v8 compatibility (runtime peer range unchanged) | see the guide's peer-range section |

Note for release notes: existing `@ts-expect-error …/issues/11543` workarounds must be removed on upgrade, otherwise they surface as `TS2578`.

### What this buys the project

- **#11543 closes for the ecosystem, not just our exports.** Plugins built on `RuleCreator` — hundreds of public repositories, by GitHub code search — become `defineConfig`-compatible on upgrade, provided they don't rely on the twelve removed context members, function-style rule records, or third-party values typed against `@types/eslint` v8.
- **Plugin-level workarounds can retire on upgrade.** The forked rule creators and boundary casts plugins adopted (import-x, angular-eslint style) are no longer needed once they move to this major.
- **The typings stop promising what the runtime doesn't have.** No member remains typed that the ESLint 10 runtime doesn't deliver.
- **Both config entries stay green for as long as the compatibility matrix runs in CI.** Any future drift between `defineConfig()` and `tseslint.config()` fails the build instead of users.
