### PR TITLE
feat(eslint-plugin): [no-unused-vars] add enableAutofixRemoval.functions and .variables

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-unused-vars.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unused-vars.mdx
@@ -34,6 +34,38 @@ In such codebases, it is generally safe to automatically remove unused imports.
 
 If your codebase relies on side-effects caused by importing modules, you should leave this option set to `false`.
 
+#### `enableAutofixRemoval.functions`
+
+{/* TODO -- we don't support nested object properties in our option doc generator */}
+Whether to enable automatic removal of unused function declarations.
+
+When this is set to `false` (the default) the rule will not provide a fixer for unused function declarations.
+When this is set to `true` the rule will provide an **_automatic fixer_** that removes the entire declaration.
+
+A function declaration is hoisted and its body is never evaluated on declaration, so removing an unused one is side-effect free.
+
+Note: this only applies to function declarations that are a statement in their own right.
+A declaration that is the sole body of another statement (such as `if (x) function f() {}`) is left alone, as removing it would leave behind invalid syntax.
+
+#### `enableAutofixRemoval.variables`
+
+{/* TODO -- we don't support nested object properties in our option doc generator */}
+Whether to enable automatic removal of unused variable declarations.
+
+When this is set to `false` (the default) the rule will not provide a fixer for unused variable declarations.
+When this is set to `true` the rule will provide an **_automatic fixer_** that removes the entire declaration.
+
+Unlike imports and function declarations, **a variable's initializer may have side-effects** -- removing `const x = doSomething();` also removes the call to `doSomething()`.
+Only enable this option if you are comfortable with that tradeoff.
+
+To keep the fixer predictable, it only applies to a declaration that declares exactly one variable using a plain name.
+The following are always left alone:
+
+- Multiple declarators (`let a, b;`), which would require removing just one declarator and its comma.
+- Destructuring (`const { a, b } = obj;`), where the remaining bindings may well be used.
+- `using` and `await using` declarations, where removal would also drop the resource's disposal.
+- Declarations that are not a statement in their own right, such as the head of a `for` loop.
+
 ## FAQs
 
 ### What benefits does this rule have over TypeScript?

--- a/packages/eslint-plugin/docs/rules/no-unused-vars.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unused-vars.mdx
@@ -36,7 +36,6 @@ If your codebase relies on side-effects caused by importing modules, you should 
 
 #### `enableAutofixRemoval.functions`
 
-{/* TODO -- we don't support nested object properties in our option doc generator */}
 Whether to enable automatic removal of unused function declarations.
 
 When this is set to `false` (the default) the rule will not provide a fixer for unused function declarations.
