### PR TITLE
feat(eslint-plugin): [no-unnecessary-condition] flag type guards passed to array predicates

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
@@ -188,6 +188,9 @@ function assertIsString(value: unknown): asserts value is string {
 }
 
 assertIsString(s); // Unnecessary; s is always a string.
+
+declare const strings: string[];
+strings.filter(isString); // Unnecessary; each element is already a string.
 ```
 
 Whether this option makes sense for your project may vary.

--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -574,6 +574,59 @@ export default createRule<Options, MessageId>({
       checkNode(node.test);
     }
 
+    function isUnnecessaryTypeGuard(
+      typeOfArgument: ts.Type,
+      typeGuardType: ts.Type,
+    ): boolean {
+      // Skip `any` — it is assignable to everything, producing
+      // false positives for meaningful runtime type guards.
+      return (
+        !tsutils.isTypeFlagSet(
+          typeOfArgument,
+          ts.TypeFlags.Any | ts.TypeFlags.Unknown,
+        ) &&
+        checker.isTypeAssignableTo(typeOfArgument, typeGuardType) &&
+        // Only flag if the types are mutually assignable (i.e. equivalent,
+        // like Narrower ↔ Wider with optional props) or the predicate type
+        // is a union that the argument is a strict subtype of.  This avoids
+        // false positives with structural subtypes whose extra members are
+        // all optional in the *predicate* type (e.g. custom MappedType
+        // interfaces extending ts.Type).
+        (checker.isTypeAssignableTo(typeGuardType, typeOfArgument) ||
+          typeGuardType.isUnion())
+      );
+    }
+
+    function findTypePredicateOfCallback(
+      callback: TSESTree.Expression,
+    ): ts.Type | undefined {
+      const type =
+        services.getContextualType(callback) ??
+        getConstrainedTypeAtLocation(services, callback);
+
+      for (const signature of tsutils.getCallSignaturesOfType(type)) {
+        const predicate = checker.getTypePredicateOfSignature(signature);
+        if (
+          predicate?.type != null &&
+          predicate.kind === ts.TypePredicateKind.Identifier
+        ) {
+          return predicate.type;
+        }
+      }
+
+      return undefined;
+    }
+
+    function getArrayElementType(type: ts.Type): ts.Type | undefined {
+      for (const part of tsutils.unionConstituents(type)) {
+        if (checker.isArrayType(part)) {
+          return checker.getTypeArguments(part)[0];
+        }
+      }
+
+      return undefined;
+    }
+
     function checkCallExpression(node: TSESTree.CallExpression): void {
       if (checkTypePredicates) {
         const truthinessAssertedArgument = findTruthinessAssertedArgument(
@@ -594,27 +647,10 @@ export default createRule<Options, MessageId>({
             typeGuardAssertedArgument.argument,
           );
           if (
-            // Skip `any` — it is assignable to everything, producing
-            // false positives for meaningful runtime type guards.
-            !tsutils.isTypeFlagSet(
-              typeOfArgument,
-              ts.TypeFlags.Any | ts.TypeFlags.Unknown,
-            ) &&
-            checker.isTypeAssignableTo(
+            isUnnecessaryTypeGuard(
               typeOfArgument,
               typeGuardAssertedArgument.type,
-            ) &&
-            // Only flag if the types are mutually assignable (i.e. equivalent,
-            // like Narrower ↔ Wider with optional props) or the predicate type
-            // is a union that the argument is a strict subtype of.  This avoids
-            // false positives with structural subtypes whose extra members are
-            // all optional in the *predicate* type (e.g. custom MappedType
-            // interfaces extending ts.Type).
-            (checker.isTypeAssignableTo(
-              typeGuardAssertedArgument.type,
-              typeOfArgument,
-            ) ||
-              typeGuardAssertedArgument.type.isUnion())
+            )
           ) {
             context.report({
               node: typeGuardAssertedArgument.argument,
@@ -657,6 +693,30 @@ export default createRule<Options, MessageId>({
           // Potential enhancement: could use code-path analysis to check
           //   any function with a single return statement
           // (Value to complexity ratio is dubious however)
+        } else if (
+          checkTypePredicates &&
+          callback.type !== AST_NODE_TYPES.SpreadElement &&
+          node.callee.type === AST_NODE_TYPES.MemberExpression
+        ) {
+          const typePredicate = findTypePredicateOfCallback(callback);
+          if (typePredicate != null) {
+            const elementType = getArrayElementType(
+              getConstrainedTypeAtLocation(services, node.callee.object),
+            );
+            if (
+              elementType != null &&
+              isUnnecessaryTypeGuard(elementType, typePredicate)
+            ) {
+              context.report({
+                node: callback,
+                messageId: 'typeGuardAlreadyIsType',
+                data: {
+                  typeGuardOrAssertionFunction: 'type guard',
+                },
+              });
+            }
+            return;
+          }
         }
         // Otherwise just do type analysis on the function as a whole.
         const returnTypes = tsutils

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unnecessary-condition.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unnecessary-condition.shot
@@ -144,6 +144,10 @@ function assertIsString(value: unknown): asserts value is string {
 assertIsString(s); // Unnecessary; s is always a string.
                ~ Unnecessary conditional, expression already has the type being checked by the assertion function.
 
+declare const strings: string[];
+strings.filter(isString); // Unnecessary; each element is already a string.
+               ~~~~~~~~ Unnecessary conditional, expression already has the type being checked by the type guard.
+
 
 
 const array: string[] = [];

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -1235,6 +1235,39 @@ isString(a);
       `,
       options: [{ checkTypePredicates: false }],
     },
