### PR TITLE
feat(ast-spec): standardize qualified import types

### DIFF
--- a/packages/ast-spec/src/legacy-fixtures/basics/fixtures/type-import-type-with-type-parameters-in-type-reference/snapshots/1-TSESTree-AST.shot
+++ b/packages/ast-spec/src/legacy-fixtures/basics/fixtures/type-import-type-with-type-parameters-in-type-reference/snapshots/1-TSESTree-AST.shot
@@ -21,32 +21,8 @@ Program {
         typeArguments: TSTypeParameterInstantiation {
           type: "TSTypeParameterInstantiation",
           params: [
-            TSImportType {
-              type: "TSImportType",
-              options: null,
-              qualifier: Identifier {
-                type: "Identifier",
-                decorators: [],
-                name: "B",
-                optional: false,
-
-                range: [95, 96],
-                loc: {
-                  start: { column: 22, line: 3 },
-                  end: { column: 23, line: 3 },
-                },
-              },
-              source: Literal {
-                type: "Literal",
-                raw: "''",
-                value: "",
-
-                range: [91, 93],
-                loc: {
-                  start: { column: 18, line: 3 },
-                  end: { column: 20, line: 3 },
-                },
-              },
+            TSTypeReference {
+              type: "TSTypeReference",
               typeArguments: TSTypeParameterInstantiation {
                 type: "TSTypeParameterInstantiation",
                 params: [
@@ -65,6 +41,48 @@ Program {
                 loc: {
                   start: { column: 23, line: 3 },
                   end: { column: 28, line: 3 },
+                },
+              },
+              typeName: TSQualifiedName {
+                type: "TSQualifiedName",
+                left: TSImportType {
+                  type: "TSImportType",
+                  options: null,
+                  source: Literal {
+                    type: "Literal",
+                    raw: "''",
+                    value: "",
+
+                    range: [91, 93],
+                    loc: {
+                      start: { column: 18, line: 3 },
+                      end: { column: 20, line: 3 },
+                    },
+                  },
+
+                  range: [84, 94],
+                  loc: {
+                    start: { column: 11, line: 3 },
+                    end: { column: 21, line: 3 },
+                  },
+                },
+                right: Identifier {
+                  type: "Identifier",
+                  decorators: [],
+                  name: "B",
+                  optional: false,
+
+                  range: [95, 96],
+                  loc: {
+                    start: { column: 22, line: 3 },
+                    end: { column: 23, line: 3 },
+                  },
+                },
+
+                range: [84, 96],
+                loc: {
+                  start: { column: 11, line: 3 },
+                  end: { column: 23, line: 3 },
                 },
               },
 

--- a/packages/ast-spec/src/legacy-fixtures/basics/fixtures/type-import-type-with-type-parameters-in-type-reference/snapshots/5-AST-Alignment-AST.shot
+++ b/packages/ast-spec/src/legacy-fixtures/basics/fixtures/type-import-type-with-type-parameters-in-type-reference/snapshots/5-AST-Alignment-AST.shot
@@ -28,32 +28,34 @@ Snapshot Diff:
           typeArguments: TSTypeParameterInstantiation {
             type: 'TSTypeParameterInstantiation',
             params: Array [
-              TSImportType {
-                type: 'TSImportType',
-                options: null,
-                qualifier: Identifier {
-                  type: 'Identifier',
-                  decorators: Array [],
-                  name: 'B',
-                  optional: false,
-
-                  range: [95, 96],
-                  loc: {
-                    start: { column: 22, line: 3 },
-                    end: { column: 23, line: 3 },
-                  },
-                },
-                source: Literal {
-                  type: 'Literal',
-                  raw: '\'\'',
-                  value: '',
-
-                  range: [91, 93],
-                  loc: {
-                    start: { column: 18, line: 3 },
-                    end: { column: 20, line: 3 },
-                  },
-                },
+-             TSTypeReference {
+-               type: 'TSTypeReference',
++             TSImportType {
++               type: 'TSImportType',
++               options: null,
++               qualifier: Identifier {
++                 type: 'Identifier',
++                 decorators: Array [],
++                 name: 'B',
++                 optional: false,
++
++                 range: [95, 96],
++                 loc: {
++                   start: { column: 22, line: 3 },
++                   end: { column: 23, line: 3 },
++                 },
++               },
++               source: Literal {
++                 type: 'Literal',
++                 raw: '\'\'',
++                 value: '',
++
++                 range: [91, 93],
++                 loc: {
++                   start: { column: 18, line: 3 },
++                   end: { column: 20, line: 3 },
++                 },
++               },
                 typeArguments: TSTypeParameterInstantiation {
                   type: 'TSTypeParameterInstantiation',
                   params: Array [
@@ -72,7 +74,49 @@ Snapshot Diff:
                   loc: {
                     start: { column: 23, line: 3 },
                     end: { column: 28, line: 3 },
+-                 },
+-               },
+-               typeName: TSQualifiedName {
+-                 type: 'TSQualifiedName',
+-                 left: TSImportType {
+-                   type: 'TSImportType',
+-                   options: null,
+-                   source: Literal {
+-                     type: 'Literal',
+-                     raw: '\'\'',
+-                     value: '',
+-
+-                     range: [91, 93],
+-                     loc: {
+-                       start: { column: 18, line: 3 },
+-                       end: { column: 20, line: 3 },
+-                     },
+-                   },
+-
+-                   range: [84, 94],
+-                   loc: {
+-                     start: { column: 11, line: 3 },
+-                     end: { column: 21, line: 3 },
+-                   },
+-                 },
+-                 right: Identifier {
+-                   type: 'Identifier',
+-                   decorators: Array [],
+-                   name: 'B',
+-                   optional: false,
+-
+-                   range: [95, 96],
+-                   loc: {
+-                     start: { column: 22, line: 3 },
+-                     end: { column: 23, line: 3 },
+-                   },
                   },
+-
+-                 range: [84, 96],
+-                 loc: {
+-                   start: { column: 11, line: 3 },
+-                   end: { column: 23, line: 3 },
+-                 },
                 },
 
                 range: [84, 101],

--- a/packages/ast-spec/src/legacy-fixtures/basics/fixtures/type-import-type/snapshots/1-TSESTree-AST.shot
+++ b/packages/ast-spec/src/legacy-fixtures/basics/fixtures/type-import-type/snapshots/1-TSESTree-AST.shot
@@ -21,7 +21,6 @@ Program {
         exprName: TSImportType {
           type: "TSImportType",
           options: null,
-          qualifier: null,
           source: Literal {
             type: "Literal",
             raw: "'A'",
@@ -33,7 +32,6 @@ Program {
               end: { column: 26, line: 3 },
             },
           },
-          typeArguments: null,
 
           range: [89, 100],
           loc: {
@@ -70,32 +68,8 @@ Program {
           end: { column: 6, line: 4 },
         },
       },
-      typeAnnotation: TSImportType {
-        type: "TSImportType",
-        options: null,
-        qualifier: Identifier {
-          type: "Identifier",
-          decorators: [],
-          name: "X",
-          optional: false,
-
-          range: [123, 124],
-          loc: {
-            start: { column: 21, line: 4 },
-            end: { column: 22, line: 4 },
-          },
-        },
-        source: Literal {
-          type: "Literal",
-          raw: "'B'",
-          value: "B",
-
-          range: [118, 121],
-          loc: {
-            start: { column: 16, line: 4 },
-            end: { column: 19, line: 4 },
-          },
-        },
+      typeAnnotation: TSTypeReference {
+        type: "TSTypeReference",
         typeArguments: TSTypeParameterInstantiation {
           type: "TSTypeParameterInstantiation",
           params: [
@@ -126,6 +100,48 @@ Program {
           loc: {
             start: { column: 22, line: 4 },
             end: { column: 25, line: 4 },
+          },
+        },
+        typeName: TSQualifiedName {
+          type: "TSQualifiedName",
+          left: TSImportType {
+            type: "TSImportType",
+            options: null,
+            source: Literal {
+              type: "Literal",
+              raw: "'B'",
+              value: "B",
+
+              range: [118, 121],
+              loc: {
+                start: { column: 16, line: 4 },
+                end: { column: 19, line: 4 },
+              },
+            },
+
+            range: [111, 122],
+            loc: {
+              start: { column: 9, line: 4 },
+              end: { column: 20, line: 4 },
+            },
+          },
+          right: Identifier {
+            type: "Identifier",
+            decorators: [],
+            name: "X",
+            optional: false,
+
+            range: [123, 124],
+            loc: {
+              start: { column: 21, line: 4 },
+              end: { column: 22, line: 4 },
+            },
+          },
+
+          range: [111, 124],
+          loc: {
+            start: { column: 9, line: 4 },
+            end: { column: 22, line: 4 },
           },
         },
 

--- a/packages/ast-spec/src/legacy-fixtures/basics/fixtures/type-import-type/snapshots/5-AST-Alignment-AST.shot
+++ b/packages/ast-spec/src/legacy-fixtures/basics/fixtures/type-import-type/snapshots/5-AST-Alignment-AST.shot
@@ -28,7 +28,7 @@ Snapshot Diff:
           exprName: TSImportType {
             type: 'TSImportType',
             options: null,
-            qualifier: null,
++           qualifier: null,
             source: Literal {
               type: 'Literal',
               raw: '\'A\'',
@@ -40,7 +40,7 @@ Snapshot Diff:
                 end: { column: 26, line: 3 },
               },
             },
-            typeArguments: null,
++           typeArguments: null,
 
             range: [89, 100],
             loc: {
@@ -77,32 +77,34 @@ Snapshot Diff:
             end: { column: 6, line: 4 },
           },
         },
-        typeAnnotation: TSImportType {
-          type: 'TSImportType',
-          options: null,
-          qualifier: Identifier {
-            type: 'Identifier',
-            decorators: Array [],
-            name: 'X',
-            optional: false,
-
-            range: [123, 124],
-            loc: {
-              start: { column: 21, line: 4 },
-              end: { column: 22, line: 4 },
-            },
-          },
-          source: Literal {
-            type: 'Literal',
-            raw: '\'B\'',
-            value: 'B',
-
-            range: [118, 121],
-            loc: {
-              start: { column: 16, line: 4 },
-              end: { column: 19, line: 4 },
-            },
-          },
+-       typeAnnotation: TSTypeReference {
+-         type: 'TSTypeReference',
++       typeAnnotation: TSImportType {
++         type: 'TSImportType',
++         options: null,
++         qualifier: Identifier {
++           type: 'Identifier',
++           decorators: Array [],
++           name: 'X',
++           optional: false,
++
++           range: [123, 124],
++           loc: {
++             start: { column: 21, line: 4 },
++             end: { column: 22, line: 4 },
++           },
++         },
++         source: Literal {
++           type: 'Literal',
++           raw: '\'B\'',
++           value: 'B',
++
++           range: [118, 121],
++           loc: {
++             start: { column: 16, line: 4 },
++             end: { column: 19, line: 4 },
++           },
++         },
           typeArguments: TSTypeParameterInstantiation {
             type: 'TSTypeParameterInstantiation',
             params: Array [
@@ -133,7 +135,49 @@ Snapshot Diff:
             loc: {
               start: { column: 22, line: 4 },
               end: { column: 25, line: 4 },
+-           },
+-         },
+-         typeName: TSQualifiedName {
+-           type: 'TSQualifiedName',
+-           left: TSImportType {
+-             type: 'TSImportType',
+-             options: null,
+-             source: Literal {
+-               type: 'Literal',
+-               raw: '\'B\'',
+-               value: 'B',
+-
+-               range: [118, 121],
+-               loc: {
+-                 start: { column: 16, line: 4 },
+-                 end: { column: 19, line: 4 },
+-               },
+-             },
+-
+-             range: [111, 122],
+-             loc: {
+-               start: { column: 9, line: 4 },
+-               end: { column: 20, line: 4 },
+-             },
             },
+-           right: Identifier {
+-             type: 'Identifier',
+-             decorators: Array [],
+-             name: 'X',
+-             optional: false,
+-
+-             range: [123, 124],
+-             loc: {
+-               start: { column: 21, line: 4 },
+-               end: { column: 22, line: 4 },
+-             },
+-           },
+-
+-           range: [111, 124],
+-           loc: {
+-             start: { column: 9, line: 4 },
+-             end: { column: 22, line: 4 },
+-           },
           },
 
           range: [111, 127],

--- a/packages/ast-spec/src/type/TSImportType/fixtures/type-import-type-with-import-attributes-with/snapshots/1-TSESTree-AST.shot
+++ b/packages/ast-spec/src/type/TSImportType/fixtures/type-import-type-with-import-attributes-with/snapshots/1-TSESTree-AST.shot
@@ -103,7 +103,6 @@ Program {
             end: { column: 47, line: 1 },
           },
         },
-        qualifier: null,
         source: Literal {
           type: "Literal",
           raw: "'A'",
@@ -115,7 +114,6 @@ Program {
             end: { column: 19, line: 1 },
           },
         },
-        typeArguments: null,
 
         range: [9, 48],
         loc: {

--- a/packages/ast-spec/src/type/TSImportType/fixtures/type-import-type-with-import-attributes-with/snapshots/5-AST-Alignment-AST.shot
+++ b/packages/ast-spec/src/type/TSImportType/fixtures/type-import-type-with-import-attributes-with/snapshots/5-AST-Alignment-AST.shot
@@ -1,0 +1,148 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AST Fixtures > type > TSImportType > type-import-type-with-import-attributes-with > AST Alignment - AST`]
+Snapshot Diff:
+- TSESTree
++ Babel
+
+  Program {
+    type: 'Program',
+    body: Array [
+      TSTypeAliasDeclaration {
+        type: 'TSTypeAliasDeclaration',
+        declare: false,
+        id: Identifier {
+          type: 'Identifier',
+          decorators: Array [],
+          name: 'A',
+          optional: false,
+
+          range: [5, 6],
+          loc: {
+            start: { column: 5, line: 1 },
+            end: { column: 6, line: 1 },
+          },
+        },
+        typeAnnotation: TSImportType {
+          type: 'TSImportType',
+          options: ObjectExpression {
+            type: 'ObjectExpression',
+            properties: Array [
+              Property {
+                type: 'Property',
+                computed: false,
+                key: Identifier {
+                  type: 'Identifier',
+                  decorators: Array [],
+                  name: 'with',
+                  optional: false,
+
+                  range: [23, 27],
+                  loc: {
+                    start: { column: 23, line: 1 },
+                    end: { column: 27, line: 1 },
+                  },
+                },
+                kind: 'init',
+                method: false,
+                optional: false,
+                shorthand: false,
+                value: ObjectExpression {
+                  type: 'ObjectExpression',
+                  properties: Array [
+                    Property {
+                      type: 'Property',
+                      computed: false,
+                      key: Identifier {
+                        type: 'Identifier',
+                        decorators: Array [],
+                        name: 'type',
+                        optional: false,
+
+                        range: [31, 35],
+                        loc: {
+                          start: { column: 31, line: 1 },
+                          end: { column: 35, line: 1 },
+                        },
+                      },
+                      kind: 'init',
+                      method: false,
+                      optional: false,
+                      shorthand: false,
+                      value: Literal {
+                        type: 'Literal',
+                        raw: '\'json\'',
+                        value: 'json',
+
+                        range: [37, 43],
+                        loc: {
+                          start: { column: 37, line: 1 },
+                          end: { column: 43, line: 1 },
+                        },
+                      },
+
+                      range: [31, 43],
+                      loc: {
+                        start: { column: 31, line: 1 },
+                        end: { column: 43, line: 1 },
+                      },
+                    },
+                  ],
+
+                  range: [29, 45],
+                  loc: {
+                    start: { column: 29, line: 1 },
+                    end: { column: 45, line: 1 },
+                  },
+                },
+
+                range: [23, 45],
+                loc: {
+                  start: { column: 23, line: 1 },
+                  end: { column: 45, line: 1 },
+                },
+              },
+            ],
+
+            range: [21, 47],
+            loc: {
+              start: { column: 21, line: 1 },
+              end: { column: 47, line: 1 },
+            },
+          },
++         qualifier: null,
+          source: Literal {
+            type: 'Literal',
+            raw: '\'A\'',
+            value: 'A',
+
+            range: [16, 19],
+            loc: {
+              start: { column: 16, line: 1 },
+              end: { column: 19, line: 1 },
+            },
+          },
++         typeArguments: null,
+
+          range: [9, 48],
+          loc: {
+            start: { column: 9, line: 1 },
+            end: { column: 48, line: 1 },
+          },
+        },
+
+        range: [0, 49],
+        loc: {
+          start: { column: 0, line: 1 },
+          end: { column: 49, line: 1 },
+        },
+      },
+    ],
+    sourceType: 'script',
+
+    range: [0, 50],
+    loc: {
+      start: { column: 0, line: 1 },
+      end: { column: 0, line: 2 },
+    },
+  }

--- a/packages/ast-spec/src/type/TSImportType/fixtures/type-import-type-with-trailing-comma-in-import-attributes/snapshots/1-TSESTree-AST.shot
+++ b/packages/ast-spec/src/type/TSImportType/fixtures/type-import-type-with-trailing-comma-in-import-attributes/snapshots/1-TSESTree-AST.shot
@@ -102,7 +102,6 @@ Program {
             end: { column: 76, line: 1 },
           },
         },
-        qualifier: null,
         source: Literal {
           type: "Literal",
           raw: ""A"",
@@ -114,7 +113,6 @@ Program {
             end: { column: 31, line: 1 },
           },
         },
-        typeArguments: null,
 
         range: [21, 78],
         loc: {

--- a/packages/ast-spec/src/type/TSImportType/fixtures/type-import-type-with-trailing-comma-in-import-attributes/snapshots/5-AST-Alignment-AST.shot
+++ b/packages/ast-spec/src/type/TSImportType/fixtures/type-import-type-with-trailing-comma-in-import-attributes/snapshots/5-AST-Alignment-AST.shot
@@ -1,0 +1,147 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AST Fixtures > type > TSImportType > type-import-type-with-trailing-comma-in-import-attributes > AST Alignment - AST`]
+Snapshot Diff:
+- TSESTree
++ Babel
+
+  Program {
+    type: 'Program',
+    body: Array [
+      TSTypeAliasDeclaration {
+        type: 'TSTypeAliasDeclaration',
+        declare: false,
+        id: Identifier {
+          type: 'Identifier',
+          decorators: Array [],
+          name: 'TrailingComma',
+          optional: false,
+
+          range: [5, 18],
+          loc: {
+            start: { column: 5, line: 1 },
+            end: { column: 18, line: 1 },
+          },
+        },
+        typeAnnotation: TSImportType {
+          type: 'TSImportType',
+          options: ObjectExpression {
+            type: 'ObjectExpression',
+            properties: Array [
+              Property {
+                type: 'Property',
+                computed: false,
+                key: Identifier {
+                  type: 'Identifier',
+                  decorators: Array [],
+                  name: 'with',
+                  optional: false,
+
+                  range: [35, 39],
+                  loc: {
+                    start: { column: 35, line: 1 },
+                    end: { column: 39, line: 1 },
+                  },
+                },
+                kind: 'init',
+                method: false,
+                optional: false,
+                shorthand: false,
+                value: ObjectExpression {
+                  type: 'ObjectExpression',
+                  properties: Array [
+                    Property {
+                      type: 'Property',
+                      computed: false,
+                      key: Literal {
+                        type: 'Literal',
+                        raw: '"resolution-mode"',
+                        value: 'resolution-mode',
+
+                        range: [43, 60],
+                        loc: {
+                          start: { column: 43, line: 1 },
+                          end: { column: 60, line: 1 },
+                        },
+                      },
+                      kind: 'init',
+                      method: false,
+                      optional: false,
+                      shorthand: false,
+                      value: Literal {
+                        type: 'Literal',
+                        raw: '"import"',
+                        value: 'import',
+
+                        range: [62, 70],
+                        loc: {
+                          start: { column: 62, line: 1 },
+                          end: { column: 70, line: 1 },
+                        },
+                      },
+
+                      range: [43, 70],
+                      loc: {
+                        start: { column: 43, line: 1 },
+                        end: { column: 70, line: 1 },
+                      },
+                    },
+                  ],
+
+                  range: [41, 73],
+                  loc: {
+                    start: { column: 41, line: 1 },
+                    end: { column: 73, line: 1 },
+                  },
+                },
+
+                range: [35, 73],
+                loc: {
+                  start: { column: 35, line: 1 },
+                  end: { column: 73, line: 1 },
+                },
+              },
+            ],
+
+            range: [33, 76],
+            loc: {
+              start: { column: 33, line: 1 },
+              end: { column: 76, line: 1 },
+            },
+          },
++         qualifier: null,
+          source: Literal {
+            type: 'Literal',
+            raw: '"A"',
+            value: 'A',
+
+            range: [28, 31],
+            loc: {
+              start: { column: 28, line: 1 },
+              end: { column: 31, line: 1 },
+            },
+          },
++         typeArguments: null,
+
+          range: [21, 78],
+          loc: {
+            start: { column: 21, line: 1 },
+            end: { column: 78, line: 1 },
+          },
+        },
+
+        range: [0, 79],
+        loc: {
+          start: { column: 0, line: 1 },
+          end: { column: 79, line: 1 },
+        },
+      },
+    ],
+    sourceType: 'script',
+
+    range: [0, 80],
+    loc: {
+      start: { column: 0, line: 1 },
+      end: { column: 0, line: 2 },
+    },
+  }

--- a/packages/ast-spec/src/type/TSImportType/spec.ts
+++ b/packages/ast-spec/src/type/TSImportType/spec.ts
@@ -2,8 +2,6 @@ import type { AST_NODE_TYPES } from '../../ast-node-types';
 import type { BaseNode } from '../../base/BaseNode';
 import type { StringLiteral } from '../../expression/literal/StringLiteral/spec';
 import type { ObjectExpression } from '../../expression/ObjectExpression/spec';
-import type { TSTypeParameterInstantiation } from '../../special/TSTypeParameterInstantiation/spec';
-import type { EntityName } from '../../unions/EntityName';
 import type { TypeNode } from '../../unions/TypeNode';
 
 export interface TSImportType extends BaseNode {
@@ -11,7 +9,5 @@ export interface TSImportType extends BaseNode {
   /** @deprecated Use {@link `source`} instead. */
   argument: TypeNode;
   options: ObjectExpression | null;
-  qualifier: EntityName | null;
   source: StringLiteral;
-  typeArguments: TSTypeParameterInstantiation | null;
 }

--- a/packages/ast-spec/src/type/TSQualifiedName/spec.ts
+++ b/packages/ast-spec/src/type/TSQualifiedName/spec.ts
@@ -2,9 +2,10 @@ import type { AST_NODE_TYPES } from '../../ast-node-types';
 import type { BaseNode } from '../../base/BaseNode';
 import type { Identifier } from '../../expression/Identifier/spec';
 import type { EntityName } from '../../unions/EntityName';
+import type { TSImportType } from '../TSImportType/spec';
 
 export interface TSQualifiedName extends BaseNode {
   type: AST_NODE_TYPES.TSQualifiedName;
-  left: EntityName;
+  left: EntityName | TSImportType;
   right: Identifier;
 }

--- a/packages/ast-spec/tests/fixtures-with-differences-ast.shot
+++ b/packages/ast-spec/tests/fixtures-with-differences-ast.shot
@@ -314,5 +314,7 @@ exports[`AST Fixtures > List fixtures with AST differences`]
   "legacy-fixtures/types/fixtures/union-type/fixture.ts",
   "special/ImportSpecifier/fixtures/type-only-import-specifier/fixture.ts",
   "special/ImportSpecifier/fixtures/type-only-import-specifiers/fixture.ts",
-  "statement/ForInStatement/fixtures/expr-init/fixture.ts"
+  "statement/ForInStatement/fixtures/expr-init/fixture.ts",
+  "type/TSImportType/fixtures/type-import-type-with-import-attributes-with/fixture.ts",
+  "type/TSImportType/fixtures/type-import-type-with-trailing-comma-in-import-attributes/fixture.ts"
 ]

--- a/packages/eslint-plugin/src/rules/no-mixed-enums.ts
+++ b/packages/eslint-plugin/src/rules/no-mixed-enums.ts
@@ -52,6 +52,9 @@ export default createRule({
       let current: TSESTree.EntityName = id;
       while (current.type === AST_NODE_TYPES.TSQualifiedName) {
         qualifiers = `.${current.right.name}${qualifiers}`;
+        if (current.left.type === AST_NODE_TYPES.TSImportType) {
+          return context.sourceCode.getText(id);
+        }
         current = current.left;
       }
 

--- a/packages/eslint-plugin/src/rules/no-mixed-enums.ts
+++ b/packages/eslint-plugin/src/rules/no-mixed-enums.ts
@@ -52,10 +52,7 @@ export default createRule({
       let current: TSESTree.EntityName = id;
       while (current.type === AST_NODE_TYPES.TSQualifiedName) {
         qualifiers = `.${current.right.name}${qualifiers}`;
-        if (current.left.type === AST_NODE_TYPES.TSImportType) {
-          return context.sourceCode.getText(id);
-        }
-        current = current.left;
+        current = current.left as TSESTree.EntityName;
       }
 
       return context.sourceCode.getText(current) + qualifiers;

--- a/packages/eslint-plugin/src/rules/no-unnecessary-qualifier.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-qualifier.ts
@@ -184,7 +184,9 @@ export default createRule({
         enterDeclaration(node.parent);
       },
       TSQualifiedName(node: TSESTree.TSQualifiedName): void {
-        visitNamespaceAccess(node, node.left, node.right);
+        if (node.left.type !== AST_NODE_TYPES.TSImportType) {
+          visitNamespaceAccess(node, node.left, node.right);
+        }
       },
       'TSQualifiedName:exit': resetCurrentNamespaceExpression,
     };

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/consistent-type-imports.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/consistent-type-imports.shot
@@ -40,6 +40,6 @@ const x: Bar = 1;
 Options: { "disallowTypeAnnotations": true }
 
 type T = import('Foo').Foo;
-         ~~~~~~~~~~~~~~~~~ `import()` type annotations are forbidden.
+         ~~~~~~~~~~~~~ `import()` type annotations are forbidden.
 const x: import('Bar') = 1;
          ~~~~~~~~~~~~~ `import()` type annotations are forbidden.

--- a/packages/eslint-plugin/tests/rules/consistent-type-imports.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-imports.test.ts
@@ -999,7 +999,7 @@ let bar: import('foo').Bar;
             },
             {
               column: 10,
-              endColumn: 27,
+              endColumn: 23,
               endLine: 3,
               line: 3,
               messageId: 'noImportTypeAnnotations',

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-qualifier.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-qualifier.test.ts
@@ -21,6 +21,12 @@ namespace A.B {
 }
     `,
     `
+declare module 'mod' {
+  export type T = string;
+}
+type T = import('mod').T;
+    `,
+    `
 enum A {
   X,
   Y,

--- a/packages/scope-manager/src/referencer/TypeVisitor.ts
+++ b/packages/scope-manager/src/referencer/TypeVisitor.ts
@@ -122,10 +122,8 @@ export class TypeVisitor extends Visitor {
     this.visitFunctionType(node);
   }
 
-  protected TSImportType(node: TSESTree.TSImportType): void {
-    // the TS parser allows any type to be the parameter, but it's a syntax error - so we can ignore it
-    this.visit(node.typeArguments);
-    // the qualifier is just part of a standard EntityName, so it should not be visited
+  protected TSImportType(): void {
+    // Import module specifiers cannot reference local variables.
   }
 
   protected TSIndexSignature(node: TSESTree.TSIndexSignature): void {

--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -93,6 +93,23 @@ export class Converter {
     checkSyntaxError(node, parent, this.allowPattern);
   }
 
+  #convertImportTypeQualifier(
+    qualifier: ts.EntityName,
+    importType: TSESTree.TSImportType,
+  ): TSESTree.TSQualifiedName {
+    const left = ts.isIdentifier(qualifier)
+      ? importType
+      : this.#convertImportTypeQualifier(qualifier.left, importType);
+    const right = ts.isIdentifier(qualifier) ? qualifier : qualifier.right;
+
+    return this.createNode<TSESTree.TSQualifiedName>(qualifier, {
+      type: AST_NODE_TYPES.TSQualifiedName,
+      range: [importType.range[0], qualifier.end],
+      left,
+      right: this.convertChild(right),
+    });
+  }
+
   #isValidEscape(text: string): boolean {
     if (/\\[xu]/.test(text)) {
       const hasInvalidUnicodeEscape = /\\u(?![0-9a-fA-F]{4}|{)/.test(text);
@@ -2543,17 +2560,19 @@ export class Converter {
 
         const argument = this.convertChild(node.argument);
         const source = argument.literal;
+        let closingParenToken = findNextToken(node.argument, node, this.ast)!;
+        while (closingParenToken.kind !== SyntaxKind.CloseParenToken) {
+          closingParenToken = findNextToken(closingParenToken, node, this.ast)!;
+        }
 
-        const result = this.createNode<TSESTree.TSImportType>(
+        const importType = this.createNode<TSESTree.TSImportType>(
           node,
           this.#withDeprecatedGetter(
             {
               type: AST_NODE_TYPES.TSImportType,
-              range,
+              range: [range[0], closingParenToken.end],
               options,
-              qualifier: this.convertChild(node.qualifier),
               source,
-              typeArguments: this.convertTypeArguments(node) ?? null,
             },
             'argument',
             'source',
@@ -2561,14 +2580,26 @@ export class Converter {
           ),
         );
 
+        const typeArguments = this.convertTypeArguments(node) ?? undefined;
+        const typeName = node.qualifier
+          ? this.#convertImportTypeQualifier(node.qualifier, importType)
+          : importType;
+
         if (node.isTypeOf) {
           return this.createNode<TSESTree.TSTypeQuery>(node, {
             type: AST_NODE_TYPES.TSTypeQuery,
-            exprName: result,
-            typeArguments: undefined,
+            exprName: typeName,
+            typeArguments,
           });
         }
-        return result;
+        if (typeName.type === AST_NODE_TYPES.TSQualifiedName) {
+          return this.createNode<TSESTree.TSTypeReference>(node, {
+            type: AST_NODE_TYPES.TSTypeReference,
+            typeArguments,
+            typeName,
+          });
+        }
+        return importType;
       }
 
       case SyntaxKind.EnumDeclaration: {

--- a/packages/typescript-estree/tests/lib/convert.test.ts
+++ b/packages/typescript-estree/tests/lib/convert.test.ts
@@ -98,6 +98,50 @@ describe('convert', () => {
   });
   /* eslint-enable @typescript-eslint/dot-notation */
 
+  it('standardizes qualified import types as type references', () => {
+    const code = `
+      type A = import('a').b.c<x>;
+      type B = typeof import('b').c<d>;
+    `;
+    const program = new Converter(convertCode(code)).convertProgram();
+
+    const typeAlias = program.body[0];
+    assert(typeAlias.type === AST_NODE_TYPES.TSTypeAliasDeclaration);
+    const typeReference = typeAlias.typeAnnotation;
+    assert(typeReference.type === AST_NODE_TYPES.TSTypeReference);
+    const outerQualifiedName = typeReference.typeName;
+    assert(outerQualifiedName.type === AST_NODE_TYPES.TSQualifiedName);
+    const innerQualifiedName = outerQualifiedName.left;
+    assert(innerQualifiedName.type === AST_NODE_TYPES.TSQualifiedName);
+    const importType = innerQualifiedName.left;
+    assert(importType.type === AST_NODE_TYPES.TSImportType);
+
+    expect(code.slice(...importType.range)).toBe("import('a')");
+    expect(code.slice(...outerQualifiedName.range)).toBe("import('a').b.c");
+    expect(typeReference.typeArguments?.params).toMatchObject([
+      { type: AST_NODE_TYPES.TSTypeReference },
+    ]);
+    expect(importType).not.toHaveProperty('qualifier');
+    expect(importType).not.toHaveProperty('typeArguments');
+
+    const typeQueryAlias = program.body[1];
+    assert(typeQueryAlias.type === AST_NODE_TYPES.TSTypeAliasDeclaration);
+    const typeQuery = typeQueryAlias.typeAnnotation;
+    assert(typeQuery.type === AST_NODE_TYPES.TSTypeQuery);
+
+    expect(typeQuery.exprName).toMatchObject({
+      left: {
+        source: { value: 'b' },
+        type: AST_NODE_TYPES.TSImportType,
+      },
+      right: { name: 'c' },
+      type: AST_NODE_TYPES.TSQualifiedName,
+    });
+    expect(typeQuery.typeArguments?.params).toMatchObject([
+      { type: AST_NODE_TYPES.TSTypeReference },
+    ]);
+  });
+
   it('nodeMaps should contain basic nodes', () => {
     const ast = convertCode(`
       'test';

--- a/packages/visitor-keys/src/visitor-keys.ts
+++ b/packages/visitor-keys/src/visitor-keys.ts
@@ -214,7 +214,7 @@ const additionalKeys: AdditionalKeys = {
   TSExternalModuleReference: ['expression'],
   TSFunctionType: SharedVisitorKeys.FunctionType,
   TSImportEqualsDeclaration: ['id', 'moduleReference'],
-  TSImportType: ['source', 'options', 'qualifier', 'typeArguments'],
+  TSImportType: ['source', 'options'],
   TSIndexedAccessType: ['objectType', 'indexType'],
   TSIndexSignature: ['parameters', 'typeAnnotation'],
   TSInferType: ['typeParameter'],


### PR DESCRIPTION
BREAKING CHANGE: Qualified import types are now represented using the standard `TSTypeReference` and `TSQualifiedName` structure. `TSImportType` no longer contains `qualifier` or `typeArguments`; its range is limited to the `import(...)` expression.

## PR Checklist

- [x] Addresses an existing open issue: fixes #~11615~
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

This standardizes qualified import types with the rest of the ESTree TypeScript AST. For example, `import('mod').A<T>` is now a `TSTypeReference` whose `typeName` is a `TSQualifiedName` rooted at the `TSImportType`, and whose `typeArguments` live on the reference. `typeof import('mod').A<T>` remains a `TSTypeQuery`, with the qualified name in `exprName` and type arguments on the query.

The change also updates visitor keys, scope analysis, and affected rules for the new nesting. Regression coverage checks multi-segment qualified names, node ranges, type arguments, `typeof` queries, scope analysis, and rule behavior. Generated AST and Babel-alignment snapshots document the breaking output change.

Validation included the focused converter suite (34 tests), the affected rule suites (82 tests), import-type scope fixtures (4 tests), the visitor-keys suite (336 tests), the complete AST fixture file (4,545 passing cases and 8,101 intentionally skipped parser variants), exact touched-file ESLint and Prettier checks, no-emit TypeScript checks for all five affected package scopes, `git diff --check`, and the repository's lint-staged pre-commit check.

AI assistance disclosure: I used Codex with GPT-5 to help inspect the existing AST conversion patterns, implement the change, and draft tests. I reviewed every changed line and generated snapshot, ran the validation listed above, understand the implementation, and can respond to review feedback.

💖