### PR TITLE
fix(eslint-plugin): [no-useless-default-assignment] false positive on variadic tuple rest elements

### DIFF
--- a/packages/eslint-plugin/src/rules/no-useless-default-assignment.ts
+++ b/packages/eslint-plugin/src/rules/no-useless-default-assignment.ts
@@ -225,6 +225,19 @@ export default createRule<Options, MessageId>({
         if (elementIndex < 0 || elementIndex >= tupleArgs.length) {
           return;
         }
+
+        // For variadic tuples (those with rest or optional elements), an element
+        // at a non-Required position can be absent at runtime even if the
+        // TypeScript type for that slot does not include `undefined`.
+        // E.g., for `[string, ...string[]]`, the rest element at index 1 has
+        // type `string`, but `arr[1]` is `undefined` when the rest is empty.
+        const tupleTarget = (sourceType as ts.TupleTypeReference).target;
+        const elementFlag = tupleTarget.elementFlags[elementIndex];
+        if ((elementFlag & ts.ElementFlags.Required) === 0) {
+          // Element is Optional, Rest, or Variadic — default may be reached.
+          return;
+        }
+
         const elementType = tupleArgs[elementIndex];
         if (!canBeUndefined(elementType)) {
           reportUselessDefaultAssignment(node, 'property');

--- a/packages/eslint-plugin/tests/rules/no-useless-default-assignment.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-useless-default-assignment.test.ts
@@ -226,6 +226,16 @@ useCallback((value: number[] = []) => {});
 declare const tuple: [string];
 const [a, b = 'default'] = tuple;
     `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/12767
+    // Rest elements in variadic tuples — element can be absent at runtime
+    `
+declare const commands: [string, ...string[]];
+const [cmd, arg = 'run'] = commands;
+    `,
+    `
+declare const pairs: [string, ...number[]];
+const [name, x = 0, y = 0] = pairs;
+    `,
     // https://github.com/typescript-eslint/typescript-eslint/issues/11911
     `
 const run = (cb: (...args: unknown[]) => void) => cb();


### PR DESCRIPTION
Fixes #12767

## Problem

When destructuring a variadic tuple that contains a rest element (`...T[]`), the rule incorrectly flags defaults as useless. The TypeScript type for a slot in the rest position is the element type (e.g. `string`) without `undefined`, even though the rest may be empty and the slot absent at runtime:

```ts
declare const commands: [string, ...string[]];
const [cmd, arg = 'run'] = commands;
//               ^^^^^^^ ❌ incorrectly flagged as useless
```

`commands` has minimum length 1, so `commands[1]` is `undefined` when the rest is empty — making `arg = 'run'` necessary.

## Root Cause

In `checkAssignmentPattern`, the tuple element's TypeScript type (`string`) does not include `undefined`, so `canBeUndefined(elementType)` returns `false` and the rule fires. But for rest-element slots, the type only describes *what the element would be if present* — it doesn't account for the slot being absent when the rest is empty.

## Fix

Inspect the tuple target's `elementFlags` array (the same mechanism already used by the `no-unsafe-argument` rule via `spreadArgType.target.combinedFlags`). Skip reporting when the element at the destructured index is not `Required` (i.e., it is `Rest`, `Variadic`, or `Optional`) — in those cases the default can be reached at runtime.

```diff
+        const tupleTarget = (sourceType as ts.TupleTypeReference).target;
+        const elementFlag = tupleTarget.elementFlags[elementIndex];
+        if ((elementFlag & ts.ElementFlags.Required) === 0) {
+          // Element is Optional, Rest, or Variadic — default may be reached.
+          return;
+        }
         const elementType = tupleArgs[elementIndex];
         if (!canBeUndefined(elementType)) {
           reportUselessDefaultAssignment(node, 'property');
         }
```

## Test Cases Added

```ts
// Both correctly allowed after this fix:
declare const commands: [string, ...string[]];
const [cmd, arg = 'run'] = commands;

declare const pairs: [string, ...number[]];
const [name, x = 0, y = 0] = pairs;
```