+    // https://github.com/typescript-eslint/typescript-eslint/issues/12343
+    {
+      code: `
+declare function isNotNil<T>(value: T | null | undefined): value is T;
+declare const arr: (string | null)[];
+arr.filter(isNotNil);
+      `,
+      options: [{ checkTypePredicates: true }],
+    },
+    {
+      code: `
+declare function isNotNil<T>(value: T | null | undefined): value is T;
+declare const arr: string[];
+arr.filter(isNotNil);
+      `,
+      options: [{ checkTypePredicates: false }],
+    },
+    {
+      code: `
+declare function isString(value: unknown): value is string;
+declare const mixed: (string | number)[];
+mixed.filter(isString);
+      `,
+      options: [{ checkTypePredicates: true }],
+    },
+    {
+      code: `
+declare function isNotNil<T>(value: T | null | undefined): value is T;
+declare const arr: any[];
+arr.filter(isNotNil);
+      `,
+      options: [{ checkTypePredicates: true }],
+    },
     {
       // Technically, this has type 'falafel' and not string.
       code: `
@@ -3840,6 +3873,43 @@ if (isNarrower(w)) {
       errors: [
         {
           line: 11,
+          messageId: 'typeGuardAlreadyIsType',
+        },
+      ],
+      options: [{ checkTypePredicates: true }],
+    },
+    // https://github.com/typescript-eslint/typescript-eslint/issues/12343
+    {
+      code: `
+declare function isNotNil<T>(value: T | null | undefined): value is T;
+declare const arr: string[];
+arr.filter(isNotNil);
+      `,
+      errors: [
+        {
+          column: 12,
+          data: { typeGuardOrAssertionFunction: 'type guard' },
+          endColumn: 20,
+          endLine: 4,
+          line: 4,
+          messageId: 'typeGuardAlreadyIsType',
+        },
+      ],
+      options: [{ checkTypePredicates: true }],
+    },
+    {
+      code: `
+declare function isNotNil<T>(value: T | null | undefined): value is T;
+declare const arr: string[];
+arr.find(isNotNil);
+      `,
+      errors: [
+        {
+          column: 10,
+          data: { typeGuardOrAssertionFunction: 'type guard' },
+          endColumn: 18,
+          endLine: 4,
+          line: 4,
           messageId: 'typeGuardAlreadyIsType',
         },
       ],

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -1269,6 +1269,22 @@ arr.filter(isNotNil);
       options: [{ checkTypePredicates: true }],
     },
     {
+      code: `
+declare function hasLength(value: string): boolean;
+declare const arr: string[];
+arr.filter(hasLength);
+      `,
+      options: [{ checkTypePredicates: true }],
+    },
+    {
+      code: `
+declare function isNotNil<T>(value: T | null | undefined): value is T;
+declare const pair: [string, string];
+pair.filter(isNotNil);
+      `,
+      options: [{ checkTypePredicates: true }],
+    },
+    {
       // Technically, this has type 'falafel' and not string.
       code: `
 declare function assertString(x: unknown): asserts x is string;


### PR DESCRIPTION
## PR Checklist

* [x] Addresses an existing open issue: #12343
* [x] That issue was marked as [[accepting PRs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)]
* [x] Steps in [[Contributing](https://typescript-eslint.io/contributing)] were taken
* [x] Tests have been added/updated to cover the new behavior
* [x] If this PR used AI assistance, I followed the [[AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)]

## Overview

Fixes #12343, by extending `no-unnecessary-condition` to detect unnecessary type guard callbacks that were passed directly to array predicate methods when `checkTypePredicates` is enabled.

For instance, `arr.filter(isNotNil)` is now reported consistently with `arr.filter(x => isNotNil(x))`.

This applies to the existing supported array predicate methods (`every`, `filter`, `find`, `findIndex`, `findLast`, `findLastIndex`, and `some`).

This PR does not cover always-false type predicates, RxJS operators, or custom helper functions. Always-false predicates are tracked separately in #10997.

