### PR TITLE
fix(eslint-plugin): [no-explicit-any] use unknown[] for bare any rest parameters

### DIFF
--- a/packages/eslint-plugin/src/rules/no-explicit-any.ts
+++ b/packages/eslint-plugin/src/rules/no-explicit-any.ts
@@ -198,6 +198,18 @@ export default createRule<Options, MessageIds>({
       };
     }
 
+    function createUnknownFixer(node: TSESTree.TSAnyKeyword) {
+      return (fixer: TSESLint.RuleFixer) => {
+        return fixer.replaceText(
+          node,
+          node.parent.type === AST_NODE_TYPES.TSTypeAnnotation &&
+            isNodeRestElementInFunction(node.parent.parent)
+            ? 'unknown[]'
+            : 'unknown',
+        );
+      };
+    }
+
     return {
       TSAnyKeyword(node): void {
         const isKeyofAny = isNodeWithinKeyofAny(node);
@@ -221,7 +233,7 @@ export default createRule<Options, MessageIds>({
             : [
                 {
                   messageId: 'suggestUnknown',
-                  fix: fixer => fixer.replaceText(node, 'unknown'),
+                  fix: createUnknownFixer(node),
                 },
                 {
                   messageId: 'suggestNever',
@@ -233,7 +245,7 @@ export default createRule<Options, MessageIds>({
         if (fixToUnknown) {
           fixOrSuggest.fix = isKeyofAny
             ? createPropertyKeyFixer(node)
-            : fixer => fixer.replaceText(node, 'unknown');
+            : createUnknownFixer(node);
         }
 
         context.report({

--- a/packages/eslint-plugin/tests/rules/no-explicit-any.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-explicit-any.test.ts
@@ -1771,7 +1771,7 @@ function foo(a: number, ...rest: never[]): void {
           suggestions: [
             {
               messageId: 'suggestUnknown',
-              output: 'function foo5(...args: unknown) {}',
+              output: 'function foo5(...args: unknown[]) {}',
             },
             {
               messageId: 'suggestNever',
@@ -1780,7 +1780,8 @@ function foo(a: number, ...rest: never[]): void {
           ],
         },
       ],
-      options: [{ ignoreRestArgs: true }],
+      options: [{ fixToUnknown: true, ignoreRestArgs: true }],
+      output: 'function foo5(...args: unknown[]) {}',
     },
     {
       code: 'const bar5 = function (...args: any) {};',
@@ -1794,7 +1795,7 @@ function foo(a: number, ...rest: never[]): void {
           suggestions: [
             {
               messageId: 'suggestUnknown',
-              output: 'const bar5 = function (...args: unknown) {};',
+              output: 'const bar5 = function (...args: unknown[]) {};',
             },
             {
               messageId: 'suggestNever',
@@ -1817,7 +1818,7 @@ function foo(a: number, ...rest: never[]): void {
           suggestions: [
             {
               messageId: 'suggestUnknown',
-              output: 'const baz5 = (...args: unknown) => {};',
+              output: 'const baz5 = (...args: unknown[]) => {};',
             },
             {
               messageId: 'suggestNever',
@@ -1846,7 +1847,7 @@ interface Qux5 {
               messageId: 'suggestUnknown',
               output: `
 interface Qux5 {
-  (...args: unknown): void;
+  (...args: unknown[]): void;
 }
       `,
             },
@@ -1875,7 +1876,8 @@ interface Qux5 {
           suggestions: [
             {
               messageId: 'suggestUnknown',
-              output: 'function quux5(fn: (...args: unknown) => void): void {}',
+              output:
+                'function quux5(fn: (...args: unknown[]) => void): void {}',
             },
             {
               messageId: 'suggestNever',
@@ -1898,7 +1900,7 @@ interface Qux5 {
           suggestions: [
             {
               messageId: 'suggestUnknown',
-              output: 'function quuz5(): (...args: unknown) => void {}',
+              output: 'function quuz5(): (...args: unknown[]) => void {}',
             },
             {
               messageId: 'suggestNever',
@@ -1920,7 +1922,7 @@ interface Qux5 {
           suggestions: [
             {
               messageId: 'suggestUnknown',
-              output: 'type Fred5 = (...args: unknown) => void;',
+              output: 'type Fred5 = (...args: unknown[]) => void;',
             },
             {
               messageId: 'suggestNever',
@@ -1943,7 +1945,7 @@ interface Qux5 {
           suggestions: [
             {
               messageId: 'suggestUnknown',
-              output: 'type Corge5 = new (...args: unknown) => void;',
+              output: 'type Corge5 = new (...args: unknown[]) => void;',
             },
             {
               messageId: 'suggestNever',
@@ -1972,7 +1974,7 @@ interface Grault5 {
               messageId: 'suggestUnknown',
               output: `
 interface Grault5 {
-  new (...args: unknown): void;
+  new (...args: unknown[]): void;
 }
       `,
             },
@@ -2007,7 +2009,7 @@ interface Garply5 {
               messageId: 'suggestUnknown',
               output: `
 interface Garply5 {
-  f(...args: unknown): void;
+  f(...args: unknown[]): void;
 }
       `,
             },
@@ -2036,7 +2038,7 @@ interface Garply5 {
           suggestions: [
             {
               messageId: 'suggestUnknown',
-              output: 'declare function waldo5(...args: unknown): void;',
+              output: 'declare function waldo5(...args: unknown[]): void;',
             },
             {
               messageId: 'suggestNever',


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #12813
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview
fixes `no-explicit-any` to use `unknown[]` instead of `unknown` for bare any rest parameters

