### PR TITLE
feat(eslint-plugin): add no-redundant-default-arguments

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-redundant-default-arguments.mdx
+++ b/packages/eslint-plugin/docs/rules/no-redundant-default-arguments.mdx
@@ -13,7 +13,7 @@ import TabItem from '@theme/TabItem';
 Passing a hardcoded argument that is the same as that default does not change the result.
 
 This rule reports those redundant arguments, object properties, and JSX props, and can remove them.
-It uses type information so imported callees are resolved across files.
+It uses type information so imported functions are resolved across files.
 
 The rule only considers:
 

--- a/packages/eslint-plugin/docs/rules/no-redundant-default-arguments.mdx
+++ b/packages/eslint-plugin/docs/rules/no-redundant-default-arguments.mdx
@@ -1,0 +1,90 @@
+---
+description: 'Disallow arguments and JSX props that equal their parameter default.'
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+> 🛑 This file is source code, not the primary documentation location! 🛑
+>
+> See **https://typescript-eslint.io/rules/no-redundant-default-arguments** for documentation.
+
+[Default parameters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters) and [destructuring default values](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#default_value) apply when the caller omits a value.
+Passing a hardcoded argument that is the same as that default does not change the result.
+
+This rule reports those redundant arguments, object properties, and JSX props, and can remove them.
+It uses type information so imported callees are resolved across files.
+
+The rule only considers:
+
+- calls whose callee is a stable identifier (not a member access, and not a reassigned binding)
+- hardcoded literals (`0`, `'all'`, `false`, `` `all` ``, `-1`)
+- trailing positional arguments, so a later non-default argument is not dropped
+- object properties and JSX props that cannot be overridden by a spread
+
+## Examples
+
+<Tabs>
+<TabItem value="❌ Incorrect">
+
+```tsx
+function loadPage(page = 20) {}
+loadPage(20);
+
+function loadOptions({ page = 20 }: { page?: number }) {}
+loadOptions({ page: 20 });
+
+function Header({ title = 'Inbox' }: { title?: string }) {
+  return null;
+}
+<Header title="Inbox" />;
+```
+
+</TabItem>
+<TabItem value="✅ Correct">
+
+```tsx
+function loadPage(page = 20) {}
+loadPage();
+loadPage(1);
+
+function loadOptions({ page = 20 }: { page?: number }) {}
+loadOptions({});
+loadOptions({ page: 1 });
+
+function Header({ title = 'Inbox' }: { title?: string }) {
+  return null;
+}
+<Header />;
+<Header title="Sent" />;
+```
+
+</TabItem>
+</Tabs>
+
+The following are not reported because omitting the value would change behavior or cannot be proven safe:
+
+```ts
+function loadPage(page = 20, limit = 10) {}
+loadPage(20, 5);
+
+function loadOptions({ page = 20 }: { page?: number }) {}
+loadOptions({ page: 20, ...other });
+
+const api = { loadPage(page = 20) {} };
+api.loadPage(20);
+
+let loadPage = (page = 20) => {};
+loadPage(20);
+```
+
+## When Not To Use It
+
+If your project is not accurately typed, such as if it's in the process of being converted to TypeScript, it may be difficult to enable this rule.
+
+If you pass default values at call sites as documentation, or you rely on a function's runtime [`.length`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/length), you may want to disable this rule.
+
+## Related To
+
+- [`no-useless-default-assignment`](./no-useless-default-assignment.mdx)
+- [`default-param-last`](./default-param-last.mdx)

--- a/packages/eslint-plugin/src/configs/eslintrc/all.ts
+++ b/packages/eslint-plugin/src/configs/eslintrc/all.ts
@@ -80,6 +80,7 @@ export = {
     '@typescript-eslint/no-non-null-assertion': 'error',
     'no-redeclare': 'off',
     '@typescript-eslint/no-redeclare': 'error',
+    '@typescript-eslint/no-redundant-default-arguments': 'error',
     '@typescript-eslint/no-redundant-type-constituents': 'error',
     '@typescript-eslint/no-require-imports': 'error',
     '@typescript-eslint/no-restricted-types': 'error',

--- a/packages/eslint-plugin/src/configs/eslintrc/disable-type-checked.ts
+++ b/packages/eslint-plugin/src/configs/eslintrc/disable-type-checked.ts
@@ -27,6 +27,7 @@ export = {
     '@typescript-eslint/no-misused-promises': 'off',
     '@typescript-eslint/no-misused-spread': 'off',
     '@typescript-eslint/no-mixed-enums': 'off',
+    '@typescript-eslint/no-redundant-default-arguments': 'off',
     '@typescript-eslint/no-redundant-type-constituents': 'off',
     '@typescript-eslint/no-unnecessary-boolean-literal-compare': 'off',
     '@typescript-eslint/no-unnecessary-condition': 'off',

--- a/packages/eslint-plugin/src/configs/flat/all.ts
+++ b/packages/eslint-plugin/src/configs/flat/all.ts
@@ -93,6 +93,7 @@ export default (
       '@typescript-eslint/no-non-null-assertion': 'error',
       'no-redeclare': 'off',
       '@typescript-eslint/no-redeclare': 'error',
+      '@typescript-eslint/no-redundant-default-arguments': 'error',
       '@typescript-eslint/no-redundant-type-constituents': 'error',
       '@typescript-eslint/no-require-imports': 'error',
       '@typescript-eslint/no-restricted-types': 'error',

--- a/packages/eslint-plugin/src/configs/flat/disable-type-checked.ts
+++ b/packages/eslint-plugin/src/configs/flat/disable-type-checked.ts
@@ -34,6 +34,7 @@ export default (
     '@typescript-eslint/no-misused-promises': 'off',
     '@typescript-eslint/no-misused-spread': 'off',
     '@typescript-eslint/no-mixed-enums': 'off',
+    '@typescript-eslint/no-redundant-default-arguments': 'off',
     '@typescript-eslint/no-redundant-type-constituents': 'off',
     '@typescript-eslint/no-unnecessary-boolean-literal-compare': 'off',
     '@typescript-eslint/no-unnecessary-condition': 'off',

--- a/packages/eslint-plugin/src/rules/index.ts
+++ b/packages/eslint-plugin/src/rules/index.ts
@@ -60,6 +60,7 @@ import noNonNullAssertedNullishCoalescing from './no-non-null-asserted-nullish-c
 import noNonNullAssertedOptionalChain from './no-non-null-asserted-optional-chain';
 import noNonNullAssertion from './no-non-null-assertion';
 import noRedeclare from './no-redeclare';
+import noRedundantDefaultArguments from './no-redundant-default-arguments';
 import noRedundantTypeConstituents from './no-redundant-type-constituents';
 import noRequireImports from './no-require-imports';
 import noRestrictedImports from './no-restricted-imports';
@@ -196,6 +197,7 @@ const rules = {
   'no-non-null-asserted-optional-chain': noNonNullAssertedOptionalChain,
   'no-non-null-assertion': noNonNullAssertion,
   'no-redeclare': noRedeclare,
+  'no-redundant-default-arguments': noRedundantDefaultArguments,
   'no-redundant-type-constituents': noRedundantTypeConstituents,
   'no-require-imports': noRequireImports,
   'no-restricted-imports': noRestrictedImports,

--- a/packages/eslint-plugin/src/rules/no-redundant-default-arguments.ts
+++ b/packages/eslint-plugin/src/rules/no-redundant-default-arguments.ts
@@ -693,7 +693,6 @@ function unwrapExpression(
     case AST_NODE_TYPES.TSTypeAssertion:
     case AST_NODE_TYPES.TSNonNullExpression:
     case AST_NODE_TYPES.TSSatisfiesExpression:
-    case AST_NODE_TYPES.ParenthesizedExpression:
       return unwrapExpression(node.expression);
     default:
       return node;
@@ -708,7 +707,6 @@ function getHardcodedValue(
     case AST_NODE_TYPES.TSTypeAssertion:
     case AST_NODE_TYPES.TSNonNullExpression:
     case AST_NODE_TYPES.TSSatisfiesExpression:
-    case AST_NODE_TYPES.ParenthesizedExpression:
       return getHardcodedValue(node.expression);
     case AST_NODE_TYPES.Literal:
       if (

--- a/packages/eslint-plugin/src/rules/no-redundant-default-arguments.ts
+++ b/packages/eslint-plugin/src/rules/no-redundant-default-arguments.ts
@@ -6,7 +6,12 @@ import { ASTUtils, AST_NODE_TYPES } from '@typescript-eslint/utils';
 import * as tsutils from 'ts-api-utils';
 import * as ts from 'typescript';
 
-import { createRule, getParserServices } from '../util';
+import {
+  createRule,
+  getParserServices,
+  nullThrows,
+  NullThrowsReasons,
+} from '../util';
 
 const NOT_HARDCODED = Symbol('notHardcoded');
 
@@ -337,8 +342,14 @@ export default createRule<Options, MessageIds>({
         indices[0] === 0 &&
         indices.at(-1) === node.properties.length - 1
       ) {
-        const open = sourceCode.getFirstToken(node)!;
-        const close = sourceCode.getLastToken(node)!;
+        const open = nullThrows(
+          sourceCode.getFirstToken(node),
+          NullThrowsReasons.MissingToken('{', 'object'),
+        );
+        const close = nullThrows(
+          sourceCode.getLastToken(node),
+          NullThrowsReasons.MissingToken('}', 'object'),
+        );
         return [[open.range[1], close.range[0]]];
       }
 
@@ -351,7 +362,7 @@ export default createRule<Options, MessageIds>({
           }
           const tokenAfter = sourceCode.getTokenAfter(last);
           return [
-            previous!.range[1],
+            previous == null ? first.range[0] : previous.range[1],
             tokenAfter?.value === ',' ? tokenAfter.range[1] : last.range[1],
           ];
         },

--- a/packages/eslint-plugin/src/rules/no-redundant-default-arguments.ts
+++ b/packages/eslint-plugin/src/rules/no-redundant-default-arguments.ts
@@ -1,0 +1,820 @@
+import type { ScopeVariable } from '@typescript-eslint/scope-manager';
+import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
+
+import { DefinitionType } from '@typescript-eslint/scope-manager';
+import { ASTUtils, AST_NODE_TYPES } from '@typescript-eslint/utils';
+import * as tsutils from 'ts-api-utils';
+import * as ts from 'typescript';
+
+import { createRule, getParserServices } from '../util';
+
+const NOT_HARDCODED = Symbol('notHardcoded');
+
+type HardcodedValue = boolean | number | string | null;
+type MessageIds = 'redundantDefaultValue';
+type Options = [];
+
+interface NamedDefault {
+  name: string;
+  value: HardcodedValue;
+}
+
+interface FunctionDefaults {
+  objectProperties: Map<number, Map<string, NamedDefault>>;
+  positional: Map<number, NamedDefault>;
+}
+
+export default createRule<Options, MessageIds>({
+  name: 'no-redundant-default-arguments',
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Disallow arguments and JSX props that equal their parameter default',
+      requiresTypeChecking: true,
+    },
+    fixable: 'code',
+    messages: {
+      redundantDefaultValue:
+        'This {{kind}} passes the default value {{value}} for "{{name}}" and can be omitted.',
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    const services = getParserServices(context);
+    const checker = services.program.getTypeChecker();
+    const sourceCode = context.sourceCode;
+
+    function getVariable(
+      node: TSESTree.Identifier | TSESTree.JSXIdentifier,
+    ): ScopeVariable | null {
+      return ASTUtils.findVariable(sourceCode.getScope(node), node.name);
+    }
+
+    function getDefaultsForCallee(
+      identifier: TSESTree.Identifier | TSESTree.JSXIdentifier,
+    ): FunctionDefaults | undefined {
+      const variable = getVariable(identifier);
+      if (variable == null || !isResolvableCallee(variable)) {
+        return undefined;
+      }
+
+      const fromAst = getDefaultsFromVariable(variable);
+      if (fromAst != null) {
+        return fromAst;
+      }
+
+      const tsNode = services.esTreeNodeToTSNodeMap.get(identifier);
+      const symbol = checker.getSymbolAtLocation(tsNode);
+      if (symbol == null) {
+        return undefined;
+      }
+
+      return getDefaultsFromTypeScriptSymbol(checker, symbol);
+    }
+
+    function checkCallExpression(node: TSESTree.CallExpression): void {
+      if (
+        node.callee.type !== AST_NODE_TYPES.Identifier ||
+        node.arguments.length === 0
+      ) {
+        return;
+      }
+
+      const defaults = getDefaultsForCallee(node.callee);
+      if (defaults == null) {
+        return;
+      }
+
+      const spreadIndex = node.arguments.findIndex(
+        argument => argument.type === AST_NODE_TYPES.SpreadElement,
+      );
+
+      if (spreadIndex === -1) {
+        reportRedundantTrailingArguments(node, defaults.positional);
+      }
+
+      const alignedCount =
+        spreadIndex === -1 ? node.arguments.length : spreadIndex;
+      for (let index = 0; index < alignedCount; index++) {
+        const argument = node.arguments[index];
+        const objectDefaults = defaults.objectProperties.get(index);
+        if (
+          argument.type === AST_NODE_TYPES.ObjectExpression &&
+          objectDefaults != null
+        ) {
+          reportRedundantObjectProperties(argument, objectDefaults);
+        }
+      }
+    }
+
+    function checkJSXOpeningElement(node: TSESTree.JSXOpeningElement): void {
+      if (
+        node.name.type !== AST_NODE_TYPES.JSXIdentifier ||
+        node.name.name[0] !== node.name.name[0].toUpperCase() ||
+        !node.attributes.some(
+          attribute => attribute.type === AST_NODE_TYPES.JSXAttribute,
+        )
+      ) {
+        return;
+      }
+
+      const defaults = getDefaultsForCallee(node.name);
+      const propDefaults = defaults?.objectProperties.get(0);
+      if (propDefaults == null) {
+        return;
+      }
+
+      reportRedundantJSXAttributes(node, propDefaults);
+    }
+
+    function reportRedundantTrailingArguments(
+      node: TSESTree.CallExpression,
+      positional: Map<number, NamedDefault>,
+    ): void {
+      let firstRedundant = node.arguments.length;
+      for (let index = node.arguments.length - 1; index >= 0; index--) {
+        const argument = node.arguments[index];
+        const defaultValue = positional.get(index);
+        if (
+          defaultValue == null ||
+          !hardcodedValuesAreEqual(
+            getHardcodedValue(argument),
+            defaultValue.value,
+          )
+        ) {
+          break;
+        }
+        firstRedundant = index;
+      }
+
+      for (let index = firstRedundant; index < node.arguments.length; index++) {
+        const argument = node.arguments[index];
+        const defaultValue = positional.get(index);
+        if (defaultValue == null) {
+          continue;
+        }
+        context.report({
+          node: argument,
+          messageId: 'redundantDefaultValue',
+          data: {
+            name: defaultValue.name,
+            kind: 'argument',
+            value: formatHardcodedValue(defaultValue.value),
+          },
+          fix:
+            index === firstRedundant
+              ? fixer =>
+                  removeRangeIfUncommented(
+                    fixer,
+                    trailingArgumentRange(node, firstRedundant),
+                  )
+              : undefined,
+        });
+      }
+    }
+
+    function reportRedundantObjectProperties(
+      node: TSESTree.ObjectExpression,
+      defaults: Map<string, NamedDefault>,
+    ): void {
+      const seen = new Set<string>();
+      const redundant: {
+        defaultValue: NamedDefault;
+        index: number;
+        property: TSESTree.Property;
+      }[] = [];
+
+      for (let index = node.properties.length - 1; index >= 0; index--) {
+        const property = node.properties[index];
+        if (property.type === AST_NODE_TYPES.SpreadElement) {
+          return;
+        }
+
+        const name = getPropertyName(property);
+        if (name == null || seen.has(name)) {
+          continue;
+        }
+        seen.add(name);
+
+        const defaultValue = defaults.get(name);
+        if (
+          defaultValue != null &&
+          hardcodedValuesAreEqual(
+            getHardcodedValue(property.value),
+            defaultValue.value,
+          )
+        ) {
+          redundant.push({ defaultValue, index, property });
+        }
+      }
+
+      redundant.reverse();
+      const indices = redundant.map(({ index }) => index);
+      redundant.forEach(({ defaultValue, property }, reportIndex) => {
+        context.report({
+          node: property,
+          messageId: 'redundantDefaultValue',
+          data: {
+            name: defaultValue.name,
+            kind: 'property',
+            value: formatHardcodedValue(defaultValue.value),
+          },
+          fix:
+            reportIndex === 0
+              ? fixer =>
+                  removeRangeIfUncommented(
+                    fixer,
+                    objectPropertyRanges(node, indices),
+                  )
+              : undefined,
+        });
+      });
+    }
+
+    function reportRedundantJSXAttributes(
+      node: TSESTree.JSXOpeningElement,
+      defaults: Map<string, NamedDefault>,
+    ): void {
+      const seen = new Set<string>();
+      const redundant: {
+        attribute: TSESTree.JSXAttribute;
+        defaultValue: NamedDefault;
+        index: number;
+      }[] = [];
+
+      for (let index = node.attributes.length - 1; index >= 0; index--) {
+        const attribute = node.attributes[index];
+        if (attribute.type === AST_NODE_TYPES.JSXSpreadAttribute) {
+          return;
+        }
+        if (attribute.name.type !== AST_NODE_TYPES.JSXIdentifier) {
+          continue;
+        }
+
+        const name = attribute.name.name;
+        if (seen.has(name)) {
+          continue;
+        }
+        seen.add(name);
+
+        const defaultValue = defaults.get(name);
+        if (
+          defaultValue != null &&
+          hardcodedValuesAreEqual(
+            getJSXAttributeValue(attribute),
+            defaultValue.value,
+          )
+        ) {
+          redundant.push({ attribute, defaultValue, index });
+        }
+      }
+
+      redundant.reverse();
+      const indices = redundant.map(({ index }) => index);
+      redundant.forEach(({ attribute, defaultValue }, reportIndex) => {
+        context.report({
+          node: attribute,
+          messageId: 'redundantDefaultValue',
+          data: {
+            name: defaultValue.name,
+            kind: 'prop',
+            value: formatHardcodedValue(defaultValue.value),
+          },
+          fix:
+            reportIndex === 0
+              ? fixer =>
+                  removeRangeIfUncommented(
+                    fixer,
+                    jsxAttributeRanges(node, indices),
+                  )
+              : undefined,
+        });
+      });
+    }
+
+    function rangeContainsComment(range: TSESTree.Range): boolean {
+      return sourceCode
+        .getAllComments()
+        .some(
+          comment =>
+            comment.range[0] >= range[0] && comment.range[1] <= range[1],
+        );
+    }
+
+    function removeRangeIfUncommented(
+      fixer: TSESLint.RuleFixer,
+      ranges: TSESTree.Range | TSESTree.Range[] | null,
+    ): TSESLint.RuleFix | TSESLint.RuleFix[] | null {
+      if (ranges == null) {
+        return null;
+      }
+      const list: TSESTree.Range[] =
+        typeof ranges[0] === 'number'
+          ? [ranges as TSESTree.Range]
+          : (ranges as TSESTree.Range[]);
+      if (list.some(rangeContainsComment)) {
+        return null;
+      }
+      return list.map(range => fixer.removeRange(range));
+    }
+
+    function trailingArgumentRange(
+      node: TSESTree.CallExpression,
+      firstIndex: number,
+    ): TSESTree.Range | null {
+      const firstArgument = node.arguments[firstIndex];
+      const lastArgument = node.arguments[node.arguments.length - 1];
+      let rangeStart = firstArgument.range[0];
+      if (firstIndex > 0) {
+        rangeStart = node.arguments[firstIndex - 1].range[1];
+      }
+
+      const tokenAfter = sourceCode.getTokenAfter(lastArgument);
+      return [
+        rangeStart,
+        tokenAfter?.value === ',' ? tokenAfter.range[1] : lastArgument.range[1],
+      ];
+    }
+
+    function objectPropertyRanges(
+      node: TSESTree.ObjectExpression,
+      indices: number[],
+    ): TSESTree.Range[] | null {
+      if (
+        node.properties.length > 0 &&
+        indices.length === node.properties.length &&
+        indices[0] === 0 &&
+        indices.at(-1) === node.properties.length - 1
+      ) {
+        const open = sourceCode.getFirstToken(node);
+        const close = sourceCode.getLastToken(node);
+        if (open == null || close == null) {
+          return null;
+        }
+        return [[open.range[1], close.range[0]]];
+      }
+
+      return contiguousRemovalRanges(
+        node.properties,
+        indices,
+        (first, last, next, previous) => {
+          if (next != null) {
+            return [first.range[0], next.range[0]];
+          }
+          const rangeStart = previous?.range[1] ?? first.range[0];
+          const tokenAfter = sourceCode.getTokenAfter(last);
+          return [
+            rangeStart,
+            tokenAfter?.value === ',' ? tokenAfter.range[1] : last.range[1],
+          ];
+        },
+      );
+    }
+
+    function jsxAttributeRanges(
+      node: TSESTree.JSXOpeningElement,
+      indices: number[],
+    ): TSESTree.Range[] | null {
+      return contiguousRemovalRanges(
+        node.attributes,
+        indices,
+        (first, last, next, previous) => {
+          if (next != null) {
+            return [first.range[0], next.range[0]];
+          }
+          return [previous?.range[1] ?? node.name.range[1], last.range[1]];
+        },
+      );
+    }
+
+    return {
+      CallExpression: checkCallExpression,
+      JSXOpeningElement: checkJSXOpeningElement,
+    };
+  },
+});
+
+function isStableBinding(variable: ScopeVariable): boolean {
+  return !variable.references.some(
+    reference => reference.isWrite() && !reference.init,
+  );
+}
+
+function isResolvableCallee(variable: ScopeVariable): boolean {
+  if (!isStableBinding(variable)) {
+    return false;
+  }
+
+  const functionNameDefs = variable.defs.filter(
+    def => def.type === DefinitionType.FunctionName,
+  );
+  if (functionNameDefs.length > 1) {
+    return false;
+  }
+
+  return variable.defs.some(def => {
+    switch (def.type) {
+      case DefinitionType.FunctionName:
+      case DefinitionType.ImportBinding:
+        return true;
+      case DefinitionType.Variable:
+        return def.node.parent.kind === 'const';
+      default:
+        return false;
+    }
+  });
+}
+
+function getDefaultsFromVariable(
+  variable: ScopeVariable,
+): FunctionDefaults | undefined {
+  for (const def of variable.defs) {
+    if (def.node.type === AST_NODE_TYPES.FunctionDeclaration) {
+      const defaults = getFunctionDefaults(def.node);
+      if (hasDefaults(defaults)) {
+        return defaults;
+      }
+    }
+
+    if (
+      def.node.type === AST_NODE_TYPES.VariableDeclarator &&
+      def.node.parent.kind === 'const'
+    ) {
+      const init = unwrapExpression(def.node.init);
+      if (
+        init?.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+        init?.type === AST_NODE_TYPES.FunctionExpression
+      ) {
+        const defaults = getFunctionDefaults(init);
+        if (hasDefaults(defaults)) {
+          return defaults;
+        }
+      }
+    }
+  }
+  return undefined;
+}
+
+function getFunctionDefaults(
+  node:
+    | TSESTree.ArrowFunctionExpression
+    | TSESTree.FunctionDeclaration
+    | TSESTree.FunctionExpression,
+): FunctionDefaults {
+  const defaults: FunctionDefaults = {
+    objectProperties: new Map(),
+    positional: new Map(),
+  };
+
+  let runtimeIndex = 0;
+  for (const parameter of node.params) {
+    if (
+      parameter.type === AST_NODE_TYPES.Identifier &&
+      parameter.name === 'this'
+    ) {
+      continue;
+    }
+
+    if (parameter.type === AST_NODE_TYPES.AssignmentPattern) {
+      if (parameter.left.type === AST_NODE_TYPES.Identifier) {
+        const value = getHardcodedValue(parameter.right);
+        if (value !== NOT_HARDCODED) {
+          defaults.positional.set(runtimeIndex, {
+            name: parameter.left.name,
+            value,
+          });
+        }
+      } else if (parameter.left.type === AST_NODE_TYPES.ObjectPattern) {
+        const properties = getObjectPatternDefaults(parameter.left);
+        if (properties.size > 0) {
+          defaults.objectProperties.set(runtimeIndex, properties);
+        }
+      }
+    } else if (parameter.type === AST_NODE_TYPES.ObjectPattern) {
+      const properties = getObjectPatternDefaults(parameter);
+      if (properties.size > 0) {
+        defaults.objectProperties.set(runtimeIndex, properties);
+      }
+    }
+
+    runtimeIndex += 1;
+  }
+
+  return defaults;
+}
+
+function getObjectPatternDefaults(
+  pattern: TSESTree.ObjectPattern,
+): Map<string, NamedDefault> {
+  const defaults = new Map<string, NamedDefault>();
+  for (const property of pattern.properties) {
+    if (
+      property.type !== AST_NODE_TYPES.Property ||
+      property.value.type !== AST_NODE_TYPES.AssignmentPattern
+    ) {
+      continue;
+    }
+    const name = getPropertyName(property);
+    const value = getHardcodedValue(property.value.right);
+    if (name != null && value !== NOT_HARDCODED) {
+      defaults.set(name, { name, value });
+    }
+  }
+  return defaults;
+}
+
+function getDefaultsFromTypeScriptSymbol(
+  checker: ts.TypeChecker,
+  symbol: ts.Symbol,
+): FunctionDefaults | undefined {
+  const resolved = tsutils.isSymbolFlagSet(symbol, ts.SymbolFlags.Alias)
+    ? checker.getAliasedSymbol(symbol)
+    : symbol;
+
+  const functionLikes: ts.SignatureDeclarationBase[] = [];
+  for (const declaration of resolved.getDeclarations() ?? []) {
+    const functionLike = getTypeScriptFunctionLike(declaration);
+    if (functionLike != null) {
+      functionLikes.push(functionLike);
+    }
+  }
+  if (functionLikes.length !== 1) {
+    return undefined;
+  }
+
+  const defaults = getTypeScriptFunctionDefaults(functionLikes[0]);
+  return hasDefaults(defaults) ? defaults : undefined;
+}
+
+function getTypeScriptFunctionLike(
+  declaration: ts.Declaration,
+): ts.SignatureDeclarationBase | undefined {
+  if (
+    ts.isFunctionDeclaration(declaration) ||
+    ts.isFunctionExpression(declaration) ||
+    ts.isArrowFunction(declaration)
+  ) {
+    return declaration;
+  }
+  if (
+    !ts.isVariableDeclaration(declaration) ||
+    declaration.initializer == null ||
+    !ts.isVariableDeclarationList(declaration.parent) ||
+    (declaration.parent.flags & ts.NodeFlags.Const) === 0
+  ) {
+    return undefined;
+  }
+  const initializer = unwrapTypeScriptExpression(declaration.initializer);
+  return ts.isFunctionExpression(initializer) || ts.isArrowFunction(initializer)
+    ? initializer
+    : undefined;
+}
+
+function getTypeScriptFunctionDefaults(
+  node: ts.SignatureDeclarationBase,
+): FunctionDefaults {
+  const defaults: FunctionDefaults = {
+    objectProperties: new Map(),
+    positional: new Map(),
+  };
+  let runtimeIndex = 0;
+
+  for (const parameter of node.parameters) {
+    if (ts.isIdentifier(parameter.name) && parameter.name.text === 'this') {
+      continue;
+    }
+
+    if (parameter.initializer != null && ts.isIdentifier(parameter.name)) {
+      const value = getTypeScriptHardcodedValue(parameter.initializer);
+      if (value !== NOT_HARDCODED) {
+        defaults.positional.set(runtimeIndex, {
+          name: parameter.name.text,
+          value,
+        });
+      }
+    } else if (ts.isObjectBindingPattern(parameter.name)) {
+      const properties = getTypeScriptObjectDefaults(parameter.name);
+      if (properties.size > 0) {
+        defaults.objectProperties.set(runtimeIndex, properties);
+      }
+    }
+
+    runtimeIndex += 1;
+  }
+
+  return defaults;
+}
+
+function getTypeScriptObjectDefaults(
+  pattern: ts.ObjectBindingPattern,
+): Map<string, NamedDefault> {
+  const defaults = new Map<string, NamedDefault>();
+  for (const element of pattern.elements) {
+    if (element.dotDotDotToken != null || element.initializer == null) {
+      continue;
+    }
+    const name = getTypeScriptPropertyName(
+      element.propertyName ?? element.name,
+    );
+    const value = getTypeScriptHardcodedValue(element.initializer);
+    if (name != null && value !== NOT_HARDCODED) {
+      defaults.set(name, { name, value });
+    }
+  }
+  return defaults;
+}
+
+function getTypeScriptPropertyName(
+  node: ts.BindingName | ts.PropertyName,
+): string | undefined {
+  if (ts.isIdentifier(node) || ts.isStringLiteralLike(node)) {
+    return node.text;
+  }
+  if (ts.isNumericLiteral(node)) {
+    return String(Number(node.text.replaceAll('_', '')));
+  }
+  return undefined;
+}
+
+function getTypeScriptHardcodedValue(
+  expression: ts.Expression,
+): HardcodedValue | typeof NOT_HARDCODED {
+  const node = unwrapTypeScriptExpression(expression);
+  if (ts.isStringLiteralLike(node)) {
+    return node.text;
+  }
+  if (ts.isNumericLiteral(node)) {
+    return Number(node.text.replaceAll('_', ''));
+  }
+  if (node.kind === ts.SyntaxKind.TrueKeyword) {
+    return true;
+  }
+  if (node.kind === ts.SyntaxKind.FalseKeyword) {
+    return false;
+  }
+  if (node.kind === ts.SyntaxKind.NullKeyword) {
+    return null;
+  }
+  if (
+    ts.isPrefixUnaryExpression(node) &&
+    node.operator === ts.SyntaxKind.MinusToken
+  ) {
+    const operand = getTypeScriptHardcodedValue(node.operand);
+    if (typeof operand === 'number') {
+      return -operand;
+    }
+  }
+  return NOT_HARDCODED;
+}
+
+function unwrapTypeScriptExpression(node: ts.Expression): ts.Expression {
+  if (
+    ts.isAsExpression(node) ||
+    ts.isTypeAssertionExpression(node) ||
+    ts.isNonNullExpression(node) ||
+    ts.isParenthesizedExpression(node) ||
+    ts.isSatisfiesExpression(node)
+  ) {
+    return unwrapTypeScriptExpression(node.expression);
+  }
+  return node;
+}
+
+function unwrapExpression(
+  node: TSESTree.Expression | null | undefined,
+): TSESTree.Expression | null | undefined {
+  if (node == null) {
+    return node;
+  }
+  switch (node.type) {
+    case AST_NODE_TYPES.TSAsExpression:
+    case AST_NODE_TYPES.TSTypeAssertion:
+    case AST_NODE_TYPES.TSNonNullExpression:
+    case AST_NODE_TYPES.TSSatisfiesExpression:
+    case AST_NODE_TYPES.ParenthesizedExpression:
+      return unwrapExpression(node.expression);
+    default:
+      return node;
+  }
+}
+
+function getHardcodedValue(
+  node: TSESTree.Node,
+): HardcodedValue | typeof NOT_HARDCODED {
+  switch (node.type) {
+    case AST_NODE_TYPES.TSAsExpression:
+    case AST_NODE_TYPES.TSTypeAssertion:
+    case AST_NODE_TYPES.TSNonNullExpression:
+    case AST_NODE_TYPES.TSSatisfiesExpression:
+    case AST_NODE_TYPES.ParenthesizedExpression:
+      return getHardcodedValue(node.expression);
+    case AST_NODE_TYPES.Literal:
+      if (
+        node.value == null ||
+        typeof node.value === 'string' ||
+        typeof node.value === 'number' ||
+        typeof node.value === 'boolean'
+      ) {
+        return node.value;
+      }
+      return NOT_HARDCODED;
+    case AST_NODE_TYPES.TemplateLiteral:
+      if (
+        node.expressions.length === 0 &&
+        node.quasis[0]?.value.cooked != null
+      ) {
+        return node.quasis[0].value.cooked;
+      }
+      return NOT_HARDCODED;
+    case AST_NODE_TYPES.UnaryExpression:
+      if (
+        node.operator === '-' &&
+        node.argument.type === AST_NODE_TYPES.Literal &&
+        typeof node.argument.value === 'number'
+      ) {
+        return -node.argument.value;
+      }
+      return NOT_HARDCODED;
+    default:
+      return NOT_HARDCODED;
+  }
+}
+
+function getJSXAttributeValue(
+  attribute: TSESTree.JSXAttribute,
+): HardcodedValue | typeof NOT_HARDCODED {
+  if (attribute.value == null) {
+    return true;
+  }
+  if (attribute.value.type === AST_NODE_TYPES.JSXExpressionContainer) {
+    return getHardcodedValue(attribute.value.expression);
+  }
+  return getHardcodedValue(attribute.value);
+}
+
+function getPropertyName(property: TSESTree.Property): string | undefined {
+  if (property.computed) {
+    return undefined;
+  }
+  if (property.key.type === AST_NODE_TYPES.Identifier) {
+    return property.key.name;
+  }
+  if (
+    typeof property.key.value === 'string' ||
+    typeof property.key.value === 'number'
+  ) {
+    return String(property.key.value);
+  }
+  return undefined;
+}
+
+function hasDefaults(defaults: FunctionDefaults): boolean {
+  return defaults.positional.size > 0 || defaults.objectProperties.size > 0;
+}
+
+function hardcodedValuesAreEqual(
+  actual: HardcodedValue | typeof NOT_HARDCODED,
+  expected: HardcodedValue,
+): boolean {
+  return actual !== NOT_HARDCODED && Object.is(actual, expected);
+}
+
+function formatHardcodedValue(value: HardcodedValue): string {
+  return typeof value === 'string' ? JSON.stringify(value) : String(value);
+}
+
+function contiguousRemovalRanges<T extends { range: TSESTree.Range }>(
+  nodes: T[],
+  indices: number[],
+  rangeForRun: (
+    first: T,
+    last: T,
+    next: T | undefined,
+    previous: T | undefined,
+  ) => TSESTree.Range,
+): TSESTree.Range[] | null {
+  const ranges: TSESTree.Range[] = [];
+  for (const { start, end } of getContiguousRuns(indices)) {
+    ranges.push(
+      rangeForRun(nodes[start], nodes[end], nodes[end + 1], nodes[start - 1]),
+    );
+  }
+  return ranges;
+}
+
+function getContiguousRuns(
+  indices: number[],
+): { end: number; start: number }[] {
+  const runs: { end: number; start: number }[] = [];
+  for (const index of indices) {
+    const previous = runs.at(-1);
+    if (previous?.end === index - 1) {
+      previous.end = index;
+    } else {
+      runs.push({ start: index, end: index });
+    }
+  }
+  return runs;
+}

--- a/packages/eslint-plugin/src/rules/no-redundant-default-arguments.ts
+++ b/packages/eslint-plugin/src/rules/no-redundant-default-arguments.ts
@@ -166,10 +166,9 @@ export default createRule<Options, MessageIds>({
           fix:
             reportIndex === 0
               ? fixer =>
-                  removeRangeIfUncommented(
-                    fixer,
+                  removeRangeIfUncommented(fixer, [
                     trailingArgumentRange(node, firstRedundant),
-                  )
+                  ])
               : undefined,
         });
       });
@@ -302,14 +301,12 @@ export default createRule<Options, MessageIds>({
 
     function removeRangeIfUncommented(
       fixer: TSESLint.RuleFixer,
-      ranges: TSESTree.Range | TSESTree.Range[],
-    ): TSESLint.RuleFix | TSESLint.RuleFix[] | null {
-      const list: TSESTree.Range[] =
-        typeof ranges[0] === 'number' ? [ranges as TSESTree.Range] : ranges;
-      if (list.some(rangeContainsComment)) {
+      ranges: TSESTree.Range[],
+    ): TSESLint.RuleFix[] | null {
+      if (ranges.some(rangeContainsComment)) {
         return null;
       }
-      return list.map(range => fixer.removeRange(range));
+      return ranges.map(range => fixer.removeRange(range));
     }
 
     function trailingArgumentRange(

--- a/packages/eslint-plugin/src/rules/no-redundant-default-arguments.ts
+++ b/packages/eslint-plugin/src/rules/no-redundant-default-arguments.ts
@@ -133,7 +133,10 @@ export default createRule<Options, MessageIds>({
       node: TSESTree.CallExpression,
       positional: Map<number, NamedDefault>,
     ): void {
-      let firstRedundant = node.arguments.length;
+      const redundant: {
+        argument: TSESTree.CallExpressionArgument;
+        defaultValue: NamedDefault;
+      }[] = [];
       for (let index = node.arguments.length - 1; index >= 0; index--) {
         const argument = node.arguments[index];
         const defaultValue = positional.get(index);
@@ -146,15 +149,12 @@ export default createRule<Options, MessageIds>({
         ) {
           break;
         }
-        firstRedundant = index;
+        redundant.push({ argument, defaultValue });
       }
 
-      for (let index = firstRedundant; index < node.arguments.length; index++) {
-        const argument = node.arguments[index];
-        const defaultValue = positional.get(index);
-        if (defaultValue == null) {
-          continue;
-        }
+      const firstRedundant = node.arguments.length - redundant.length;
+      redundant.reverse();
+      redundant.forEach(({ argument, defaultValue }, reportIndex) => {
         context.report({
           node: argument,
           messageId: 'redundantDefaultValue',
@@ -164,7 +164,7 @@ export default createRule<Options, MessageIds>({
             value: formatHardcodedValue(defaultValue.value),
           },
           fix:
-            index === firstRedundant
+            reportIndex === 0
               ? fixer =>
                   removeRangeIfUncommented(
                     fixer,
@@ -172,7 +172,7 @@ export default createRule<Options, MessageIds>({
                   )
               : undefined,
         });
-      }
+      });
     }
 
     function reportRedundantObjectProperties(
@@ -193,8 +193,11 @@ export default createRule<Options, MessageIds>({
         }
 
         const name = getPropertyName(property);
-        if (name == null || seen.has(name)) {
+        if (name == null) {
           continue;
+        }
+        if (seen.has(name)) {
+          return;
         }
         seen.add(name);
 
@@ -237,7 +240,6 @@ export default createRule<Options, MessageIds>({
       node: TSESTree.JSXOpeningElement,
       defaults: Map<string, NamedDefault>,
     ): void {
-      const seen = new Set<string>();
       const redundant: {
         attribute: TSESTree.JSXAttribute;
         defaultValue: NamedDefault;
@@ -254,11 +256,6 @@ export default createRule<Options, MessageIds>({
         }
 
         const name = attribute.name.name;
-        if (seen.has(name)) {
-          continue;
-        }
-        seen.add(name);
-
         const defaultValue = defaults.get(name);
         if (
           defaultValue != null &&
@@ -305,15 +302,10 @@ export default createRule<Options, MessageIds>({
 
     function removeRangeIfUncommented(
       fixer: TSESLint.RuleFixer,
-      ranges: TSESTree.Range | TSESTree.Range[] | null,
+      ranges: TSESTree.Range | TSESTree.Range[],
     ): TSESLint.RuleFix | TSESLint.RuleFix[] | null {
-      if (ranges == null) {
-        return null;
-      }
       const list: TSESTree.Range[] =
-        typeof ranges[0] === 'number'
-          ? [ranges as TSESTree.Range]
-          : (ranges as TSESTree.Range[]);
+        typeof ranges[0] === 'number' ? [ranges as TSESTree.Range] : ranges;
       if (list.some(rangeContainsComment)) {
         return null;
       }
@@ -323,13 +315,13 @@ export default createRule<Options, MessageIds>({
     function trailingArgumentRange(
       node: TSESTree.CallExpression,
       firstIndex: number,
-    ): TSESTree.Range | null {
+    ): TSESTree.Range {
       const firstArgument = node.arguments[firstIndex];
       const lastArgument = node.arguments[node.arguments.length - 1];
-      let rangeStart = firstArgument.range[0];
-      if (firstIndex > 0) {
-        rangeStart = node.arguments[firstIndex - 1].range[1];
-      }
+      const rangeStart =
+        firstIndex > 0
+          ? node.arguments[firstIndex - 1].range[1]
+          : firstArgument.range[0];
 
       const tokenAfter = sourceCode.getTokenAfter(lastArgument);
       return [
@@ -341,18 +333,15 @@ export default createRule<Options, MessageIds>({
     function objectPropertyRanges(
       node: TSESTree.ObjectExpression,
       indices: number[],
-    ): TSESTree.Range[] | null {
+    ): TSESTree.Range[] {
       if (
         node.properties.length > 0 &&
         indices.length === node.properties.length &&
         indices[0] === 0 &&
         indices.at(-1) === node.properties.length - 1
       ) {
-        const open = sourceCode.getFirstToken(node);
-        const close = sourceCode.getLastToken(node);
-        if (open == null || close == null) {
-          return null;
-        }
+        const open = sourceCode.getFirstToken(node)!;
+        const close = sourceCode.getLastToken(node)!;
         return [[open.range[1], close.range[0]]];
       }
 
@@ -363,10 +352,9 @@ export default createRule<Options, MessageIds>({
           if (next != null) {
             return [first.range[0], next.range[0]];
           }
-          const rangeStart = previous?.range[1] ?? first.range[0];
           const tokenAfter = sourceCode.getTokenAfter(last);
           return [
-            rangeStart,
+            previous!.range[1],
             tokenAfter?.value === ',' ? tokenAfter.range[1] : last.range[1],
           ];
         },
@@ -376,7 +364,7 @@ export default createRule<Options, MessageIds>({
     function jsxAttributeRanges(
       node: TSESTree.JSXOpeningElement,
       indices: number[],
-    ): TSESTree.Range[] | null {
+    ): TSESTree.Range[] {
       return contiguousRemovalRanges(
         node.attributes,
         indices,
@@ -792,7 +780,7 @@ function contiguousRemovalRanges<T extends { range: TSESTree.Range }>(
     next: T | undefined,
     previous: T | undefined,
   ) => TSESTree.Range,
-): TSESTree.Range[] | null {
+): TSESTree.Range[] {
   const ranges: TSESTree.Range[] = [];
   for (const { start, end } of getContiguousRuns(indices)) {
     ranges.push(

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-redundant-default-arguments.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-redundant-default-arguments.shot
@@ -1,0 +1,31 @@
+Incorrect
+
+function loadPage(page = 20) {}
+loadPage(20);
+         ~~ This argument passes the default value 20 for "page" and can be omitted.
+
+function loadOptions({ page = 20 }: { page?: number }) {}
+loadOptions({ page: 20 });
+              ~~~~~~~~ This property passes the default value 20 for "page" and can be omitted.
+
+function Header({ title = 'Inbox' }: { title?: string }) {
+  return null;
+}
+<Header title="Inbox" />;
+        ~~~~~~~~~~~~~ This prop passes the default value "Inbox" for "title" and can be omitted.
+
+Correct
+
+function loadPage(page = 20) {}
+loadPage();
+loadPage(1);
+
+function loadOptions({ page = 20 }: { page?: number }) {}
+loadOptions({});
+loadOptions({ page: 1 });
+
+function Header({ title = 'Inbox' }: { title?: string }) {
+  return null;
+}
+<Header />;
+<Header title="Sent" />;

--- a/packages/eslint-plugin/tests/fixtures/redundant-default-arguments.ts
+++ b/packages/eslint-plugin/tests/fixtures/redundant-default-arguments.ts
@@ -1,0 +1,7 @@
+export function importedWithDefault(value = 0): void {}
+
+export function importedWithOptions({ value = 5 }: { value?: number }): void {}
+
+export function ImportedComponent({ value = 5 }: { value?: number }): null {
+  return null;
+}

--- a/packages/eslint-plugin/tests/fixtures/redundant-default-arguments.ts
+++ b/packages/eslint-plugin/tests/fixtures/redundant-default-arguments.ts
@@ -5,3 +5,48 @@ export function importedWithOptions({ value = 5 }: { value?: number }): void {}
 export function ImportedComponent({ value = 5 }: { value?: number }): null {
   return null;
 }
+
+export const importedArrow = (value = 0): void => {};
+
+export const importedFnExpr = function (value = 0): void {};
+
+export function importedWithThis(this: void, value = 0): void {}
+
+export function importedLiterals(
+  mode = 'all',
+  enabled = true,
+  disabled = false,
+  empty: null = null,
+  offset = -1,
+  count = -1n,
+): void {}
+
+export function importedWrapped(
+  asserted = 0 as const,
+  // prettier-ignore
+  parens = (0),
+  nonNull = 0!,
+  satisfied = 0 satisfies number,
+): void {}
+
+export function importedOverload(value?: number): void;
+export function importedOverload(value = 0): void {}
+
+// prettier-ignore
+export function importedKeys({
+  'the-value': renamed = 5,
+  0: indexed = 5,
+  ['skip']: skipped = 5,
+  ...rest
+}: {
+  'the-value'?: number;
+  0?: number;
+  skip?: number;
+  extra?: number;
+}): void {}
+
+export let importedLet = (value = 0): void => {};
+
+export const importedAny: any = 1;
+
+export declare const importedDecl: (value?: number) => void;

--- a/packages/eslint-plugin/tests/fixtures/tsconfig.json
+++ b/packages/eslint-plugin/tests/fixtures/tsconfig.json
@@ -14,6 +14,7 @@
     "deprecated.ts",
     "mixed-enums-decl.ts",
     "react.tsx",
+    "redundant-default-arguments.ts",
     "var-declaration.ts",
     "errors.ts",
     "switch-exhaustiveness-check.ts"

--- a/packages/eslint-plugin/tests/rules/no-redundant-default-arguments.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-redundant-default-arguments.test.ts
@@ -1,0 +1,704 @@
+import rule from '../../src/rules/no-redundant-default-arguments';
+import { createRuleTesterWithTypes } from '../RuleTester';
+
+const ruleTester = createRuleTesterWithTypes({
+  ecmaFeatures: {
+    jsx: true,
+  },
+});
+
+ruleTester.run('no-redundant-default-arguments', rule, {
+  valid: [
+    `
+function loadPage(page = 20) {}
+loadPage();
+    `,
+    `
+function loadPage(page = 20) {}
+loadPage(1);
+    `,
+    `
+function loadPage(page = 20) {}
+loadPage(page);
+    `,
+    `
+declare const DEFAULT_PAGE: number;
+function loadPage(page = DEFAULT_PAGE) {}
+loadPage(20);
+    `,
+    `
+function loadPage(page = 20, limit = 10) {}
+loadPage(20, 5);
+    `,
+    `
+declare const ids: string[];
+function loadPage(id: string, page = 20) {}
+loadPage(...ids, 20);
+    `,
+    `
+declare const extra: number[];
+function loadPage(page = 20, ...rest: number[]) {}
+loadPage(20, ...extra);
+    `,
+    `
+declare const ids: string[];
+function loadOptions(id: string, { page = 20 }: { page?: number }) {}
+loadOptions(...ids, { page: 20 });
+    `,
+    `
+function loadPage(page: number) {}
+loadPage(20);
+    `,
+    `
+const api = {
+  loadPage(page = 20) {},
+};
+api.loadPage(20);
+    `,
+    `
+let loadPage = (page = 20) => {};
+loadPage(20);
+    `,
+    `
+function loadPage(page = 20) {}
+loadPage = (page = 1) => {};
+loadPage(20);
+    `,
+    `
+function loadPage(page?: number): void;
+function loadPage(page = 20): void {}
+loadPage(20);
+    `,
+    `
+function loadPage(page = 20) {}
+function nested() {
+  function loadPage(page = 1) {}
+  loadPage(20);
+}
+    `,
+    `
+function loadOptions({ page = 20 }: { page?: number }) {}
+loadOptions({ page: 1 });
+    `,
+    `
+declare const page: number;
+function loadOptions({ page = 20 }: { page?: number }) {}
+loadOptions({ page });
+    `,
+    `
+declare const other: { extra?: number };
+function loadOptions({ page = 20 }: { page?: number }) {}
+loadOptions({ page: 20, ...other });
+    `,
+    `
+declare const other: { extra?: number };
+function loadOptions({ page = 20 }: { page?: number }) {}
+loadOptions({ ...other, page: 20 });
+    `,
+    `
+function loadOptions({ page = 20 }: { page?: number }) {}
+loadOptions({ ['page']: 20 });
+    `,
+    {
+      code: '<Unknown title="Inbox" />;',
+      filename: 'react.tsx',
+    },
+    {
+      code: `
+function Header({ title = 'Inbox' }: { title?: string }) {
+  return null;
+}
+<Header title="Sent" />;
+      `,
+      filename: 'react.tsx',
+    },
+    {
+      code: `
+declare const label: string;
+function Header({ title = 'Inbox' }: { title?: string }) {
+  return null;
+}
+<Header title={label} />;
+      `,
+      filename: 'react.tsx',
+    },
+    {
+      code: `
+declare const other: { subtitle?: string };
+function Header({ title = 'Inbox' }: { title?: string }) {
+  return null;
+}
+<Header title="Inbox" {...other} />;
+      `,
+      filename: 'react.tsx',
+    },
+    {
+      code: `
+declare const other: { subtitle?: string };
+function Header({ title = 'Inbox' }: { title?: string }) {
+  return null;
+}
+<Header {...other} title="Inbox" />;
+      `,
+      filename: 'react.tsx',
+    },
+    {
+      code: '<div title="Inbox" />;',
+      filename: 'react.tsx',
+    },
+    `
+function loadPage(page = -0) {}
+loadPage(0);
+    `,
+    `
+import { importedWithDefault } from './redundant-default-arguments';
+importedWithDefault(1);
+    `,
+    {
+      code: `
+import { ImportedComponent } from './redundant-default-arguments';
+<ImportedComponent value={1} />;
+      `,
+      filename: 'react.tsx',
+    },
+  ],
+  invalid: [
+    {
+      code: `
+function loadPage(page = 20) {}
+loadPage(20);
+      `,
+      errors: [
+        {
+          column: 10,
+          data: { kind: 'argument', name: 'page', value: '20' },
+          endColumn: 12,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefaultValue',
+        },
+      ],
+      output: `
+function loadPage(page = 20) {}
+loadPage();
+      `,
+    },
+    {
+      code: `
+loadPage(0);
+function loadPage(page = 0) {}
+      `,
+      errors: [
+        {
+          column: 10,
+          data: { kind: 'argument', name: 'page', value: '0' },
+          endColumn: 11,
+          endLine: 2,
+          line: 2,
+          messageId: 'redundantDefaultValue',
+        },
+      ],
+      output: `
+loadPage();
+function loadPage(page = 0) {}
+      `,
+    },
+    {
+      code: `
+const loadMode = (mode = 'all') => {};
+loadMode('all');
+      `,
+      errors: [
+        {
+          column: 10,
+          data: { kind: 'argument', name: 'mode', value: '"all"' },
+          endColumn: 15,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefaultValue',
+        },
+      ],
+      output: `
+const loadMode = (mode = 'all') => {};
+loadMode();
+      `,
+    },
+    {
+      code: `
+const loadFlag = function (enabled = false) {};
+loadFlag(false);
+      `,
+      errors: [
+        {
+          column: 10,
+          data: { kind: 'argument', name: 'enabled', value: 'false' },
+          endColumn: 15,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefaultValue',
+        },
+      ],
+      output: `
+const loadFlag = function (enabled = false) {};
+loadFlag();
+      `,
+    },
+    {
+      code: `
+function configure(enabled = false, mode = 'all') {}
+configure(false, 'all');
+      `,
+      errors: [
+        {
+          column: 11,
+          data: { kind: 'argument', name: 'enabled', value: 'false' },
+          endColumn: 16,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefaultValue',
+        },
+        {
+          column: 18,
+          data: { kind: 'argument', name: 'mode', value: '"all"' },
+          endColumn: 23,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefaultValue',
+        },
+      ],
+      output: `
+function configure(enabled = false, mode = 'all') {}
+configure();
+      `,
+    },
+    {
+      code: `
+function configure(first = false, second = true) {}
+configure(false, /* keep */ true);
+      `,
+      errors: [
+        {
+          column: 11,
+          endColumn: 16,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefaultValue',
+        },
+        {
+          column: 29,
+          endColumn: 33,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefaultValue',
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+function offsetBy(value = -1) {}
+offsetBy(-1);
+      `,
+      errors: [
+        {
+          column: 10,
+          data: { kind: 'argument', name: 'value', value: '-1' },
+          endColumn: 12,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefaultValue',
+        },
+      ],
+      output: `
+function offsetBy(value = -1) {}
+offsetBy();
+      `,
+    },
+    {
+      code: `
+function loadMode(mode = \`all\`) {}
+loadMode('all');
+      `,
+      errors: [
+        {
+          column: 10,
+          data: { kind: 'argument', name: 'mode', value: '"all"' },
+          endColumn: 15,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefaultValue',
+        },
+      ],
+      output: `
+function loadMode(mode = \`all\`) {}
+loadMode();
+      `,
+    },
+    {
+      code: `
+function loadOptions({ page = 5 }: { page?: number }) {}
+loadOptions({ page: 5 });
+      `,
+      errors: [
+        {
+          column: 15,
+          data: { kind: 'property', name: 'page', value: '5' },
+          endColumn: 22,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefaultValue',
+        },
+      ],
+      output: `
+function loadOptions({ page = 5 }: { page?: number }) {}
+loadOptions({});
+      `,
+    },
+    {
+      code: `
+function loadOptions({ page: localPage = 5 }: { page?: number }) {}
+loadOptions({ page: 5 });
+      `,
+      errors: [
+        {
+          column: 15,
+          data: { kind: 'property', name: 'page', value: '5' },
+          endColumn: 22,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefaultValue',
+        },
+      ],
+      output: `
+function loadOptions({ page: localPage = 5 }: { page?: number }) {}
+loadOptions({});
+      `,
+    },
+    {
+      code: `
+declare const values: unknown[];
+function loadOptions({ page = 5 }: { page?: number }, ...rest: unknown[]) {}
+loadOptions({ page: 5 }, ...values);
+      `,
+      errors: [
+        {
+          column: 15,
+          endColumn: 22,
+          endLine: 4,
+          line: 4,
+          messageId: 'redundantDefaultValue',
+        },
+      ],
+      output: `
+declare const values: unknown[];
+function loadOptions({ page = 5 }: { page?: number }, ...rest: unknown[]) {}
+loadOptions({}, ...values);
+      `,
+    },
+    {
+      code: `
+function loadOptions({
+  first = 1,
+  second = 2,
+}: {
+  first?: number;
+  second?: number;
+}) {}
+loadOptions({ first: 1, second: 2 });
+      `,
+      errors: [
+        {
+          column: 15,
+          endColumn: 23,
+          endLine: 9,
+          line: 9,
+          messageId: 'redundantDefaultValue',
+        },
+        {
+          column: 25,
+          endColumn: 34,
+          endLine: 9,
+          line: 9,
+          messageId: 'redundantDefaultValue',
+        },
+      ],
+      output: `
+function loadOptions({
+  first = 1,
+  second = 2,
+}: {
+  first?: number;
+  second?: number;
+}) {}
+loadOptions({});
+      `,
+    },
+    {
+      code: `
+function Header({ title = 5 }: { title?: number }) {
+  return null;
+}
+<Header title={5} />;
+      `,
+      errors: [
+        {
+          column: 9,
+          data: { kind: 'prop', name: 'title', value: '5' },
+          endColumn: 18,
+          endLine: 5,
+          line: 5,
+          messageId: 'redundantDefaultValue',
+        },
+      ],
+      filename: 'react.tsx',
+      output: `
+function Header({ title = 5 }: { title?: number }) {
+  return null;
+}
+<Header />;
+      `,
+    },
+    {
+      code: `
+const Label = ({ text = 'hello' }: { text?: string }) => null;
+<Label text="hello" />;
+      `,
+      errors: [
+        {
+          column: 8,
+          data: { kind: 'prop', name: 'text', value: '"hello"' },
+          endColumn: 20,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefaultValue',
+        },
+      ],
+      filename: 'react.tsx',
+      output: `
+const Label = ({ text = 'hello' }: { text?: string }) => null;
+<Label />;
+      `,
+    },
+    {
+      code: `
+function Toggle({ enabled = true }: { enabled?: boolean }) {
+  return null;
+}
+<Toggle enabled />;
+      `,
+      errors: [
+        {
+          column: 9,
+          data: { kind: 'prop', name: 'enabled', value: 'true' },
+          endColumn: 16,
+          endLine: 5,
+          line: 5,
+          messageId: 'redundantDefaultValue',
+        },
+      ],
+      filename: 'react.tsx',
+      output: `
+function Toggle({ enabled = true }: { enabled?: boolean }) {
+  return null;
+}
+<Toggle />;
+      `,
+    },
+    {
+      code: `
+function Header({ title = 5 }: { title?: number } = {}) {
+  return null;
+}
+<Header title={5} />;
+      `,
+      errors: [
+        {
+          column: 9,
+          endColumn: 18,
+          endLine: 5,
+          line: 5,
+          messageId: 'redundantDefaultValue',
+        },
+      ],
+      filename: 'react.tsx',
+      output: `
+function Header({ title = 5 }: { title?: number } = {}) {
+  return null;
+}
+<Header />;
+      `,
+    },
+    {
+      code: `
+function Panel({ first = 1, second = 2 }: { first?: number; second?: number }) {
+  return null;
+}
+<Panel first={1} second={2} />;
+      `,
+      errors: [
+        {
+          column: 8,
+          endColumn: 17,
+          endLine: 5,
+          line: 5,
+          messageId: 'redundantDefaultValue',
+        },
+        {
+          column: 18,
+          endColumn: 28,
+          endLine: 5,
+          line: 5,
+          messageId: 'redundantDefaultValue',
+        },
+      ],
+      filename: 'react.tsx',
+      output: `
+function Panel({ first = 1, second = 2 }: { first?: number; second?: number }) {
+  return null;
+}
+<Panel />;
+      `,
+    },
+    {
+      code: `
+const loadPage = (page = 5 as const) => {};
+loadPage(5 as const);
+      `,
+      errors: [
+        {
+          column: 10,
+          data: { kind: 'argument', name: 'page', value: '5' },
+          endColumn: 20,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefaultValue',
+        },
+      ],
+      output: `
+const loadPage = (page = 5 as const) => {};
+loadPage();
+      `,
+    },
+    {
+      code: `
+import { importedWithDefault } from './redundant-default-arguments';
+importedWithDefault(0);
+      `,
+      errors: [
+        {
+          column: 21,
+          data: { kind: 'argument', name: 'value', value: '0' },
+          endColumn: 22,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefaultValue',
+        },
+      ],
+      output: `
+import { importedWithDefault } from './redundant-default-arguments';
+importedWithDefault();
+      `,
+    },
+    {
+      code: `
+import { importedWithOptions } from './redundant-default-arguments';
+importedWithOptions({ value: 5 });
+      `,
+      errors: [
+        {
+          column: 23,
+          data: { kind: 'property', name: 'value', value: '5' },
+          endColumn: 31,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefaultValue',
+        },
+      ],
+      output: `
+import { importedWithOptions } from './redundant-default-arguments';
+importedWithOptions({});
+      `,
+    },
+    {
+      code: `
+import { ImportedComponent } from './redundant-default-arguments';
+<ImportedComponent value={5} />;
+      `,
+      errors: [
+        {
+          column: 20,
+          data: { kind: 'prop', name: 'value', value: '5' },
+          endColumn: 29,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefaultValue',
+        },
+      ],
+      filename: 'react.tsx',
+      output: `
+import { ImportedComponent } from './redundant-default-arguments';
+<ImportedComponent />;
+      `,
+    },
+    {
+      code: `
+function loadPage(this: void, page = 20) {}
+loadPage(20);
+      `,
+      errors: [
+        {
+          column: 10,
+          data: { kind: 'argument', name: 'page', value: '20' },
+          endColumn: 12,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefaultValue',
+        },
+      ],
+      output: `
+function loadPage(this: void, page = 20) {}
+loadPage();
+      `,
+    },
+    {
+      code: `
+function loadOptions({ page = 5 }: { page?: number; extra?: number }) {}
+loadOptions({ page: 5, extra: 1 });
+      `,
+      errors: [
+        {
+          column: 15,
+          data: { kind: 'property', name: 'page', value: '5' },
+          endColumn: 22,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefaultValue',
+        },
+      ],
+      output: `
+function loadOptions({ page = 5 }: { page?: number; extra?: number }) {}
+loadOptions({ extra: 1 });
+      `,
+    },
+    {
+      code: `
+function loadOptions({ page = 5 }: { page?: number; extra?: number }) {}
+loadOptions({ extra: 1, page: 5 });
+      `,
+      errors: [
+        {
+          column: 25,
+          data: { kind: 'property', name: 'page', value: '5' },
+          endColumn: 32,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefaultValue',
+        },
+      ],
+      output: `
+function loadOptions({ page = 5 }: { page?: number; extra?: number }) {}
+loadOptions({ extra: 1 });
+      `,
+    },
+  ],
+});

--- a/packages/eslint-plugin/tests/rules/no-redundant-default-arguments.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-redundant-default-arguments.test.ts
@@ -1,3 +1,5 @@
+import { noFormat } from '@typescript-eslint/rule-tester';
+
 import rule from '../../src/rules/no-redundant-default-arguments';
 import { createRuleTesterWithTypes } from '../RuleTester';
 
@@ -161,6 +163,71 @@ import { ImportedComponent } from './redundant-default-arguments';
       `,
       filename: 'react.tsx',
     },
+    `
+function loadOptions({ page = 5 }: { page?: number }) {}
+loadOptions({ page: 1, page: 5 });
+    `,
+    `
+declare const loadPage: (page?: number) => void;
+loadPage(20);
+    `,
+    `
+const loadPage = (page: number) => {};
+loadPage(20);
+    `,
+    `
+function run(loadPage = (page = 20) => {}) {
+  loadPage(20);
+}
+    `,
+    `
+function loadPage([page = 20] = []) {}
+loadPage([20]);
+    `,
+    `
+function loadOptions({ page }: { page: number }) {}
+loadOptions({ page: 5 });
+    `,
+    `
+function loadOptions({} = {}) {}
+loadOptions({});
+    `,
+    `
+function loadOptions({ ['page']: page = 5 }: { page?: number }) {}
+loadOptions({ page: 5 });
+    `,
+    `
+function loadPage(page = 1n) {}
+loadPage(1n);
+    `,
+    `
+function loadPage(page = \`x\${1}\`) {}
+loadPage('x1');
+    `,
+    `
+function loadPage(page = +1) {}
+loadPage(1);
+    `,
+    `
+import { importedOverload } from './redundant-default-arguments';
+importedOverload(0);
+    `,
+    `
+import { importedLet } from './redundant-default-arguments';
+importedLet(0);
+    `,
+    `
+import { importedAny } from './redundant-default-arguments';
+importedAny(0);
+    `,
+    `
+import { importedDecl } from './redundant-default-arguments';
+importedDecl(20);
+    `,
+    `
+import { importedKeys } from './redundant-default-arguments';
+importedKeys({ skip: 5 });
+    `,
   ],
   invalid: [
     {
@@ -698,6 +765,420 @@ loadOptions({ extra: 1, page: 5 });
       output: `
 function loadOptions({ page = 5 }: { page?: number; extra?: number }) {}
 loadOptions({ extra: 1 });
+      `,
+    },
+    {
+      code: `
+function loadPage(id: string, page = 20) {}
+loadPage('a', 20);
+      `,
+      errors: [
+        {
+          column: 15,
+          data: { kind: 'argument', name: 'page', value: '20' },
+          endColumn: 17,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefaultValue',
+        },
+      ],
+      output: `
+function loadPage(id: string, page = 20) {}
+loadPage('a');
+      `,
+    },
+    {
+      code: noFormat`
+function loadPage(page = 20) {}
+loadPage(20,);
+      `,
+      errors: [
+        {
+          column: 10,
+          data: { kind: 'argument', name: 'page', value: '20' },
+          endColumn: 12,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefaultValue',
+        },
+      ],
+      output: `
+function loadPage(page = 20) {}
+loadPage();
+      `,
+    },
+    {
+      code: noFormat`
+function loadOptions({ page = 5 }: { page?: number; extra?: number }) {}
+loadOptions({ extra: 1, page: 5, });
+      `,
+      errors: [
+        {
+          column: 25,
+          data: { kind: 'property', name: 'page', value: '5' },
+          endColumn: 32,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefaultValue',
+        },
+      ],
+      output: `
+function loadOptions({ page = 5 }: { page?: number; extra?: number }) {}
+loadOptions({ extra: 1 });
+      `,
+    },
+    {
+      code: `
+function Header({ title = 5, extra }: { title?: number; extra?: number }) {
+  return null;
+}
+<Header title={5} extra={1} />;
+      `,
+      errors: [
+        {
+          column: 9,
+          data: { kind: 'prop', name: 'title', value: '5' },
+          endColumn: 18,
+          endLine: 5,
+          line: 5,
+          messageId: 'redundantDefaultValue',
+        },
+      ],
+      filename: 'react.tsx',
+      output: `
+function Header({ title = 5, extra }: { title?: number; extra?: number }) {
+  return null;
+}
+<Header extra={1} />;
+      `,
+    },
+    {
+      code: `
+function Header({ title = 5 }: any) {
+  return null;
+}
+<Header foo:bar={1} title={5} />;
+      `,
+      errors: [
+        {
+          column: 21,
+          data: { kind: 'prop', name: 'title', value: '5' },
+          endColumn: 30,
+          endLine: 5,
+          line: 5,
+          messageId: 'redundantDefaultValue',
+        },
+      ],
+      filename: 'react.tsx',
+      output: `
+function Header({ title = 5 }: any) {
+  return null;
+}
+<Header foo:bar={1} />;
+      `,
+    },
+    {
+      code: noFormat`
+function loadOptions({ page = 5 }: { page?: number }) {}
+loadOptions({ 'page': 5 });
+      `,
+      errors: [
+        {
+          column: 15,
+          data: { kind: 'property', name: 'page', value: '5' },
+          endColumn: 24,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefaultValue',
+        },
+      ],
+      output: `
+function loadOptions({ page = 5 }: { page?: number }) {}
+loadOptions({});
+      `,
+    },
+    {
+      code: `
+function loadOptions({ 0: page = 5 }: { 0?: number }) {}
+loadOptions({ 0: 5 });
+      `,
+      errors: [
+        {
+          column: 15,
+          data: { kind: 'property', name: '0', value: '5' },
+          endColumn: 19,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefaultValue',
+        },
+      ],
+      output: `
+function loadOptions({ 0: page = 5 }: { 0?: number }) {}
+loadOptions({});
+      `,
+    },
+    {
+      code: `
+function loadOptions({ page = 5, ...rest }: { page?: number }) {}
+loadOptions({ page: 5 });
+      `,
+      errors: [
+        {
+          column: 15,
+          data: { kind: 'property', name: 'page', value: '5' },
+          endColumn: 22,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefaultValue',
+        },
+      ],
+      output: `
+function loadOptions({ page = 5, ...rest }: { page?: number }) {}
+loadOptions({});
+      `,
+    },
+    {
+      code: `
+const loadPage = ((page = 5) => {}) as (page?: number) => void;
+loadPage(5);
+      `,
+      errors: [
+        {
+          column: 10,
+          data: { kind: 'argument', name: 'page', value: '5' },
+          endColumn: 11,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefaultValue',
+        },
+      ],
+      output: `
+const loadPage = ((page = 5) => {}) as (page?: number) => void;
+loadPage();
+      `,
+    },
+    {
+      code: `
+const loadPage = ((page = 5) => {})!;
+loadPage(5);
+      `,
+      errors: [
+        {
+          column: 10,
+          data: { kind: 'argument', name: 'page', value: '5' },
+          endColumn: 11,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefaultValue',
+        },
+      ],
+      output: `
+const loadPage = ((page = 5) => {})!;
+loadPage();
+      `,
+    },
+    {
+      code: `
+const loadPage = ((page = 5) => {}) satisfies (page?: number) => void;
+loadPage(5);
+      `,
+      errors: [
+        {
+          column: 10,
+          data: { kind: 'argument', name: 'page', value: '5' },
+          endColumn: 11,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefaultValue',
+        },
+      ],
+      output: `
+const loadPage = ((page = 5) => {}) satisfies (page?: number) => void;
+loadPage();
+      `,
+    },
+    {
+      code: `
+import { importedArrow } from './redundant-default-arguments';
+importedArrow(0);
+      `,
+      errors: [
+        {
+          column: 15,
+          data: { kind: 'argument', name: 'value', value: '0' },
+          endColumn: 16,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefaultValue',
+        },
+      ],
+      output: `
+import { importedArrow } from './redundant-default-arguments';
+importedArrow();
+      `,
+    },
+    {
+      code: `
+import { importedFnExpr } from './redundant-default-arguments';
+importedFnExpr(0);
+      `,
+      errors: [
+        {
+          column: 16,
+          data: { kind: 'argument', name: 'value', value: '0' },
+          endColumn: 17,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefaultValue',
+        },
+      ],
+      output: `
+import { importedFnExpr } from './redundant-default-arguments';
+importedFnExpr();
+      `,
+    },
+    {
+      code: `
+import { importedWithThis } from './redundant-default-arguments';
+importedWithThis(0);
+      `,
+      errors: [
+        {
+          column: 18,
+          data: { kind: 'argument', name: 'value', value: '0' },
+          endColumn: 19,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefaultValue',
+        },
+      ],
+      output: `
+import { importedWithThis } from './redundant-default-arguments';
+importedWithThis();
+      `,
+    },
+    {
+      code: `
+import { importedLiterals } from './redundant-default-arguments';
+importedLiterals('all', true, false, null, -1);
+      `,
+      errors: [
+        {
+          column: 18,
+          data: { kind: 'argument', name: 'mode', value: '"all"' },
+          endColumn: 23,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefaultValue',
+        },
+        {
+          column: 25,
+          data: { kind: 'argument', name: 'enabled', value: 'true' },
+          endColumn: 29,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefaultValue',
+        },
+        {
+          column: 31,
+          data: { kind: 'argument', name: 'disabled', value: 'false' },
+          endColumn: 36,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefaultValue',
+        },
+        {
+          column: 38,
+          data: { kind: 'argument', name: 'empty', value: 'null' },
+          endColumn: 42,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefaultValue',
+        },
+        {
+          column: 44,
+          data: { kind: 'argument', name: 'offset', value: '-1' },
+          endColumn: 46,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefaultValue',
+        },
+      ],
+      output: `
+import { importedLiterals } from './redundant-default-arguments';
+importedLiterals();
+      `,
+    },
+    {
+      code: `
+import { importedWrapped } from './redundant-default-arguments';
+importedWrapped(0, 0, 0, 0);
+      `,
+      errors: [
+        {
+          column: 17,
+          data: { kind: 'argument', name: 'asserted', value: '0' },
+          endColumn: 18,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefaultValue',
+        },
+        {
+          column: 20,
+          data: { kind: 'argument', name: 'parens', value: '0' },
+          endColumn: 21,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefaultValue',
+        },
+        {
+          column: 23,
+          data: { kind: 'argument', name: 'nonNull', value: '0' },
+          endColumn: 24,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefaultValue',
+        },
+        {
+          column: 26,
+          data: { kind: 'argument', name: 'satisfied', value: '0' },
+          endColumn: 27,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefaultValue',
+        },
+      ],
+      output: `
+import { importedWrapped } from './redundant-default-arguments';
+importedWrapped();
+      `,
+    },
+    {
+      code: `
+import { importedKeys } from './redundant-default-arguments';
+importedKeys({ 'the-value': 5, 0: 5 });
+      `,
+      errors: [
+        {
+          column: 16,
+          data: { kind: 'property', name: 'the-value', value: '5' },
+          endColumn: 30,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefaultValue',
+        },
+        {
+          column: 32,
+          data: { kind: 'property', name: '0', value: '5' },
+          endColumn: 36,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantDefaultValue',
+        },
+      ],
+      output: `
+import { importedKeys } from './redundant-default-arguments';
+importedKeys({});
       `,
     },
   ],

--- a/packages/eslint-plugin/tests/schema-snapshots/no-redundant-default-arguments.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-redundant-default-arguments.shot
@@ -1,0 +1,10 @@
+
+# SCHEMA:
+
+[]
+
+
+# TYPES:
+
+/** No options declared */
+type Options = [];


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #~12782~
- [x] That issue was marked as accepting prs
- [x] Steps in Contributing were taken
- [x] If this PR used AI assistance, I followed the AI Contribution Policy

## Overview

Fixes #~12782~.

New type-aware rule that reports when you pass an argument, object property, or JSX prop that's already the parameter's default. Not in recommended.