### PR TITLE
feat(eslint-plugin): add rule [no-redundant-default-arguments]

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-redundant-default-arguments.mdx
+++ b/packages/eslint-plugin/docs/rules/no-redundant-default-arguments.mdx
@@ -1,0 +1,90 @@
+---
+description: 'Disallow explicitly passing arguments that are equal to their parameter default value.'
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+> 🛑 This file is source code, not the primary documentation location! 🛑
+>
+> See **https://typescript-eslint.io/rules/no-redundant-default-arguments** for documentation.
+
+When a parameter declares a [default value](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters), explicitly passing that same value at a call site is redundant.
+The call behaves identically without the argument.
+Omitting the argument also keeps call sites up to date if the default value is ever changed.
+
+This rule reports arguments, destructured object properties, and JSX props that are identical to the default value declared by the called function.
+Type information is used to resolve the called function, so calls to functions declared in other files are checked as well.
+
+To avoid false positives, the rule intentionally stays conservative:
+
+- Only literal values (strings, numbers, bigints, booleans, `null`, and expression-free template literals) are compared.
+- Only functions whose implementation is a function declaration or a function assigned directly to a `const` variable are checked.
+- Positional arguments are only reported when all following arguments are also redundant, since an argument in the middle of an argument list cannot be removed.
+- Arguments, properties, and props that may be overridden by a spread are not reported.
+
+## Examples
+
+<Tabs>
+<TabItem value="❌ Incorrect">
+
+```ts
+function greet(name = 'world') {
+  return `Hello, ${name}!`;
+}
+greet('world');
+
+const paginate = (page = 1, pageSize = 50) => [page, pageSize];
+paginate(1, 50);
+
+function search({ caseSensitive = false }) {
+  return caseSensitive;
+}
+search({ caseSensitive: false });
+```
+
+```tsx
+function Status({ visible = true }) {
+  return visible ? 'visible' : 'hidden';
+}
+
+<Status visible={true} />;
+```
+
+</TabItem>
+<TabItem value="✅ Correct">
+
+```ts
+function greet(name = 'world') {
+  return `Hello, ${name}!`;
+}
+greet();
+greet('typescript-eslint');
+
+const paginate = (page = 1, pageSize = 50) => [page, pageSize];
+paginate(2);
+
+function search({ caseSensitive = false }) {
+  return caseSensitive;
+}
+search({ caseSensitive: true });
+```
+
+```tsx
+function Status({ visible = true }) {
+  return visible ? 'visible' : 'hidden';
+}
+
+<Status />;
+<Status visible={false} />;
+```
+
+</TabItem>
+</Tabs>
+
+## When Not To Use It
+
+If you prefer call sites to be explicit about the values they pass — for example, to protect them from changes to default values — you may not want this rule.
+
+In rare cases, removing an argument can be observable at runtime, such as when the called function inspects [`arguments.length`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments/length).
+For that reason this rule provides suggestions rather than an auto-fix, so removals are always applied deliberately.

