### PR TITLE
fix(eslint-plugin): [no-useless-default-assignment] ignore tuple elements at or after a rest element

### DIFF
--- a/packages/eslint-plugin/src/rules/no-useless-default-assignment.ts
+++ b/packages/eslint-plugin/src/rules/no-useless-default-assignment.ts
@@ -225,6 +225,19 @@ export default createRule<Options, MessageId>({
         if (elementIndex < 0 || elementIndex >= tupleArgs.length) {
           return;
         }
+
+        // A tuple element is only guaranteed to sit at its declared index while
+        // no rest element precedes it. A rest element may match zero elements,
+        // so everything at or after it can shift down and the destructured
+        // position can genuinely be missing at runtime.
+        const { elementFlags } = sourceType.target;
+        const restIndex = elementFlags.findIndex(
+          (flags: ts.ElementFlags) => flags & ts.ElementFlags.Variable,
+        );
+        if (restIndex !== -1 && elementIndex >= restIndex) {
+          return;
+        }
+
         const elementType = tupleArgs[elementIndex];
         if (!canBeUndefined(elementType)) {
           reportUselessDefaultAssignment(node, 'property');

--- a/packages/eslint-plugin/tests/rules/no-useless-default-assignment.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-useless-default-assignment.test.ts
@@ -226,6 +226,26 @@ useCallback((value: number[] = []) => {});
 declare const tuple: [string];
 const [a, b = 'default'] = tuple;
     `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/12767
+    `
+declare const commands: [string, ...string[]];
+const [cmd, arg = 'run'] = commands;
+    `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/12767
+    `
+declare const items: [...string[], string | undefined];
+const [first = 'fallback'] = items;
+    `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/12767
+    `
+declare const pair: [string, string?];
+const [a, b = 'default'] = pair;
+    `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/12767
+    `
+declare const rest: [...number[], boolean];
+const [a = 1] = rest;
+    `,
     // https://github.com/typescript-eslint/typescript-eslint/issues/11911
     `
 const run = (cb: (...args: unknown[]) => void) => cb();


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #12767
- [x] That issue was marked as [`accepting prs`](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

`[no-useless-default-assignment]` reported — and its fixer deleted — defaults on tuple destructuring positions that are reachable at runtime.

The array-pattern branch looked up `checker.getTypeArguments(sourceType)[elementIndex]` and, if that type could not be `undefined`, reported the default. That assumes the element at the destructured index is always present, which only holds when no rest element precedes it. A rest element can match zero elements, so anything at or after it shifts down and the position can genuinely be missing.

```ts
declare const commands: [string, ...string[]];
const [cmd, arg = 'run'] = commands; // commands = ['build'] → arg is undefined

declare const items: [...string[], string | undefined];
const [first = 'fallback'] = items; // items = [undefined] → first is undefined
```

Both were reported as `uselessDefaultAssignment`, and because the rule is `fixable: 'code'` the fixer removed the defaults, silently changing runtime behaviour.

The fix reads `elementFlags` off the tuple target, finds the first element carrying `ts.ElementFlags.Variable`, and bails out when the destructured index is at or after it. Optional elements (`[string, string?]`) fall out of this for free: they are already typed `string | undefined`, so the existing `canBeUndefined` check handles them.

Non-rest tuples are unaffected — `declare const tuple: [string]; const [a, b = 'default'] = tuple;` and the other existing valid/invalid cases still behave as before.

## Validation

Added four valid test cases (the two from the issue, plus a trailing-rest and an optional-element case).

- `vitest run tests/rules/no-useless-default-assignment.test.ts` → **89 passed**. The three new rest-element cases fail on `main` without the rule change, so they pin the regression.
- Full rule suite `vitest run tests/rules/` → **180 files, 29465 passed, 1 skipped**.
- `tsc -p tsconfig.json --noEmit` → clean.
- `eslint` on both changed files → clean.
