### PR TITLE
fix(typescript-estree): include decorators in exported class ranges

### DIFF
--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -3027,14 +3027,19 @@ export class Converter {
       const varToken = declarationIsDefault
         ? findNextToken(nextModifier, this.ast, this.ast)
         : findNextToken(exportKeyword, this.ast, this.ast);
+      const decoratorStart = getDecorators(node)?.[0]?.getStart(this.ast);
 
-      result.range[0] = varToken!.getStart(this.ast);
+      result.range[0] = decoratorStart ?? varToken!.getStart(this.ast);
       result.loc = getLocFor(result.range, this.ast);
+      const exportStart = Math.min(
+        exportKeyword.getStart(this.ast),
+        result.range[0],
+      );
 
       if (declarationIsDefault) {
         return this.createNode<TSESTree.ExportDefaultDeclaration>(node, {
           type: AST_NODE_TYPES.ExportDefaultDeclaration,
-          range: [exportKeyword.getStart(this.ast), result.range[1]],
+          range: [exportStart, result.range[1]],
           declaration: result as TSESTree.DefaultExportDeclarations,
           exportKind: 'value',
         });
@@ -3049,7 +3054,7 @@ export class Converter {
         this.#withDeprecatedAliasGetter(
           {
             type: AST_NODE_TYPES.ExportNamedDeclaration,
-            range: [exportKeyword.getStart(this.ast), result.range[1]],
+            range: [exportStart, result.range[1]],
             attributes: [],
             declaration: result,
             exportKind: isType || isDeclare ? 'type' : 'value',

--- a/packages/typescript-estree/tests/lib/convert.test.ts
+++ b/packages/typescript-estree/tests/lib/convert.test.ts
@@ -98,6 +98,29 @@ describe('convert', () => {
   });
   /* eslint-enable @typescript-eslint/dot-notation */
 
+  it('includes decorators in exported class ranges', () => {
+    const code = `
+      @named({ name: 1 })
+      export class Named {}
+
+      @defaultDecorator
+      export default class Default {}
+    `;
+    const program = new Converter(convertCode(code)).convertProgram();
+
+    for (const statement of program.body) {
+      assert(
+        statement.type === AST_NODE_TYPES.ExportDefaultDeclaration ||
+          statement.type === AST_NODE_TYPES.ExportNamedDeclaration,
+      );
+      assert(statement.declaration?.type === AST_NODE_TYPES.ClassDeclaration);
+
+      const decorator = statement.declaration.decorators[0];
+      expect(statement.range[0]).toBe(decorator.range[0]);
+      expect(statement.declaration.range[0]).toBe(decorator.range[0]);
+    }
+  });
+
   it('nodeMaps should contain basic nodes', () => {
     const ast = convertCode(`
       'test';


### PR DESCRIPTION
BREAKING CHANGE: Exported decorated class declarations and their export wrappers now begin at the first decorator. This changes their `range`/`loc` values and the first token returned for those nodes.

## PR Checklist

- [x] Addresses an existing open issue: fixes #~11578~
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

`fixExports()` previously rewrote an exported class declaration's start to the `class` token and its export wrapper's start to the `export` token. For decorators placed before `export`, that left child decorator ranges outside both parent ranges and caused range-based ESLint lookups to skip nodes inside decorator expressions.

This preserves the first decorator as the class declaration's start and uses the earliest of that position and the `export` keyword for the export wrapper. Non-decorated exports retain their existing ranges. The regression covers both named and default exported decorated classes.

Validation included the focused converter suite (34 tests), the TypeScript-ESTree package suite (311 tests passed in the main run; its sole loaded-run timeout passed in 2.5 seconds when isolated; only the known drive-letter path snapshot file was excluded), exact touched-file ESLint and Prettier checks, the TypeScript-ESTree no-emit typecheck, `git diff --check`, and the repository's lint-staged pre-commit check.

AI assistance disclosure: I used Codex with GPT-5 to help trace the range mutation through `fixExports()`, implement the narrow fix, and draft the regression test. I reviewed the complete diff, ran the validation listed above, understand the implementation, and can respond to review feedback.

💖