--- a/packages/eslint-plugin/src/configs/eslintrc/all.ts
+++ b/packages/eslint-plugin/src/configs/eslintrc/all.ts
@@ -80,6 +80,7 @@ export = {
     '@typescript-eslint/no-non-null-assertion': 'error',
     'no-redeclare': 'off',
     '@typescript-eslint/no-redeclare': 'error',
+    '@typescript-eslint/no-redundant-default-arguments': 'error',
     '@typescript-eslint/no-redundant-type-constituents': 'error',
     '@typescript-eslint/no-require-imports': 'error',
     '@typescript-eslint/no-restricted-types': 'error',

--- a/packages/eslint-plugin/src/configs/eslintrc/disable-type-checked.ts
+++ b/packages/eslint-plugin/src/configs/eslintrc/disable-type-checked.ts
@@ -27,6 +27,7 @@ export = {
     '@typescript-eslint/no-misused-promises': 'off',
     '@typescript-eslint/no-misused-spread': 'off',
     '@typescript-eslint/no-mixed-enums': 'off',
+    '@typescript-eslint/no-redundant-default-arguments': 'off',
     '@typescript-eslint/no-redundant-type-constituents': 'off',
     '@typescript-eslint/no-unnecessary-boolean-literal-compare': 'off',
     '@typescript-eslint/no-unnecessary-condition': 'off',

--- a/packages/eslint-plugin/src/configs/flat/all.ts
+++ b/packages/eslint-plugin/src/configs/flat/all.ts
@@ -93,6 +93,7 @@ export default (
       '@typescript-eslint/no-non-null-assertion': 'error',
       'no-redeclare': 'off',
       '@typescript-eslint/no-redeclare': 'error',
+      '@typescript-eslint/no-redundant-default-arguments': 'error',
       '@typescript-eslint/no-redundant-type-constituents': 'error',
       '@typescript-eslint/no-require-imports': 'error',
       '@typescript-eslint/no-restricted-types': 'error',

--- a/packages/eslint-plugin/src/configs/flat/disable-type-checked.ts
+++ b/packages/eslint-plugin/src/configs/flat/disable-type-checked.ts
@@ -34,6 +34,7 @@ export default (
     '@typescript-eslint/no-misused-promises': 'off',
     '@typescript-eslint/no-misused-spread': 'off',
     '@typescript-eslint/no-mixed-enums': 'off',
+    '@typescript-eslint/no-redundant-default-arguments': 'off',
     '@typescript-eslint/no-redundant-type-constituents': 'off',
     '@typescript-eslint/no-unnecessary-boolean-literal-compare': 'off',
     '@typescript-eslint/no-unnecessary-condition': 'off',

--- a/packages/eslint-plugin/src/rules/index.ts
+++ b/packages/eslint-plugin/src/rules/index.ts
@@ -60,6 +60,7 @@ import noNonNullAssertedNullishCoalescing from './no-non-null-asserted-nullish-c
 import noNonNullAssertedOptionalChain from './no-non-null-asserted-optional-chain';
 import noNonNullAssertion from './no-non-null-assertion';
 import noRedeclare from './no-redeclare';
+import noRedundantDefaultArguments from './no-redundant-default-arguments';
 import noRedundantTypeConstituents from './no-redundant-type-constituents';
 import noRequireImports from './no-require-imports';
 import noRestrictedImports from './no-restricted-imports';
@@ -196,6 +197,7 @@ const rules = {
   'no-non-null-asserted-optional-chain': noNonNullAssertedOptionalChain,
   'no-non-null-assertion': noNonNullAssertion,
   'no-redeclare': noRedeclare,
+  'no-redundant-default-arguments': noRedundantDefaultArguments,
   'no-redundant-type-constituents': noRedundantTypeConstituents,
   'no-require-imports': noRequireImports,
   'no-restricted-imports': noRestrictedImports,

--- a/packages/eslint-plugin/src/rules/no-redundant-default-arguments.ts
+++ b/packages/eslint-plugin/src/rules/no-redundant-default-arguments.ts
@@ -1,0 +1,664 @@
+import type { TSESTree } from '@typescript-eslint/utils';
+
+import { AST_NODE_TYPES, ASTUtils } from '@typescript-eslint/utils';
+import * as ts from 'typescript';
+
+import { createRule, getParserServices, nullThrows } from '../util';
+
+const NOT_HARDCODED = Symbol('not hardcoded');
+
+type HardcodedValue = bigint | boolean | number | string | null;
+
+interface NamedDefault {
+  name: string;
+  value: HardcodedValue;
+}
+
+interface ParameterDefaults {
+  positional: Map<number, NamedDefault>;
+  properties: Map<number, Map<string, NamedDefault>>;
+}
+
+function getStaticLiteralValue(
+  node: TSESTree.Node,
+): HardcodedValue | typeof NOT_HARDCODED {
+  switch (node.type) {
+    case AST_NODE_TYPES.TSAsExpression:
+    case AST_NODE_TYPES.TSNonNullExpression:
+    case AST_NODE_TYPES.TSSatisfiesExpression:
+    case AST_NODE_TYPES.TSTypeAssertion:
+      return getStaticLiteralValue(node.expression);
+
+    case AST_NODE_TYPES.Literal: {
+      const { value } = node;
+      if (value == null) {
+        // A regex literal's value is null in environments that don't support
+        // its flags; only a true `null` literal counts.
+        return node.raw === 'null' ? null : NOT_HARDCODED;
+      }
+      if (typeof value === 'object') {
+        // RegExp literal.
+        return NOT_HARDCODED;
+      }
+      return value;
+    }
+
+    case AST_NODE_TYPES.TemplateLiteral: {
+      if (node.expressions.length !== 0) {
+        return NOT_HARDCODED;
+      }
+      const cooked = node.quasis[0].value.cooked;
+      return cooked;
+    }
+
+    case AST_NODE_TYPES.UnaryExpression: {
+      if (node.operator !== '-' && node.operator !== '+') {
+        return NOT_HARDCODED;
+      }
+      const operand = getStaticLiteralValue(node.argument);
+      if (typeof operand === 'number') {
+        return node.operator === '-' ? -operand : operand;
+      }
+      if (typeof operand === 'bigint' && node.operator === '-') {
+        return -operand;
+      }
+      return NOT_HARDCODED;
+    }
+
+    default:
+      return NOT_HARDCODED;
+  }
+}
+
+function unwrapTsExpression(node: ts.Expression): ts.Expression {
+  if (
+    ts.isAsExpression(node) ||
+    ts.isNonNullExpression(node) ||
+    ts.isParenthesizedExpression(node) ||
+    ts.isSatisfiesExpression(node) ||
+    ts.isTypeAssertionExpression(node)
+  ) {
+    return unwrapTsExpression(node.expression);
+  }
+  return node;
+}
+
+function getTsStaticLiteralValue(
+  expression: ts.Expression,
+): HardcodedValue | typeof NOT_HARDCODED {
+  const node = unwrapTsExpression(expression);
+
+  if (ts.isStringLiteralLike(node)) {
+    return node.text;
+  }
+  if (ts.isNumericLiteral(node)) {
+    return Number(node.text);
+  }
+  if (ts.isBigIntLiteral(node)) {
+    const text = node.text.replaceAll('_', '');
+    return BigInt(text.endsWith('n') ? text.slice(0, -1) : text);
+  }
+  if (node.kind === ts.SyntaxKind.TrueKeyword) {
+    return true;
+  }
+  if (node.kind === ts.SyntaxKind.FalseKeyword) {
+    return false;
+  }
+  if (node.kind === ts.SyntaxKind.NullKeyword) {
+    return null;
+  }
+  if (ts.isPrefixUnaryExpression(node)) {
+    const operand = getTsStaticLiteralValue(node.operand);
+    if (typeof operand === 'number') {
+      if (node.operator === ts.SyntaxKind.MinusToken) {
+        return -operand;
+      }
+      if (node.operator === ts.SyntaxKind.PlusToken) {
+        return operand;
+      }
+    }
+    if (
+      typeof operand === 'bigint' &&
+      node.operator === ts.SyntaxKind.MinusToken
+    ) {
+      return -operand;
+    }
+  }
+  return NOT_HARDCODED;
+}
+
+function getTsPropertyName(
+  node: ts.BindingName | ts.PropertyName,
+): string | undefined {
+  if (ts.isIdentifier(node) || ts.isStringLiteralLike(node)) {
+    return node.text;
+  }
+  if (ts.isNumericLiteral(node)) {
+    return String(Number(node.text));
+  }
+  return undefined;
+}
+
+function getTsObjectPatternDefaults(
+  pattern: ts.ObjectBindingPattern,
+): Map<string, NamedDefault> {
+  const defaults = new Map<string, NamedDefault>();
+
+  for (const element of pattern.elements) {
+    if (element.dotDotDotToken || element.initializer == null) {
+      continue;
+    }
+
+    const name = getTsPropertyName(element.propertyName ?? element.name);
+    if (name == null) {
+      continue;
+    }
+
+    const value = getTsStaticLiteralValue(element.initializer);
+    if (value !== NOT_HARDCODED) {
+      defaults.set(name, { name, value });
+    }
+  }
+
+  return defaults;
+}
+
+type TrustedDeclaration =
+  ts.ArrowFunction | ts.FunctionDeclaration | ts.FunctionExpression;
+
+function getParameterDefaults(
+  declaration: TrustedDeclaration,
+): ParameterDefaults {
+  const defaults: ParameterDefaults = {
+    positional: new Map(),
+    properties: new Map(),
+  };
+  let parameterIndex = 0;
+
+  for (const parameter of declaration.parameters) {
+    if (ts.isIdentifier(parameter.name) && parameter.name.text === 'this') {
+      continue;
+    }
+
+    if (ts.isIdentifier(parameter.name) && parameter.initializer != null) {
+      const value = getTsStaticLiteralValue(parameter.initializer);
+      if (value !== NOT_HARDCODED) {
+        defaults.positional.set(parameterIndex, {
+          name: parameter.name.text,
+          value,
+        });
+      }
+    } else if (ts.isObjectBindingPattern(parameter.name)) {
+      const properties = getTsObjectPatternDefaults(parameter.name);
+      if (properties.size > 0) {
+        defaults.properties.set(parameterIndex, properties);
+      }
+    }
+
+    parameterIndex++;
+  }
+
+  return defaults;
+}
+
+/**
+ * A declaration's parameter defaults are only trusted when the value called at
+ * runtime is guaranteed to be the declared function itself: a function
+ * declaration, or a function expression assigned directly to a `const`
+ * variable.
+ */
+function isTrustedFunctionDeclaration(
+  declaration: ts.JSDocSignature | ts.SignatureDeclaration,
+): declaration is TrustedDeclaration {
+  if (ts.isFunctionDeclaration(declaration)) {
+    return declaration.body != null;
+  }
+
+  if (
+    !ts.isArrowFunction(declaration) &&
+    !ts.isFunctionExpression(declaration)
+  ) {
+    return false;
+  }
+
+  let node: ts.Node = declaration;
+  while (
+    ts.isParenthesizedExpression(node.parent) ||
+    ts.isAsExpression(node.parent) ||
+    ts.isSatisfiesExpression(node.parent) ||
+    ts.isNonNullExpression(node.parent) ||
+    ts.isTypeAssertionExpression(node.parent)
+  ) {
+    node = node.parent;
+  }
+
+  return (
+    ts.isVariableDeclaration(node.parent) &&
+    node.parent.initializer === node &&
+    (ts.getCombinedNodeFlags(node.parent) & ts.NodeFlags.Const) !== 0
+  );
+}
+
+function getPropertyName(property: TSESTree.Property): string | undefined {
+  if (property.computed) {
+    return undefined;
+  }
+  if (property.key.type === AST_NODE_TYPES.Identifier) {
+    return property.key.name;
+  }
+  return String(property.key.value);
+}
+
+function formatValue(value: HardcodedValue): string {
+  if (typeof value === 'string') {
+    return JSON.stringify(value);
+  }
+  if (typeof value === 'bigint') {
+    return `${value}n`;
+  }
+  if (Object.is(value, -0)) {
+    return '-0';
+  }
+  return String(value);
+}
+
+export default createRule({
+  name: 'no-redundant-default-arguments',
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Disallow explicitly passing arguments that are equal to their parameter default value',
+      requiresTypeChecking: true,
+    },
+    hasSuggestions: true,
+    messages: {
+      redundantDefault:
+        'Explicitly passing the default value ({{value}}) of `{{name}}` is redundant.',
+      removeArguments: 'Remove the redundant trailing arguments.',
+      removeAttribute: 'Remove the redundant attribute.',
+      removeProperty: 'Remove the redundant property.',
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    const services = getParserServices(context);
+    const checker = services.program.getTypeChecker();
+
+    function isStableIdentifier(
+      identifier: TSESTree.Identifier | TSESTree.JSXIdentifier,
+    ): boolean {
+      const variable = ASTUtils.findVariable(
+        context.sourceCode.getScope(identifier),
+        identifier.name,
+      );
+      return (
+        variable != null &&
+        variable.defs.length > 0 &&
+        !variable.references.some(
+          reference => reference.isWrite() && !reference.init,
+        )
+      );
+    }
+
+    function getCallLikeDefaults(
+      node: TSESTree.CallExpression | TSESTree.JSXOpeningElement,
+    ): ParameterDefaults | undefined {
+      const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+      const declaration = checker.getResolvedSignature(tsNode)?.declaration;
+      if (declaration == null || !isTrustedFunctionDeclaration(declaration)) {
+        return undefined;
+      }
+
+      return getParameterDefaults(declaration);
+    }
+
+    function hasCommentInRange(range: TSESTree.Range): boolean {
+      return context.sourceCode
+        .getAllComments()
+        .some(
+          comment =>
+            comment.range[0] >= range[0] && comment.range[1] <= range[1],
+        );
+    }
+
+    /**
+     * Computes the source range that removes all arguments from `firstIndex`
+     * through the end of the argument list, or `undefined` when the removal
+     * cannot be done safely.
+     */
+    function getTrailingArgumentsRemovalRange(
+      node: TSESTree.CallExpression,
+      firstIndex: number,
+    ): TSESTree.Range | undefined {
+      const closingParen = nullThrows(
+        context.sourceCode.getLastToken(node),
+        'Call expressions always end with a closing parenthesis.',
+      );
+
+      let start: number;
+      if (firstIndex === 0) {
+        // Walk left over any parentheses wrapping the first argument to find
+        // the call expression's own opening parenthesis.
+        let openingParen: TSESTree.Token | undefined;
+        let token = context.sourceCode.getTokenBefore(
+          nullThrows(
+            context.sourceCode.getFirstToken(node.arguments[0]),
+            'Arguments always contain at least one token.',
+          ),
+        );
+        while (token != null && ASTUtils.isOpeningParenToken(token)) {
+          openingParen = token;
+          token = context.sourceCode.getTokenBefore(token);
+        }
+        start = nullThrows(
+          openingParen,
+          'The first argument is always preceded by the opening parenthesis.',
+        ).range[1];
+      } else {
+        // Walk right over any parentheses wrapping the previous argument to
+        // find the comma that separates it from the removed arguments.
+        let token = context.sourceCode.getTokenAfter(
+          node.arguments[firstIndex - 1],
+        );
+        while (token != null && ASTUtils.isClosingParenToken(token)) {
+          token = context.sourceCode.getTokenAfter(token);
+        }
+        const comma = nullThrows(
+          token != null && ASTUtils.isCommaToken(token) ? token : undefined,
+          'Arguments are always separated by a comma.',
+        );
+        start = nullThrows(
+          context.sourceCode.getTokenBefore(comma),
+          'A comma token always has a preceding token.',
+        ).range[1];
+      }
+
+      const range: TSESTree.Range = [start, closingParen.range[0]];
+      if (hasCommentInRange(range)) {
+        return undefined;
+      }
+      return range;
+    }
+
+    function getPropertyRemovalRange(
+      property: TSESTree.Property,
+    ): TSESTree.Range | undefined {
+      const tokenBefore = nullThrows(
+        context.sourceCode.getTokenBefore(property),
+        'Object properties always have a preceding token.',
+      );
+      const tokenAfter = nullThrows(
+        context.sourceCode.getTokenAfter(property),
+        'Object properties always have a following token.',
+      );
+
+      let range: TSESTree.Range;
+      if (ASTUtils.isCommaToken(tokenAfter)) {
+        const tokenAfterComma = nullThrows(
+          context.sourceCode.getTokenAfter(tokenAfter),
+          'A comma inside an object literal always has a following token.',
+        );
+        range = [property.range[0], tokenAfterComma.range[0]];
+      } else if (ASTUtils.isCommaToken(tokenBefore)) {
+        range = [tokenBefore.range[0], property.range[1]];
+      } else {
+        range = [tokenBefore.range[1], tokenAfter.range[0]];
+      }
+      if (hasCommentInRange(range)) {
+        return undefined;
+      }
+      return range;
+    }
+
+    function getAttributeRemovalRange(
+      attribute: TSESTree.JSXAttribute,
+    ): TSESTree.Range | undefined {
+      const tokenBefore = nullThrows(
+        context.sourceCode.getTokenBefore(attribute),
+        'JSX attributes always have a preceding token.',
+      );
+
+      const range: TSESTree.Range = [tokenBefore.range[1], attribute.range[1]];
+      if (hasCommentInRange(range)) {
+        return undefined;
+      }
+      return range;
+    }
+
+    function report(
+      node: TSESTree.Node,
+      defaultValue: NamedDefault,
+      suggestionMessageId:
+        'removeArguments' | 'removeAttribute' | 'removeProperty',
+      removalRange: TSESTree.Range | undefined,
+    ): void {
+      context.report({
+        node,
+        messageId: 'redundantDefault',
+        data: {
+          name: defaultValue.name,
+          value: formatValue(defaultValue.value),
+        },
+        suggest:
+          removalRange == null
+            ? null
+            : [
+                {
+                  messageId: suggestionMessageId,
+                  fix: fixer => fixer.removeRange(removalRange),
+                },
+              ],
+      });
+    }
+
+    function checkObjectArgument(
+      node: TSESTree.ObjectExpression,
+      defaults: Map<string, NamedDefault>,
+    ): void {
+      if (
+        node.properties.some(
+          property => property.type === AST_NODE_TYPES.SpreadElement,
+        )
+      ) {
+        return;
+      }
+
+      const seen = new Set<string>();
+      // Iterate from the end so that only the last occurrence of a duplicate
+      // property name - the one that wins at runtime - is considered.
+      for (let index = node.properties.length - 1; index >= 0; index--) {
+        const property = node.properties[index];
+        if (
+          property.type !== AST_NODE_TYPES.Property ||
+          property.kind !== 'init'
+        ) {
+          continue;
+        }
+
+        const name = getPropertyName(property);
+        if (name == null || seen.has(name)) {
+          continue;
+        }
+        seen.add(name);
+
+        const defaultValue = defaults.get(name);
+        if (defaultValue == null) {
+          continue;
+        }
+
+        const value = getStaticLiteralValue(property.value);
+        if (value !== NOT_HARDCODED && Object.is(value, defaultValue.value)) {
+          report(
+            property,
+            defaultValue,
+            'removeProperty',
+            getPropertyRemovalRange(property),
+          );
+        }
+      }
+    }
+
+    function checkCallArguments(
+      node: TSESTree.CallExpression,
+      defaults: ParameterDefaults,
+    ): void {
+      const firstSpreadIndex = node.arguments.findIndex(
+        argument => argument.type === AST_NODE_TYPES.SpreadElement,
+      );
+
+      if (firstSpreadIndex === -1) {
+        // Only a trailing run of redundant arguments is reported: removing an
+        // earlier argument would shift the position of later ones.
+        let firstRedundantIndex = node.arguments.length;
+        for (let index = node.arguments.length - 1; index >= 0; index--) {
+          const defaultValue = defaults.positional.get(index);
+          if (defaultValue == null) {
+            break;
+          }
+          const value = getStaticLiteralValue(node.arguments[index]);
+          if (
+            value === NOT_HARDCODED ||
+            !Object.is(value, defaultValue.value)
+          ) {
+            break;
+          }
+          firstRedundantIndex = index;
+        }
+
+        if (firstRedundantIndex < node.arguments.length) {
+          const removalRange = getTrailingArgumentsRemovalRange(
+            node,
+            firstRedundantIndex,
+          );
+          for (
+            let index = firstRedundantIndex;
+            index < node.arguments.length;
+            index++
+          ) {
+            report(
+              node.arguments[index],
+              nullThrows(
+                defaults.positional.get(index),
+                'Indices in the trailing run always have a default.',
+              ),
+              'removeArguments',
+              removalRange,
+            );
+          }
+        }
+      }
+
+      // Arguments after a spread element are not necessarily aligned with the
+      // parameter at the same index.
+      const alignedArgumentCount =
+        firstSpreadIndex === -1 ? node.arguments.length : firstSpreadIndex;
+      for (let index = 0; index < alignedArgumentCount; index++) {
+        const argument = node.arguments[index];
+        const propertyDefaults = defaults.properties.get(index);
+        if (
+          propertyDefaults != null &&
+          argument.type === AST_NODE_TYPES.ObjectExpression
+        ) {
+          checkObjectArgument(argument, propertyDefaults);
+        }
+      }
+    }
+
+    function checkJsxAttributes(
+      node: TSESTree.JSXOpeningElement,
+      defaults: Map<string, NamedDefault>,
+    ): void {
+      if (
+        node.attributes.some(
+          attribute => attribute.type === AST_NODE_TYPES.JSXSpreadAttribute,
+        )
+      ) {
+        return;
+      }
+
+      const seen = new Set<string>();
+      // Iterate from the end so that only the last occurrence of a duplicate
+      // attribute name - the one that wins at runtime - is considered.
+      for (let index = node.attributes.length - 1; index >= 0; index--) {
+        const attribute = node.attributes[index];
+        if (
+          attribute.type !== AST_NODE_TYPES.JSXAttribute ||
+          attribute.name.type !== AST_NODE_TYPES.JSXIdentifier
+        ) {
+          continue;
+        }
+
+        const name = attribute.name.name;
+        if (seen.has(name)) {
+          continue;
+        }
+        seen.add(name);
+
+        const defaultValue = defaults.get(name);
+        if (defaultValue == null) {
+          continue;
+        }
+
+        let value: HardcodedValue | typeof NOT_HARDCODED;
+        if (attribute.value == null) {
+          // A shorthand attribute (`<Component enabled />`) passes `true`.
+          value = true;
+        } else if (
+          attribute.value.type === AST_NODE_TYPES.JSXExpressionContainer
+        ) {
+          value =
+            attribute.value.expression.type ===
+            AST_NODE_TYPES.JSXEmptyExpression
+              ? NOT_HARDCODED
+              : getStaticLiteralValue(attribute.value.expression);
+        } else if (attribute.value.type === AST_NODE_TYPES.Literal) {
+          value = getStaticLiteralValue(attribute.value);
+        } else {
+          value = NOT_HARDCODED;
+        }
+
+        if (value !== NOT_HARDCODED && Object.is(value, defaultValue.value)) {
+          report(
+            attribute,
+            defaultValue,
+            'removeAttribute',
+            getAttributeRemovalRange(attribute),
+          );
+        }
+      }
+    }
+
+    return {
+      CallExpression(node): void {
+        if (
+          node.callee.type !== AST_NODE_TYPES.Identifier ||
+          !isStableIdentifier(node.callee)
+        ) {
+          return;
+        }
+
+        const defaults = getCallLikeDefaults(node);
+        if (defaults != null) {
+          checkCallArguments(node, defaults);
+        }
+      },
+
+      JSXOpeningElement(node): void {
+        if (
+          node.name.type !== AST_NODE_TYPES.JSXIdentifier ||
+          node.name.name[0] !== node.name.name[0].toUpperCase() ||
+          !isStableIdentifier(node.name)
+        ) {
+          return;
+        }
+
+        const propertyDefaults = getCallLikeDefaults(node)?.properties.get(0);
+        if (propertyDefaults != null) {
+          checkJsxAttributes(node, propertyDefaults);
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-redundant-default-arguments.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-redundant-default-arguments.shot
@@ -1,0 +1,52 @@
+Incorrect
+
+function greet(name = 'world') {
+  return `Hello, ${name}!`;
+}
+greet('world');
+      ~~~~~~~ Explicitly passing the default value ("world") of `name` is redundant.
+
+const paginate = (page = 1, pageSize = 50) => [page, pageSize];
+paginate(1, 50);
+         ~ Explicitly passing the default value (1) of `page` is redundant.
+            ~~ Explicitly passing the default value (50) of `pageSize` is redundant.
+
+function search({ caseSensitive = false }) {
+  return caseSensitive;
+}
+search({ caseSensitive: false });
+         ~~~~~~~~~~~~~~~~~~~~ Explicitly passing the default value (false) of `caseSensitive` is redundant.
+
+Incorrect
+
+function Status({ visible = true }) {
+  return visible ? 'visible' : 'hidden';
+}
+
+<Status visible={true} />;
+        ~~~~~~~~~~~~~~ Explicitly passing the default value (true) of `visible` is redundant.
+
+Correct
+
+function greet(name = 'world') {
+  return `Hello, ${name}!`;
+}
+greet();
+greet('typescript-eslint');
+
+const paginate = (page = 1, pageSize = 50) => [page, pageSize];
+paginate(2);
+
+function search({ caseSensitive = false }) {
+  return caseSensitive;
+}
+search({ caseSensitive: true });
+
+Correct
+
+function Status({ visible = true }) {
+  return visible ? 'visible' : 'hidden';
+}
+
+<Status />;
+<Status visible={false} />;

--- a/packages/eslint-plugin/tests/rules/no-redundant-default-arguments.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-redundant-default-arguments.test.ts
@@ -1,0 +1,1275 @@
+import { noFormat } from '@typescript-eslint/rule-tester';
+
+import rule from '../../src/rules/no-redundant-default-arguments';
+import { createRuleTesterWithTypes } from '../RuleTester';
+
+const ruleTester = createRuleTesterWithTypes();
+
+ruleTester.run('no-redundant-default-arguments', rule, {
+  valid: [
+    `
+function foo(value = 0) {}
+foo();
+    `,
+    `
+function foo(value = 0) {}
+foo(1);
+    `,
+    `
+const zero = 0;
+function foo(value = 0) {}
+foo(zero);
+    `,
+    `
+const DEFAULT_VALUE = 5;
+function foo(value = DEFAULT_VALUE) {}
+foo(5);
+    `,
+    `
+function foo(value = 0, other = 1) {}
+foo(0, 2);
+    `,
+    `
+declare const values: [number];
+function foo(first: number, value = 20) {}
+foo(...values, 20);
+    `,
+    `
+declare const values: number[];
+function foo(value = 20, ...rest: number[]) {}
+foo(20, ...values);
+    `,
+    `
+declare const values: [unknown];
+function foo(first: unknown, { value = 5 }) {}
+foo(...values, { value: 5 });
+    `,
+    `
+function foo(value: number) {}
+foo(0);
+    `,
+    `
+const object = {
+  foo(value = 0) {},
+};
+object.foo(0);
+    `,
+    `
+let foo = (value = 0) => {};
+foo(0);
+    `,
+    `
+function foo(value = 0) {}
+function bar(value = 1) {}
+foo = bar;
+foo(0);
+    `,
+    `
+function foo(value = 1) {}
+function outer() {
+  function foo(value = 0) {}
+  foo(1);
+}
+    `,
+    `
+function foo({ value = 0 }) {}
+foo({ value: 1 });
+    `,
+    `
+const value = 0;
+function foo({ value = 0 }) {}
+foo({ value });
+    `,
+    `
+declare const other: object;
+function foo({ value = 0 }) {}
+foo({ value: 0, ...other });
+    `,
+    `
+declare const other: object;
+function foo({ value = 0 }) {}
+foo({ ...other, value: 0 });
+    `,
+    `
+function foo(value = -0) {}
+foo(0);
+    `,
+    `
+function foo(value: number): void;
+function foo(value = 0): void {}
+foo(0);
+    `,
+    `
+const foo: (value?: number) => void = (value = 0) => {};
+foo(0);
+    `,
+    `
+function foo(value = 0) {}
+foo(undefined);
+    `,
+    `
+function foo(value = NaN) {}
+foo(NaN);
+    `,
+    `
+function foo(value: number | string = 5) {}
+foo('5');
+    `,
+    `
+function foo(a = 1, b = 2) {}
+foo(1, 3);
+    `,
+    `
+class C {
+  foo(value = 0) {}
+}
+new C().foo(0);
+    `,
+    `
+function foo(value = \`a\${1}b\`) {}
+foo('a1b');
+    `,
+    `
+function foo(value = /a/) {}
+foo(/a/);
+    `,
+    `
+enum E {
+  A,
+}
+function foo(value = E.A) {}
+foo(E.A);
+    `,
+    `
+function foo(value = 1n) {}
+foo(2n);
+    `,
+    `
+function foo(value = 1) {}
+foo(/a/);
+    `,
+    `
+function foo(value = 'a1b') {}
+foo(\`a\${1}b\`);
+    `,
+    `
+function foo(value = 1) {}
+foo(~1);
+    `,
+    `
+function foo(value = 1) {}
+foo(-'a');
+    `,
+    `
+function foo(value = -'a') {}
+foo(1);
+    `,
+    `
+const key = 'value';
+function foo({ [key]: renamed = 1 }) {}
+foo({ value: 1 });
+    `,
+    `
+const d = 1;
+function foo({ value = d }) {}
+foo({ value: 1 });
+    `,
+    `
+function foo({ value = 5 }) {}
+foo({
+  get value() {
+    return 5;
+  },
+});
+    `,
+    `
+const key = 'value';
+function foo({ value = 1 }) {}
+foo({ [key]: 1 });
+    `,
+    `
+function foo({ value = 1 }) {}
+foo({ other: 1 });
+    `,
+    `
+function foo({ value = 1, ...rest }) {}
+foo({ value: 2 });
+    `,
+    {
+      code: '<Foo value={5} />;',
+      filename: 'react.tsx',
+    },
+    {
+      code: `
+function Foo({ value = 5 }) {
+  return null;
+}
+<Foo ns:value={5} />;
+      `,
+      filename: 'react.tsx',
+    },
+    {
+      code: `
+function Foo({ value = 5 }) {
+  return null;
+}
+<Foo other={1} />;
+      `,
+      filename: 'react.tsx',
+    },
+    {
+      code: noFormat`function Foo({ value = 5 }) { return null; } <Foo value=<div /> />;`,
+      filename: 'react.tsx',
+    },
+    {
+      code: `
+function Foo({ value = 5 }) {
+  return null;
+}
+<Foo value={6} />;
+      `,
+      filename: 'react.tsx',
+    },
+    {
+      code: `
+const dynamic = 5;
+function Foo({ value = 5 }) {
+  return null;
+}
+<Foo value={dynamic} />;
+      `,
+      filename: 'react.tsx',
+    },
+    {
+      code: `
+declare const props: object;
+function Foo({ value = 5 }) {
+  return null;
+}
+<Foo value={5} {...props} />;
+      `,
+      filename: 'react.tsx',
+    },
+    {
+      code: `
+declare const props: object;
+function Foo({ value = 5 }) {
+  return null;
+}
+<Foo {...props} value={5} />;
+      `,
+      filename: 'react.tsx',
+    },
+    {
+      code: `
+function div({ value = 5 }) {
+  return null;
+}
+<div value={5} />;
+      `,
+      filename: 'react.tsx',
+    },
+    {
+      code: `
+function Foo({ value = 5 }) {
+  return null;
+}
+<Foo value="5" />;
+      `,
+      filename: 'react.tsx',
+    },
+  ],
+  invalid: [
+    {
+      code: `
+function foo(value = 20) {}
+foo(20);
+      `,
+      errors: [
+        {
+          column: 5,
+          data: { name: 'value', value: '20' },
+          endColumn: 7,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefault',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+function foo(value = 20) {}
+foo();
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+foo(0);
+function foo(value = 0) {}
+      `,
+      errors: [
+        {
+          column: 5,
+          data: { name: 'value', value: '0' },
+          endColumn: 6,
+          endLine: 2,
+          line: 2,
+          messageId: 'redundantDefault',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+foo();
+function foo(value = 0) {}
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+const foo = (value = 'all') => {};
+foo('all');
+      `,
+      errors: [
+        {
+          column: 5,
+          data: { name: 'value', value: '"all"' },
+          endColumn: 10,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefault',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+const foo = (value = 'all') => {};
+foo();
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+const foo = function (value = false) {};
+foo(false);
+      `,
+      errors: [
+        {
+          column: 5,
+          data: { name: 'value', value: 'false' },
+          endColumn: 10,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefault',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+const foo = function (value = false) {};
+foo();
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+function foo(enabled = false, mode = 'all') {}
+foo(false, 'all');
+      `,
+      errors: [
+        {
+          column: 5,
+          data: { name: 'enabled', value: 'false' },
+          endColumn: 10,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefault',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+function foo(enabled = false, mode = 'all') {}
+foo();
+      `,
+            },
+          ],
+        },
+        {
+          column: 12,
+          data: { name: 'mode', value: '"all"' },
+          endColumn: 17,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefault',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+function foo(enabled = false, mode = 'all') {}
+foo();
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+function foo(first = false, second = true) {}
+foo(false, /* keep */ true);
+      `,
+      errors: [
+        {
+          column: 5,
+          data: { name: 'first', value: 'false' },
+          endColumn: 10,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefault',
+        },
+        {
+          column: 23,
+          data: { name: 'second', value: 'true' },
+          endColumn: 27,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefault',
+        },
+      ],
+    },
+    {
+      code: `
+function foo(value = -1) {}
+foo(-1);
+      `,
+      errors: [
+        {
+          column: 5,
+          data: { name: 'value', value: '-1' },
+          endColumn: 7,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefault',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+function foo(value = -1) {}
+foo();
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+function foo(value = 10n) {}
+foo(10n);
+      `,
+      errors: [
+        {
+          column: 5,
+          data: { name: 'value', value: '10n' },
+          endColumn: 8,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefault',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+function foo(value = 10n) {}
+foo();
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+const foo = (value = 5 as const) => {};
+foo(5 as const);
+      `,
+      errors: [
+        {
+          column: 5,
+          data: { name: 'value', value: '5' },
+          endColumn: 15,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefault',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+const foo = (value = 5 as const) => {};
+foo();
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+function foo(value = \`all\`) {}
+foo('all');
+      `,
+      errors: [
+        {
+          column: 5,
+          data: { name: 'value', value: '"all"' },
+          endColumn: 10,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefault',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+function foo(value = \`all\`) {}
+foo();
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+function foo({ value = 5 }) {}
+foo({ value: 5 });
+      `,
+      errors: [
+        {
+          column: 7,
+          data: { name: 'value', value: '5' },
+          endColumn: 15,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefault',
+          suggestions: [
+            {
+              messageId: 'removeProperty',
+              output: `
+function foo({ value = 5 }) {}
+foo({});
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+function foo({ value: renamed = 5 }) {}
+foo({ value: 5 });
+      `,
+      errors: [
+        {
+          column: 7,
+          data: { name: 'value', value: '5' },
+          endColumn: 15,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefault',
+          suggestions: [
+            {
+              messageId: 'removeProperty',
+              output: `
+function foo({ value: renamed = 5 }) {}
+foo({});
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+declare const values: number[];
+function foo({ value = 5 }, ...rest: number[]) {}
+foo({ value: 5 }, ...values);
+      `,
+      errors: [
+        {
+          column: 7,
+          data: { name: 'value', value: '5' },
+          endColumn: 15,
+          endLine: 4,
+          line: 4,
+          messageId: 'redundantDefault',
+          suggestions: [
+            {
+              messageId: 'removeProperty',
+              output: `
+declare const values: number[];
+function foo({ value = 5 }, ...rest: number[]) {}
+foo({}, ...values);
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+function foo({ first = 1, second = 2 }) {}
+foo({ first: 1, second: 2 });
+      `,
+      errors: [
+        {
+          column: 7,
+          data: { name: 'first', value: '1' },
+          endColumn: 15,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefault',
+          suggestions: [
+            {
+              messageId: 'removeProperty',
+              output: `
+function foo({ first = 1, second = 2 }) {}
+foo({ second: 2 });
+      `,
+            },
+          ],
+        },
+        {
+          column: 17,
+          data: { name: 'second', value: '2' },
+          endColumn: 26,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefault',
+          suggestions: [
+            {
+              messageId: 'removeProperty',
+              output: `
+function foo({ first = 1, second = 2 }) {}
+foo({ first: 1 });
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+function foo(a = 1, b = 2) {}
+foo(2, 2);
+      `,
+      errors: [
+        {
+          column: 8,
+          data: { name: 'b', value: '2' },
+          endColumn: 9,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefault',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+function foo(a = 1, b = 2) {}
+foo(2);
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+function foo({ 'a-b': value = 1 }) {}
+foo({ 'a-b': 1 });
+      `,
+      errors: [
+        {
+          column: 7,
+          data: { name: 'a-b', value: '1' },
+          endColumn: 15,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefault',
+          suggestions: [
+            {
+              messageId: 'removeProperty',
+              output: `
+function foo({ 'a-b': value = 1 }) {}
+foo({});
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+function foo(value = 1) {}
+foo(+1);
+      `,
+      errors: [
+        {
+          column: 5,
+          data: { name: 'value', value: '1' },
+          endColumn: 7,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefault',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+function foo(value = 1) {}
+foo();
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+function foo(value = +1) {}
+foo(1);
+      `,
+      errors: [
+        {
+          column: 5,
+          data: { name: 'value', value: '1' },
+          endColumn: 6,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefault',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+function foo(value = +1) {}
+foo();
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+function foo(value = 1_000n) {}
+foo(1000n);
+      `,
+      errors: [
+        {
+          column: 5,
+          data: { name: 'value', value: '1000n' },
+          endColumn: 10,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefault',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+function foo(value = 1_000n) {}
+foo();
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+function foo(value: number | null = null) {}
+foo(null);
+      `,
+      errors: [
+        {
+          column: 5,
+          data: { name: 'value', value: 'null' },
+          endColumn: 9,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefault',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+function foo(value: number | null = null) {}
+foo();
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+function foo({ 1: one = 2 }) {}
+foo({ 1: 2 });
+      `,
+      errors: [
+        {
+          column: 7,
+          data: { name: '1', value: '2' },
+          endColumn: 11,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefault',
+          suggestions: [
+            {
+              messageId: 'removeProperty',
+              output: `
+function foo({ 1: one = 2 }) {}
+foo({});
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+function foo(value = 'all') {}
+foo(\`all\`);
+      `,
+      errors: [
+        {
+          column: 5,
+          data: { name: 'value', value: '"all"' },
+          endColumn: 10,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefault',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+function foo(value = 'all') {}
+foo();
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+function foo(value = -1n) {}
+foo(-1n);
+      `,
+      errors: [
+        {
+          column: 5,
+          data: { name: 'value', value: '-1n' },
+          endColumn: 8,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefault',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+function foo(value = -1n) {}
+foo();
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+function foo(value = -0) {}
+foo(-0);
+      `,
+      errors: [
+        {
+          column: 5,
+          data: { name: 'value', value: '-0' },
+          endColumn: 7,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefault',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+function foo(value = -0) {}
+foo();
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+function foo(this: void, value = 1) {}
+foo(1);
+      `,
+      errors: [
+        {
+          column: 5,
+          data: { name: 'value', value: '1' },
+          endColumn: 6,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefault',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+function foo(this: void, value = 1) {}
+foo();
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: noFormat`const foo = ((value = 1) => {}); foo(1);`,
+      errors: [
+        {
+          column: 38,
+          data: { name: 'value', value: '1' },
+          endColumn: 39,
+          endLine: 1,
+          line: 1,
+          messageId: 'redundantDefault',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: 'const foo = ((value = 1) => {}); foo();',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+function foo({ value = 5 }) {}
+foo({ value: /* keep */ 5 });
+      `,
+      errors: [
+        {
+          column: 7,
+          data: { name: 'value', value: '5' },
+          endColumn: 26,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefault',
+        },
+      ],
+    },
+    {
+      code: `
+function foo({ value = 5 }) {}
+foo({ value: 1, value: 5 });
+      `,
+      errors: [
+        {
+          column: 17,
+          data: { name: 'value', value: '5' },
+          endColumn: 25,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefault',
+          suggestions: [
+            {
+              messageId: 'removeProperty',
+              output: `
+function foo({ value = 5 }) {}
+foo({ value: 1 });
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+function Foo({ value = 5 }) {
+  return null;
+}
+<Foo value={5 /* keep */} />;
+      `,
+      errors: [
+        {
+          column: 6,
+          data: { name: 'value', value: '5' },
+          endColumn: 26,
+          endLine: 5,
+          line: 5,
+          messageId: 'redundantDefault',
+        },
+      ],
+      filename: 'react.tsx',
+    },
+    {
+      code: `
+function Foo({ value = 5 }) {
+  return null;
+}
+<Foo value={6} value={5} />;
+      `,
+      errors: [
+        {
+          column: 16,
+          data: { name: 'value', value: '5' },
+          endColumn: 25,
+          endLine: 5,
+          line: 5,
+          messageId: 'redundantDefault',
+          suggestions: [
+            {
+              messageId: 'removeAttribute',
+              output: `
+function Foo({ value = 5 }) {
+  return null;
+}
+<Foo value={6} />;
+      `,
+            },
+          ],
+        },
+      ],
+      filename: 'react.tsx',
+    },
+    {
+      code: noFormat`function foo(value = 1) {} foo((1));`,
+      errors: [
+        {
+          column: 33,
+          data: { name: 'value', value: '1' },
+          endColumn: 34,
+          endLine: 1,
+          line: 1,
+          messageId: 'redundantDefault',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: 'function foo(value = 1) {} foo();',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: noFormat`function foo(a: number, b = 2) {} foo((1), 2);`,
+      errors: [
+        {
+          column: 44,
+          data: { name: 'b', value: '2' },
+          endColumn: 45,
+          endLine: 1,
+          line: 1,
+          messageId: 'redundantDefault',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: 'function foo(a: number, b = 2) {} foo((1));',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: noFormat`function foo(value = 1) {} foo(1,);`,
+      errors: [
+        {
+          column: 32,
+          data: { name: 'value', value: '1' },
+          endColumn: 33,
+          endLine: 1,
+          line: 1,
+          messageId: 'redundantDefault',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: 'function foo(value = 1) {} foo();',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+function Foo({ value = 5 }) {
+  return null;
+}
+<Foo value={5} />;
+      `,
+      errors: [
+        {
+          column: 6,
+          data: { name: 'value', value: '5' },
+          endColumn: 15,
+          endLine: 5,
+          line: 5,
+          messageId: 'redundantDefault',
+          suggestions: [
+            {
+              messageId: 'removeAttribute',
+              output: `
+function Foo({ value = 5 }) {
+  return null;
+}
+<Foo />;
+      `,
+            },
+          ],
+        },
+      ],
+      filename: 'react.tsx',
+    },
+    {
+      code: `
+const Foo = ({ label = 'hello' }) => null;
+<Foo label="hello" />;
+      `,
+      errors: [
+        {
+          column: 6,
+          data: { name: 'label', value: '"hello"' },
+          endColumn: 19,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefault',
+          suggestions: [
+            {
+              messageId: 'removeAttribute',
+              output: `
+const Foo = ({ label = 'hello' }) => null;
+<Foo />;
+      `,
+            },
+          ],
+        },
+      ],
+      filename: 'react.tsx',
+    },
+    {
+      code: `
+function Foo({ enabled = true }) {
+  return null;
+}
+<Foo enabled />;
+      `,
+      errors: [
+        {
+          column: 6,
+          data: { name: 'enabled', value: 'true' },
+          endColumn: 13,
+          endLine: 5,
+          line: 5,
+          messageId: 'redundantDefault',
+          suggestions: [
+            {
+              messageId: 'removeAttribute',
+              output: `
+function Foo({ enabled = true }) {
+  return null;
+}
+<Foo />;
+      `,
+            },
+          ],
+        },
+      ],
+      filename: 'react.tsx',
+    },
+    {
+      code: `
+function Foo({ value = 5 } = {}) {
+  return null;
+}
+<Foo value={5} />;
+      `,
+      errors: [
+        {
+          column: 6,
+          data: { name: 'value', value: '5' },
+          endColumn: 15,
+          endLine: 5,
+          line: 5,
+          messageId: 'redundantDefault',
+          suggestions: [
+            {
+              messageId: 'removeAttribute',
+              output: `
+function Foo({ value = 5 } = {}) {
+  return null;
+}
+<Foo />;
+      `,
+            },
+          ],
+        },
+      ],
+      filename: 'react.tsx',
+    },
+    {
+      code: `
+function Foo({ first = 1, second = 2 }) {
+  return null;
+}
+<Foo first={1} second={2} />;
+      `,
+      errors: [
+        {
+          column: 6,
+          data: { name: 'first', value: '1' },
+          endColumn: 15,
+          endLine: 5,
+          line: 5,
+          messageId: 'redundantDefault',
+          suggestions: [
+            {
+              messageId: 'removeAttribute',
+              output: `
+function Foo({ first = 1, second = 2 }) {
+  return null;
+}
+<Foo second={2} />;
+      `,
+            },
+          ],
+        },
+        {
+          column: 16,
+          data: { name: 'second', value: '2' },
+          endColumn: 26,
+          endLine: 5,
+          line: 5,
+          messageId: 'redundantDefault',
+          suggestions: [
+            {
+              messageId: 'removeAttribute',
+              output: `
+function Foo({ first = 1, second = 2 }) {
+  return null;
+}
+<Foo first={1} />;
+      `,
+            },
+          ],
+        },
+      ],
+      filename: 'react.tsx',
+    },
+  ],
+});

--- a/packages/eslint-plugin/tests/schema-snapshots/no-redundant-default-arguments.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-redundant-default-arguments.shot
@@ -1,0 +1,10 @@
+
+# SCHEMA:
+
+[]
+
+
+# TYPES:
+
+/** No options declared */
+type Options = [];


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #12782
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

Implements the new no-redundant-default-arguments lint rule, which reports arguments that exactly match a function parameter's default value and are therefore redundant. The rule is intentionally conservative: it handles simple literal values such as strings, numbers, booleans, and null, while avoiding reports when resolution is uncertain, including overloads, reassigned functions, and spreads. Reports provide a suggestion to remove the redundant argument rather than an automatic fix. The implementation includes 88 tests and a documentation page. The repository has no issue-claiming system, and I'm happy to coordinate if anyone else is working on this.
