### PR TITLE
fix(website): omit DOM from playground default lib

### DIFF
--- a/packages/website/src/components/options.ts
+++ b/packages/website/src/components/options.ts
@@ -42,6 +42,7 @@ export const defaultConfig: ConfigModel = {
   ts: process.env.TS_VERSION,
   tsconfig: toJson({
     compilerOptions: {
+      lib: ['esnext'],
       strictNullChecks: true,
     },
   }),


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9648
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

Sets the Playground's default TypeScript lib to esnext. This resolves to lib.esnext.d.ts instead of TypeScript's lib.esnext.full.d.ts, so DOM globals are no longer included unless a user adds them explicitly.

Validation:

- Confirmed the default resolves to lib.esnext.d.ts without DOM
- Website TypeScript build, focused ESLint, Prettier, and diff checks passed