### PR TITLE
fix(eslint-plugin): [consistent-type-imports] attribute value references to a same-name local declaration

### DIFF
--- a/packages/eslint-plugin/src/rules/consistent-type-imports.ts
+++ b/packages/eslint-plugin/src/rules/consistent-type-imports.ts
@@ -1,6 +1,7 @@
 import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
 import type { RuleListener } from '@typescript-eslint/utils/eslint-utils';
 
+import { DefinitionType } from '@typescript-eslint/scope-manager';
 import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 
 import {
@@ -218,6 +219,14 @@ export default createRule<Options, MessageIds>({
           if (variable.references.length === 0) {
             unusedSpecifiers.push(specifier);
           } else {
+            // A same-name local declaration owns the value meaning of the name.
+            // TypeScript rejects the program with TS2440 if the import provides
+            // one too, so in valid code the import can only contribute a type.
+            const hasLocalValueDefinition = variable.defs.some(
+              def =>
+                def.type !== DefinitionType.ImportBinding &&
+                def.type !== DefinitionType.Type,
+            );
             const onlyHasTypeReferences = variable.references.every(ref => {
               /**
                * keep origin import kind when export
@@ -236,6 +245,9 @@ export default createRule<Options, MessageIds>({
                 ref.isTypeReference
               ) {
                 return node.importKind === 'type';
+              }
+              if (ref.isValueReference && hasLocalValueDefinition) {
+                return true;
               }
               if (ref.isValueReference) {
                 let parent = ref.identifier.parent as TSESTree.Node | undefined;

--- a/packages/eslint-plugin/tests/rules/consistent-type-imports.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-imports.test.ts
@@ -32,7 +32,7 @@ const foo: Foo = new Foo();
         `,
         `
 import foo from 'foo';
-const foo: foo.Foo = foo.fn();
+const bar: foo.Foo = foo.fn();
         `,
         `
 import { A, B } from 'foo';
@@ -428,6 +428,43 @@ let foo: Foo;
           output: `
 import type Foo from 'foo';
 let foo: Foo;
+          `,
+        },
+        {
+          // https://github.com/typescript-eslint/typescript-eslint/issues/8315
+          code: `
+import { Placeholder } from 'placeholder';
+export type Config = {
+  placeholder: Placeholder;
+};
+function Placeholder() {
+  return null;
+}
+export function Main() {
+  return Placeholder();
+}
+          `,
+          errors: [
+            {
+              column: 1,
+              endColumn: 43,
+              endLine: 2,
+              line: 2,
+              messageId: 'typeOverValue',
+            },
+          ],
+          options: [{ prefer: 'type-imports' }],
+          output: `
+import type { Placeholder } from 'placeholder';
+export type Config = {
+  placeholder: Placeholder;
+};
+function Placeholder() {
+  return null;
+}
+export function Main() {
+  return Placeholder();
+}
           `,
         },
         {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #~8315~
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

An import and a same-name declaration in the same scope end up sharing one scope-manager variable, since `defineVariable` pushes a second def onto the existing entry rather than creating a new one. The rule reads `variable.references` off that shared variable, so a value reference belonging to the local declaration counts as a value use of the import, and the import never gets reported.

For the example in the issue the variable is `Placeholder` with defs `ImportBinding` and `FunctionName`, and two references: a type reference at `placeholder: Placeholder`, and a value reference at the JSX usage. Only the first one belongs to the import.

Ignoring value references when there is a same-name local declaration is safe, because TypeScript will not accept the program otherwise. I checked a value import against a local `function`, `class` and `namespace`, and each one gives TS2440 "Import declaration conflicts with local declaration". So if the file compiles, the local declaration owns the value meaning and the import can only be contributing a type. Defs of type `Type` are excluded, since an interface or type alias adds no value binding.

One judgement call I would like a second opinion on. This existing valid fixture regressed:

```ts
import foo from 'foo';
const foo: foo.Foo = foo.fn();
```

As written it is TS2440-invalid (plus TS2503 and TS2448), and the case directly above it uses `Foo` for the import and `foo` for the const, so the name collision looks accidental rather than the point of the test. I renamed the const to `bar`, which keeps it covering the qualified-name type reference plus the value call. If you would rather leave that fixture untouched, I can narrow the check to function and class declarations instead.

The full eslint-plugin suite passes.