### PR TITLE
fix(eslint-plugin): [no-useless-default-assignment] false positive on variadic tuple rest elements

### DIFF
--- a/packages/eslint-plugin/src/rules/no-useless-default-assignment.ts
+++ b/packages/eslint-plugin/src/rules/no-useless-default-assignment.ts
@@ -225,6 +225,19 @@ export default createRule<Options, MessageId>({
         if (elementIndex < 0 || elementIndex >= tupleArgs.length) {
           return;
         }
+
+        // For variadic tuples (those with rest or optional elements), an element
+        // at a non-Required position can be absent at runtime even if the
+        // TypeScript type for that slot does not include `undefined`.
+        // E.g., for `[string, ...string[]]`, the rest element at index 1 has
+        // type `string`, but `arr[1]` is `undefined` when the rest is empty.
+        const tupleTarget = (sourceType as ts.TupleTypeReference).target;
+        const elementFlag = tupleTarget.elementFlags[elementIndex];
+        if ((elementFlag & ts.ElementFlags.Required) === 0) {
+          // Element is Optional, Rest, or Variadic — default may be reached.
+          return;
+        }
+
         const elementType = tupleArgs[elementIndex];
         if (!canBeUndefined(elementType)) {
           reportUselessDefaultAssignment(node, 'property');

--- a/packages/eslint-plugin/tests/rules/no-useless-default-assignment.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-useless-default-assignment.test.ts
@@ -226,6 +226,16 @@ useCallback((value: number[] = []) => {});
 declare const tuple: [string];
 const [a, b = 'default'] = tuple;
     `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/12767
+    // Rest elements in variadic tuples — element can be absent at runtime
+    `
+declare const commands: [string, ...string[]];
+const [cmd, arg = 'run'] = commands;
+    `,
+    `
+declare const pairs: [string, ...number[]];
+const [name, x = 0, y = 0] = pairs;
+    `,
     // https://github.com/typescript-eslint/typescript-eslint/issues/11911
     `
 const run = (cb: (...args: unknown[]) => void) => cb();


### PR DESCRIPTION
Fixes #12767

## Summary

`no-useless-default-assignment` was incorrectly flagging default values in destructured variadic tuple rest positions, even though those positions can legitimately be absent at runtime.

**Root cause:** The rule checked `tupleArgs[elementIndex]` (the TypeScript type of the slot) but not whether that slot was at a Rest/Variadic/Optional position in the tuple. A `[string, ...string[]]` rest slot has type `string`, but accessing `arr[1]` when the rest is empty returns `undefined` — so a default value there is perfectly valid.

**Fix:** Inspect `tupleTarget.elementFlags[elementIndex]` and skip reporting when the element flag is not `Required` (i.e. it is Rest, Variadic, or Optional). This is the same `elementFlags` mechanism used by `no-unsafe-argument`.

## Test case

```ts
declare const commands: [string, ...string[]];
const [cmd, arg = 'run'] = commands; // was incorrectly flagged, now passes
```

## Checklist

- [x] Addresses an existing issue (fixes #12767)
- [x] New test cases added that fail before fix and pass after
- [x] No unrelated changes
- [x] CI passes locally (`pnpm run build && pnpm test`)