### PR TITLE
fix(eslint-plugin): [prefer-optional-chain] safe fix when the chain ends with a strict null comparison

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-optional-chain-utils/analyzeChain.ts
+++ b/packages/eslint-plugin/src/rules/prefer-optional-chain-utils/analyzeChain.ts
@@ -805,9 +805,42 @@ export function analyzeChain(
         // foo !== null && foo !== undefined
         validatedOperands[validatedOperands.length - 1].comparedName,
       );
+
       if (comparisonResult === NodeComparisonResult.Subset) {
-        // the operands are comparable, so we can continue searching
-        subChain.push(currentOperand);
+        if (
+          operator === '||' &&
+          currentOperand.comparisonType ===
+            NullishComparisonType.StrictEqualNull &&
+          /*
+           * A paired `[=== null, === undefined]` operand is semantically safe
+           * because it merges to `== null`. Only a lone `=== null` can produce
+           * a broken strict-equality check in the merged chain.
+           */
+          validatedOperands.length === 1 &&
+          subChain
+            .flat()
+            .some(
+              operand =>
+                operand.comparisonType ===
+                NullishComparisonType.StrictEqualUndefined,
+            )
+        ) {
+          /*
+           * For OR chains that contain a `=== undefined` guard anywhere,
+           * extending the chain with a lone `=== null` subset changes
+           *  semantics: when the guarded node is undefined, `node?.child`
+           * returns `undefined`, and `undefined === null` is false (strict),
+           * but the original `=== undefined` guard was true.
+           *
+           * e.g. `foo === undefined || foo.bar === null` must NOT merge to
+           * `foo?.bar === null`, and neither should a mid-chain form like
+           * `a == null || a.b === undefined || a.b.c === null`.
+           */
+          maybeReportThenReset(validatedOperands);
+        } else {
+          // the operands are comparable, so we can continue searching
+          subChain.push(currentOperand);
+        }
       } else if (comparisonResult === NodeComparisonResult.Invalid) {
         maybeReportThenReset(validatedOperands);
       } else {
@@ -819,6 +852,7 @@ export function analyzeChain(
       subChain.push(currentOperand);
     }
   }
+
   const lastOperand = subChain.flat().at(-1);
 
   if (lastOperand && lastChainOperand) {

--- a/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain.test.ts
@@ -1802,6 +1802,48 @@ const baz = foo?.bar;
       ],
       output: 'foo?.bar && (a && b) && c',
     },
+    {
+      code: `
+interface Foo {
+  outermostFoo(): Foo | null;
+}
+
+function eitherFooOrNull(): Foo | null {
+  return Math.random() < 0.5 ? { outermostFoo: () => null } : null;
+}
+
+const foo = eitherFooOrNull();
+if (!foo || foo.outermostFoo() !== foo) {
+}
+      `,
+      errors: [
+        {
+          column: 5,
+          endColumn: 39,
+          endLine: 11,
+          line: 11,
+          messageId: 'preferOptionalChain',
+          suggestions: [
+            {
+              messageId: 'optionalChainSuggest',
+              output: `
+interface Foo {
+  outermostFoo(): Foo | null;
+}
+
+function eitherFooOrNull(): Foo | null {
+  return Math.random() < 0.5 ? { outermostFoo: () => null } : null;
+}
+
+const foo = eitherFooOrNull();
+if (foo?.outermostFoo() !== foo) {
+}
+      `,
+            },
+          ],
+        },
+      ],
+    },
   ],
   valid: [
     '!a || !b;',
@@ -1901,6 +1943,13 @@ foo !== null && foo.bar !== null;
     `
 declare const foo: { bar: string | null } | null;
 foo != null && foo.bar !== null;
+    `,
+    `
+declare const foo: { bar: number | null } | undefined;
+if (foo === undefined || foo.bar === null) {
+} else {
+  foo.bar.toExponential();
+}
     `,
     {
       code: `


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [X] Addresses an existing open issue: fixes #11840 
- [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [X] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

<!-- Description of what is changed and how the code change does that. -->

* Added verification to handle if the OR chain ends with a strict null comparison
* Added relevant tests