### PR TITLE
fix(rule-tester): expose process.cwd() to rules

### DIFF
--- a/packages/rule-tester/src/RuleTester.ts
+++ b/packages/rule-tester/src/RuleTester.ts
@@ -435,7 +435,17 @@ export class RuleTester extends TestFramework {
         // eslint-disable-next-line @typescript-eslint/no-deprecated -- For compatibility with ESLint 8
         freezeDeeply(context.parserOptions);
 
-        return (typeof rule === 'function' ? rule : rule.create)(context);
+        // Absolute filenames require the linter's config base path to be the filesystem root,
+        // but that implementation detail should not change the cwd exposed to rules.
+        const ruleContext = Object.create(context, {
+          cwd: {
+            enumerable: true,
+            value: process.cwd(),
+          },
+        }) as typeof context;
+        Object.freeze(ruleContext);
+
+        return (typeof rule === 'function' ? rule : rule.create)(ruleContext);
       },
     };
   }

--- a/packages/rule-tester/tests/filename.test.ts
+++ b/packages/rule-tester/tests/filename.test.ts
@@ -42,6 +42,29 @@ const rule = ESLintUtils.RuleCreator.withoutDocs({
   }),
 });
 
+const cwdRule = ESLintUtils.RuleCreator.withoutDocs({
+  meta: {
+    docs: {
+      description: 'some description',
+    },
+    messages: {
+      cwd: '{{cwd}}',
+    },
+    schema: [],
+    type: 'problem',
+  },
+  defaultOptions: [],
+  create: context => ({
+    Program(node): void {
+      context.report({
+        data: { cwd: context.cwd },
+        messageId: 'cwd',
+        node,
+      });
+    },
+  }),
+});
+
 describe('rule tester filename', () => {
   new RuleTester().run('without tsconfigRootDir', rule, {
     invalid: [
@@ -152,6 +175,19 @@ describe('rule tester filename', () => {
         code: '_',
         errors: [{ messageId: 'foo' }],
         filename: 'a/////////////../../../b',
+      },
+    ],
+    valid: [],
+  });
+});
+
+describe('rule tester context.cwd', () => {
+  new RuleTester().run('context-cwd', cwdRule, {
+    invalid: [
+      {
+        code: '_',
+        errors: [{ message: process.cwd() }],
+        filename: '/an-absolute-path/foo.js',
       },
     ],
     valid: [],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #11274
- [x] That issue was marked as accepting prs
- [x] Steps in Contributing were taken
- [x] If this PR used AI assistance, I followed the AI Contribution Policy

## Overview

When RuleTester receives an absolute filename, it uses the filesystem root as the Linter config base so the test configuration still matches. ESLint then exposes that implementation detail as context.cwd.

This keeps the existing config and filename behavior while making context.cwd resolve to process.cwd() for rules. The context prototype is preserved so the other context properties remain available.

Added a regression test covering an absolute filename.

## Validation

- RuleTester tests: 120 passed
- filename regression test: 20 passed
- TypeScript typecheck passed
- Prettier and ESLint passed
- rule-tester build passed