### PR TITLE
fix(eslint-plugin): [no-useless-default-assignment] avoid false positives on tuple elements at or after a rest element

### DIFF
--- a/packages/eslint-plugin/src/rules/no-useless-default-assignment.ts
+++ b/packages/eslint-plugin/src/rules/no-useless-default-assignment.ts
@@ -222,10 +222,21 @@ export default createRule<Options, MessageId>({
 
         const tupleArgs = checker.getTypeArguments(sourceType);
         const elementIndex = parent.elements.indexOf(node);
+
         if (elementIndex < 0 || elementIndex >= tupleArgs.length) {
           return;
         }
+
+        const tupleTarget = sourceType.target;
+
+        if (
+          tupleTarget.elementFlags.some(flag => flag === ts.ElementFlags.Rest)
+        ) {
+          return;
+        }
+
         const elementType = tupleArgs[elementIndex];
+
         if (!canBeUndefined(elementType)) {
           reportUselessDefaultAssignment(node, 'property');
         }

--- a/packages/eslint-plugin/tests/rules/no-useless-default-assignment.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-useless-default-assignment.test.ts
@@ -226,6 +226,22 @@ useCallback((value: number[] = []) => {});
 declare const tuple: [string];
 const [a, b = 'default'] = tuple;
     `,
+    `
+declare const commands: [string, ...string[]];
+const [cmd, arg = 'run'] = commands;
+    `,
+    `
+declare const items: [...string[], string | undefined];
+const [first = 'fallback'] = items;
+    `,
+    `
+declare const pair: [string, string?];
+const [a, b = 'default'] = pair;
+    `,
+    `
+declare const rest: [...number[], boolean];
+const [a = 1] = rest;
+    `,
     // https://github.com/typescript-eslint/typescript-eslint/issues/11911
     `
 const run = (cb: (...args: unknown[]) => void) => cb();


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [X] Addresses an existing open issue: fixes #12767
- [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [X] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

<!-- Description of what is changed and how the code change does that. -->

* Added verification for tuple targets
* Added appropriate valid cases to tests