### PR TITLE
fix(eslint-plugin): [no-deprecated] report deprecated imported values used in object shorthand properties

### DIFF
--- a/packages/eslint-plugin/src/rules/no-deprecated.ts
+++ b/packages/eslint-plugin/src/rules/no-deprecated.ts
@@ -361,7 +361,7 @@ export default createRule<Options, MessageIds>({
           searchForDeprecationInAliasesChain(propertySymbol, true) ??
           getJsDocDeprecation(property) ??
           getJsDocDeprecation(propertySymbol) ??
-          getJsDocDeprecation(valueSymbol)
+          searchForDeprecationInAliasesChain(valueSymbol, true)
         );
       }
 

--- a/packages/eslint-plugin/tests/rules/no-deprecated.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-deprecated.test.ts
@@ -4070,5 +4070,37 @@ export { deprecatedFunction as bar } from './deprecated';
         },
       ],
     },
+    {
+      code: `
+import { deprecatedVariable } from './deprecated';
+
+void { deprecatedVariable };
+      `,
+      errors: [
+        {
+          column: 8,
+          endColumn: 26,
+          endLine: 4,
+          line: 4,
+          messageId: 'deprecated',
+        },
+      ],
+    },
+    {
+      code: `
+import { normalVariable } from './deprecated';
+
+void { normalVariable };
+      `,
+      errors: [
+        {
+          column: 8,
+          endColumn: 22,
+          endLine: 4,
+          line: 4,
+          messageId: 'deprecated',
+        },
+      ],
+    },
   ],
 });

--- a/packages/typescript-eslint/src/index.ts
+++ b/packages/typescript-eslint/src/index.ts
@@ -239,6 +239,7 @@ module.exports = config(
 ```
 */
 export default {
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   config,
   configs,
   extensions,


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #12774
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

Even found one case while dog fooding my change