@@ -49,7 +48,6 @@ A declaration that is the sole body of another statement (such as `if (x) functi
 
 #### `enableAutofixRemoval.variables`
 
-{/* TODO -- we don't support nested object properties in our option doc generator */}
 Whether to enable automatic removal of unused variable declarations.
 
 When this is set to `false` (the default) the rule will not provide a fixer for unused variable declarations.

--- a/packages/eslint-plugin/src/rules/no-unused-vars.ts
+++ b/packages/eslint-plugin/src/rules/no-unused-vars.ts
@@ -25,11 +25,26 @@ import {
   getNameLocationInGlobalDirectiveComment,
   isDefinitionFile,
   isFunction,
+  isNodeOfTypes,
   nullThrows,
   NullThrowsReasons,
 } from '../util';
 import { referenceContainsTypePredicate } from '../util/referenceContainsTypePredicate';
 import { referenceContainsTypeQuery } from '../util/referenceContainsTypeQuery';
+
+/**
+ * Declarations are only safe to delete outright when they're an element of a
+ * statement list. Anywhere else the declaration is the sole body of its parent
+ * (`if (x) var a = 1;`, `label: function f() {}`, a `for` head, ...) and
+ * removing it leaves behind syntactically invalid code.
+ */
+const isStatementListParent = isNodeOfTypes([
+  AST_NODE_TYPES.BlockStatement,
+  AST_NODE_TYPES.Program,
+  AST_NODE_TYPES.StaticBlock,
+  AST_NODE_TYPES.SwitchCase,
+  AST_NODE_TYPES.TSModuleBlock,
+]);
 
 export type MessageIds =
   | 'removeUnusedImportDeclaration'
@@ -569,26 +584,6 @@ export default createRule<Options, MessageIds>({
       return fixer.remove(node);
     }
 
-    /**
-     * Declarations are only safe to delete outright when they're an element of a
-     * statement list. Anywhere else the declaration is the sole body of its
-     * parent (`if (x) var a = 1;`, `label: function f() {}`, a `for` head, ...)
-     * and removing it leaves behind syntactically invalid code.
-     */
-    function isInStatementList(node: TSESTree.Node): boolean {
-      switch (node.parent?.type) {
-        case AST_NODE_TYPES.BlockStatement:
-        case AST_NODE_TYPES.Program:
-        case AST_NODE_TYPES.StaticBlock:
-        case AST_NODE_TYPES.SwitchCase:
-        case AST_NODE_TYPES.TSModuleBlock:
-          return true;
-
-        default:
-          return false;
-      }
-    }
-
     function getFunctionNameFixer(def: FunctionNameDefinition): {
       fix?: TSESLint.ReportFixFunction;
     } {
@@ -597,7 +592,7 @@ export default createRule<Options, MessageIds>({
         // name too -- but the node is the expression, which we must not remove
         (def.node.type !== AST_NODE_TYPES.FunctionDeclaration &&
           def.node.type !== AST_NODE_TYPES.TSDeclareFunction) ||
-        !isInStatementList(def.node)
+        !isStatementListParent(def.node.parent)
       ) {
         return {};
       }
@@ -622,7 +617,7 @@ export default createRule<Options, MessageIds>({
         // TODO -- destructuring requires removing just this property/element,
         // as its siblings may well be used
         def.name.parent.type !== AST_NODE_TYPES.VariableDeclarator ||
-        !isInStatementList(declaration)
+        !isStatementListParent(declaration.parent)
       ) {
         return {};
       }

--- a/packages/eslint-plugin/src/rules/no-unused-vars.ts
+++ b/packages/eslint-plugin/src/rules/no-unused-vars.ts
@@ -1,7 +1,9 @@
 import type {
   Definition,
+  FunctionNameDefinition,
   ImportBindingDefinition,
   ScopeVariable,
+  VariableDefinition,
 } from '@typescript-eslint/scope-manager';
 import type { TSESTree } from '@typescript-eslint/utils';
 
@@ -46,7 +48,9 @@ export type Options = [
       caughtErrorsIgnorePattern?: string;
       destructuredArrayIgnorePattern?: string;
       enableAutofixRemoval?: {
+        functions?: boolean;
         imports?: boolean;
+        variables?: boolean;
       };
       ignoreClassWithStaticInitBlock?: boolean;
       ignoreRestSiblings?: boolean;
@@ -64,7 +68,9 @@ interface TranslatedOptions {
   caughtErrorsIgnorePattern?: RegExp;
   destructuredArrayIgnorePattern?: RegExp;
   enableAutofixRemoval: {
+    functions: boolean;
     imports: boolean;
+    variables: boolean;
   };
   ignoreClassWithStaticInitBlock: boolean;
   ignoreRestSiblings: boolean;
@@ -249,10 +255,20 @@ export default createRule<Options, MessageIds>({
                 description:
                   'Configurable automatic fixes for different types of unused variables.',
                 properties: {
+                  functions: {
+                    type: 'boolean',
+                    description:
+                      'Whether to enable automatic removal of unused function declarations.',
+                  },
                   imports: {
                     type: 'boolean',
                     description:
                       'Whether to enable automatic removal of unused imports.',
+                  },
+                  variables: {
+                    type: 'boolean',
+                    description:
+                      'Whether to enable automatic removal of unused variable declarations.',
                   },
                 },
               },
@@ -370,9 +386,11 @@ export default createRule<Options, MessageIds>({
               return {};
 
             case VariableType.FunctionName:
-              // TODO(bradzacher) -- this would be really easy to implement and
-              // is side-effect free!
-              return {};
+              // opt-in only -- offering this as a suggestion by default would
+              // add one to every unused function the rule already reports
+              return options.enableAutofixRemoval.functions
+                ? { ...getFunctionNameFixer(def), useAutofix: true }
+                : {};
 
             case VariableType.ImportBinding:
               return {
@@ -418,8 +436,10 @@ export default createRule<Options, MessageIds>({
               return {};
 
             case VariableType.Variable:
-              // TODO(bradzacher) -- this would be really easy to implement
-              return {};
+              // opt-in only -- see the note on FunctionName above
+              return options.enableAutofixRemoval.variables
+                ? { ...getVariableFixer(def), useAutofix: true }
+                : {};
           }
         })();
 
@@ -457,7 +477,9 @@ export default createRule<Options, MessageIds>({
         args: 'after-used',
         caughtErrors: 'all',
         enableAutofixRemoval: {
+          functions: false,
           imports: false,
+          variables: false,
         },
         ignoreClassWithStaticInitBlock: false,
         ignoreRestSiblings: false,
@@ -513,10 +535,17 @@ export default createRule<Options, MessageIds>({
         }
 
         if (firstOption.enableAutofixRemoval) {
-          // eslint-disable-next-line unicorn/no-lonely-if -- will add more cases later
+          if (firstOption.enableAutofixRemoval.functions != null) {
+            options.enableAutofixRemoval.functions =
+              firstOption.enableAutofixRemoval.functions;
+          }
           if (firstOption.enableAutofixRemoval.imports != null) {
             options.enableAutofixRemoval.imports =
               firstOption.enableAutofixRemoval.imports;
+          }
+          if (firstOption.enableAutofixRemoval.variables != null) {
+            options.enableAutofixRemoval.variables =
+              firstOption.enableAutofixRemoval.variables;
           }
         }
       }
@@ -548,6 +577,69 @@ export default createRule<Options, MessageIds>({
         return fixer.removeRange([lineRangeStart, lineRangeEnd]);
       }
       return fixer.remove(node);
+    }
+
+    /**
+     * Declarations are only safe to delete outright when they're an element of a
+     * statement list. Anywhere else the declaration is the sole body of its
+     * parent (`if (x) var a = 1;`, `label: function f() {}`, a `for` head, ...)
+     * and removing it leaves behind syntactically invalid code.
+     */
+    function isInStatementList(node: TSESTree.Node): boolean {
+      switch (node.parent?.type) {
+        case AST_NODE_TYPES.BlockStatement:
+        case AST_NODE_TYPES.Program:
+        case AST_NODE_TYPES.StaticBlock:
+        case AST_NODE_TYPES.SwitchCase:
+        case AST_NODE_TYPES.TSModuleBlock:
+          return true;
+
+        default:
+          return false;
+      }
+    }
+
+    function getFunctionNameFixer(def: FunctionNameDefinition): {
+      fix?: TSESLint.ReportFixFunction;
+    } {
+      if (
+        // a named function *expression* (`const x = function foo() {}`) binds its
+        // name too -- but the node is the expression, which we must not remove
+        (def.node.type !== AST_NODE_TYPES.FunctionDeclaration &&
+          def.node.type !== AST_NODE_TYPES.TSDeclareFunction) ||
+        !isInStatementList(def.node)
+      ) {
+        return {};
+      }
+
+      // function declarations are hoisted and their body is never evaluated on
+      // declaration -- so removing an unused one is side-effect free
+      return { fix: fixer => removeNodeWithTrailingNewline(fixer, def.node) };
+    }
+
+    function getVariableFixer(def: VariableDefinition): {
+      fix?: TSESLint.ReportFixFunction;
+    } {
+      const declaration = def.parent;
+
+      if (
+        // `using x = ...` removal would drop the resource's disposal
+        declaration.kind === 'using' ||
+        declaration.kind === 'await using' ||
+        // TODO -- multiple declarators requires removing just this declarator
+        // and its comma, rather than the whole declaration
+        declaration.declarations.length !== 1 ||
+        // TODO -- destructuring requires removing just this property/element,
+        // as its siblings may well be used
+        def.name.parent.type !== AST_NODE_TYPES.VariableDeclarator ||
+        !isInStatementList(declaration)
+      ) {
+        return {};
+      }
+
+      return {
+        fix: fixer => removeNodeWithTrailingNewline(fixer, declaration),
+      };
     }
 
     function getImportFixer(def: ImportBindingDefinition): {

--- a/packages/eslint-plugin/src/rules/no-unused-vars.ts
+++ b/packages/eslint-plugin/src/rules/no-unused-vars.ts
@@ -534,20 +534,10 @@ export default createRule<Options, MessageIds>({
           );
         }
 
-        if (firstOption.enableAutofixRemoval) {
-          if (firstOption.enableAutofixRemoval.functions != null) {
-            options.enableAutofixRemoval.functions =
-              firstOption.enableAutofixRemoval.functions;
-          }
-          if (firstOption.enableAutofixRemoval.imports != null) {
-            options.enableAutofixRemoval.imports =
-              firstOption.enableAutofixRemoval.imports;
-          }
-          if (firstOption.enableAutofixRemoval.variables != null) {
-            options.enableAutofixRemoval.variables =
-              firstOption.enableAutofixRemoval.variables;
-          }
-        }
+        options.enableAutofixRemoval = {
+          ...options.enableAutofixRemoval,
+          ...firstOption.enableAutofixRemoval,
+        };
       }
 
       return options;

--- a/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars-enableAutofixRemoval.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars-enableAutofixRemoval.test.ts
@@ -699,4 +699,261 @@ import assert from 'assert'; /* this is an important comment */
     ],
     valid: [],
   });
+
+  ruleTester.run('enableAutofixRemoval.functions = true', rule, {
+    invalid: [
+      {
+        code: `
+function unused() {}
+export {};
+        `,
+        errors: [
+          {
+            column: 10,
+            endColumn: 16,
+            endLine: 2,
+            line: 2,
+            messageId: 'unusedVar',
+          },
+        ],
+        options: [{ enableAutofixRemoval: { functions: true } }],
+        output: `
+export {};
+        `,
+      },
+      {
+        code: `
+declare function unused(): void;
+export {};
+        `,
+        errors: [
+          {
+            column: 18,
+            endColumn: 24,
+            endLine: 2,
+            line: 2,
+            messageId: 'unusedVar',
+          },
+        ],
+        options: [{ enableAutofixRemoval: { functions: true } }],
+        output: `
+export {};
+        `,
+      },
+      {
+        // sole body of an if -- removing it leaves `if (maybe)` dangling
+        code: `
+declare const maybe: boolean;
+if (maybe) function unused() {}
+export {};
+        `,
+        errors: [
+          {
+            column: 21,
+            endColumn: 27,
+            endLine: 3,
+            line: 3,
+            messageId: 'unusedVar',
+            suggestions: null,
+          },
+        ],
+        options: [{ enableAutofixRemoval: { functions: true } }],
+      },
+    ],
+    valid: [
+      {
+        code: `
+export function used() {}
+        `,
+        options: [{ enableAutofixRemoval: { functions: true } }],
+      },
+      {
+        // the name of a function *expression* is never reported -- which is just
+        // as well, since the node to remove would be the expression itself
+        code: `
+export const used = function unused() {};
+        `,
+        options: [{ enableAutofixRemoval: { functions: true } }],
+      },
+    ],
+  });
+
+  ruleTester.run('enableAutofixRemoval.functions = false', rule, {
+    invalid: [
+      {
+        code: `
+function unused() {}
+export {};
+        `,
+        errors: [
+          {
+            column: 10,
+            endColumn: 16,
+            endLine: 2,
+            line: 2,
+            messageId: 'unusedVar',
+            suggestions: null,
+          },
+        ],
+        options: [{ enableAutofixRemoval: { functions: false } }],
+        output: null,
+      },
+    ],
+    valid: [],
+  });
+
+  ruleTester.run('enableAutofixRemoval.variables = true', rule, {
+    invalid: [
+      {
+        code: `
+const unused = () => {};
+export {};
+        `,
+        errors: [
+          {
+            column: 7,
+            endColumn: 13,
+            endLine: 2,
+            line: 2,
+            messageId: 'unusedVar',
+          },
+        ],
+        options: [{ enableAutofixRemoval: { variables: true } }],
+        output: `
+export {};
+        `,
+      },
+      {
+        code: `
+let unused;
+export {};
+        `,
+        errors: [
+          {
+            column: 5,
+            endColumn: 11,
+            endLine: 2,
+            line: 2,
+            messageId: 'unusedVar',
+          },
+        ],
+        options: [{ enableAutofixRemoval: { variables: true } }],
+        output: `
+export {};
+        `,
+      },
+      {
+        // multiple declarators would need comma surgery -- not implemented
+        code: `
+let unused, used;
+used = 1;
+export { used };
+        `,
+        errors: [
+          {
+            column: 5,
+            endColumn: 11,
+            endLine: 2,
+            line: 2,
+            messageId: 'unusedVar',
+            suggestions: null,
+          },
+        ],
+        options: [{ enableAutofixRemoval: { variables: true } }],
+      },
+      {
+        // destructuring: siblings may be used, so the whole declaration must stay
+        code: `
+declare const obj: { a: string; b: string };
+const { a: unused, b: used } = obj;
+export { used };
+        `,
+        errors: [
+          {
+            column: 12,
+            endColumn: 18,
+            endLine: 3,
+            line: 3,
+            messageId: 'unusedVar',
+            suggestions: null,
+          },
+        ],
+        options: [{ enableAutofixRemoval: { variables: true } }],
+      },
+      {
+        // removing a `using` declaration would drop the resource's disposal
+        code: `
+export function open(): any {
+  return null;
+}
+{
+  using unused = open();
+}
+        `,
+        errors: [
+          {
+            column: 9,
+            endColumn: 15,
+            endLine: 6,
+            line: 6,
+            messageId: 'unusedVar',
+            suggestions: null,
+          },
+        ],
+        options: [{ enableAutofixRemoval: { variables: true } }],
+      },
+      {
+        // the declaration is a `for` head -- removing it is a syntax error
+        code: `
+declare const items: string[];
+for (const unused of items) {
+}
+export {};
+        `,
+        errors: [
+          {
+            column: 12,
+            endColumn: 18,
+            endLine: 3,
+            line: 3,
+            messageId: 'unusedVar',
+            suggestions: null,
+          },
+        ],
+        options: [{ enableAutofixRemoval: { variables: true } }],
+      },
+    ],
+    valid: [
+      {
+        code: `
+export const used = 1;
+        `,
+        options: [{ enableAutofixRemoval: { variables: true } }],
+      },
+    ],
+  });
+
+  ruleTester.run('enableAutofixRemoval.variables = false', rule, {
+    invalid: [
+      {
+        code: `
+const unused = () => {};
+export {};
+        `,
+        errors: [
+          {
+            column: 7,
+            endColumn: 13,
+            endLine: 2,
+            line: 2,
+            messageId: 'unusedVar',
+            suggestions: null,
+          },
+        ],
+        options: [{ enableAutofixRemoval: { variables: false } }],
+        output: null,
+      },
+    ],
+    valid: [],
+  });
 });

--- a/packages/eslint-plugin/tests/schema-snapshots/no-unused-vars.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-unused-vars.shot
@@ -38,8 +38,16 @@
             "additionalProperties": false,
             "description": "Configurable automatic fixes for different types of unused variables.",
             "properties": {
+              "functions": {
+                "description": "Whether to enable automatic removal of unused function declarations.",
+                "type": "boolean"
+              },
               "imports": {
                 "description": "Whether to enable automatic removal of unused imports.",
+                "type": "boolean"
+              },
+              "variables": {
+                "description": "Whether to enable automatic removal of unused variable declarations.",
                 "type": "boolean"
               }
             },
@@ -102,8 +110,12 @@ type Options = [
       destructuredArrayIgnorePattern?: string;
       /** Configurable automatic fixes for different types of unused variables. */
       enableAutofixRemoval?: {
+        /** Whether to enable automatic removal of unused function declarations. */
+        functions?: boolean;
         /** Whether to enable automatic removal of unused imports. */
         imports?: boolean;
+        /** Whether to enable automatic removal of unused variable declarations. */
+        variables?: boolean;
       };
       /** Whether to ignore classes with at least one static initialization block. */
       ignoreClassWithStaticInitBlock?: boolean;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes **MISSING ISSUE**
      <!-- No open issue yet. Precedent: #11223 added `enableAutofixRemoval.imports`. -->
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

<!-- DRAFT: author to replace this section with their own summary before marking ready. -->

Adds two default-off options alongside the existing `enableAutofixRemoval.imports`:

- `enableAutofixRemoval.functions` — autofix-removes unused `FunctionDeclaration` / `TSDeclareFunction`. Hoisted, body never evaluated on declaration, so removal is side-effect free.
- `enableAutofixRemoval.variables` — autofix-removes an unused `VariableDeclaration`. Opt-in because an initializer may have side-effects.

Both bail out where removal would be unsafe or would need partial-node surgery: declarations that are not their own statement (`if (x) function f() {}`, a `for` head), `using` / `await using`, multiple declarators, and destructuring patterns.
