### PR TITLE
fix(type-utils): match Node URL global types

### DIFF
--- a/packages/type-utils/src/TypeOrValueSpecifier.ts
+++ b/packages/type-utils/src/TypeOrValueSpecifier.ts
@@ -191,8 +191,12 @@ export function typeMatchesSpecifier(
       case 'lib':
         return typeDeclaredInLib(declarationFiles, program);
       case 'package':
+        if (!symbol) {
+          return false;
+        }
         return typeDeclaredInPackageDeclarationFile(
           specifier.package,
+          symbol,
           declarations,
           declarationFiles,
           program,
@@ -264,12 +268,16 @@ export function valueMatchesSpecifier(
 
   if (specifier.from === 'package') {
     const symbol = type.getSymbol() ?? type.aliasSymbol;
-    const declarations = symbol?.getDeclarations() ?? [];
+    if (!symbol) {
+      return false;
+    }
+    const declarations = symbol.getDeclarations() ?? [];
     const declarationFiles = declarations.map(declaration =>
       declaration.getSourceFile(),
     );
     return typeDeclaredInPackageDeclarationFile(
       specifier.package,
+      symbol,
       declarations,
       declarationFiles,
       program,

--- a/packages/type-utils/src/typeOrValueSpecifiers/typeDeclaredInPackageDeclarationFile.ts
+++ b/packages/type-utils/src/typeOrValueSpecifiers/typeDeclaredInPackageDeclarationFile.ts
@@ -28,6 +28,31 @@ function typeDeclaredInDeclareModule(
   );
 }
 
+function typeDeclaredInExportedDeclarationFile(
+  packageName: string,
+  symbol: ts.Symbol,
+  declarationFiles: ts.SourceFile[],
+  program: ts.Program,
+): boolean {
+  const checker = program.getTypeChecker();
+  const moduleSymbol = checker
+    .getAmbientModules()
+    .find(module => module.name === `"${packageName}"`);
+  const exportedSymbol = moduleSymbol
+    ? checker
+        .getExportsOfModule(moduleSymbol)
+        .find(moduleExport => moduleExport.name === symbol.name)
+    : undefined;
+  const exportedDeclarationFiles =
+    exportedSymbol
+      ?.getDeclarations()
+      ?.map(declaration => declaration.getSourceFile()) ?? [];
+
+  return exportedDeclarationFiles.some(exportedDeclarationFile =>
+    declarationFiles.includes(exportedDeclarationFile),
+  );
+}
+
 function typeDeclaredInDeclarationFile(
   packageName: string,
   declarationFiles: ts.SourceFile[],
@@ -49,12 +74,19 @@ function typeDeclaredInDeclarationFile(
 
 export function typeDeclaredInPackageDeclarationFile(
   packageName: string,
+  symbol: ts.Symbol,
   declarations: ts.Node[],
   declarationFiles: ts.SourceFile[],
   program: ts.Program,
 ): boolean {
   return (
     typeDeclaredInDeclareModule(packageName, declarations) ||
-    typeDeclaredInDeclarationFile(packageName, declarationFiles, program)
+    typeDeclaredInDeclarationFile(packageName, declarationFiles, program) ||
+    typeDeclaredInExportedDeclarationFile(
+      packageName,
+      symbol,
+      declarationFiles,
+      program,
+    )
   );
 }

--- a/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
+++ b/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
@@ -1,4 +1,5 @@
 import type { TSESTree } from '@typescript-eslint/utils';
+import type * as ts from 'typescript';
 
 import { parseForESLint } from '@typescript-eslint/parser';
 import { AST_NODE_TYPES } from '@typescript-eslint/utils';
@@ -588,6 +589,10 @@ describe('TypeOrValueSpecifier', () => {
         'type Test = URL;',
         { from: 'package', name: 'URL', package: 'node:buffer' },
       ],
+      [
+        'type Test = string;',
+        { from: 'package', name: 'string', package: 'typescript' },
+      ],
     ] as const satisfies [string, TypeOrValueSpecifier][])(
       "doesn't match a mismatched package specifier: %s\n\t%s",
       ([code, typeOrValueSpecifier], { expect }) => {
@@ -818,6 +823,30 @@ describe('TypeOrValueSpecifier', () => {
           { from: 'package', name: 'URL', package: 'node:buffer' },
         ],
       ])("doesn't match a mismatched package specifier: %s", runTestNegative);
+
+      it('does not match a package when a value symbol has no declarations', () => {
+        const symbol = {
+          getDeclarations: () => undefined,
+          name: 'value',
+        } as unknown as ts.Symbol;
+        const program = {
+          getTypeChecker: () => ({ getAmbientModules: () => [] }),
+        } as unknown as ts.Program;
+        const type = { getSymbol: () => symbol } as unknown as ts.Type;
+        const node = {
+          name: 'value',
+          type: AST_NODE_TYPES.Identifier,
+        } as TSESTree.Identifier;
+
+        expect(
+          valueMatchesSpecifier(
+            node,
+            { from: 'package', name: 'value', package: 'example' },
+            program,
+            type,
+          ),
+        ).toBe(false);
+      });
     });
 
     describe(AST_NODE_TYPES.ClassDeclaration, () => {

--- a/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
+++ b/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
@@ -382,6 +382,14 @@ describe('TypeOrValueSpecifier', () => {
         'import type {Node as TsNode} from "typescript"; type Test = TsNode;',
         { from: 'package', name: ['Node', 'Symbol'], package: 'typescript' },
       ],
+      [
+        'type Test = URL;',
+        { from: 'package', name: 'URL', package: 'node:url' },
+      ],
+      [
+        'import {URL as NodeURL} from "node:url"; type Test = NodeURL;',
+        { from: 'package', name: 'URL', package: 'node:url' },
+      ],
       // The following type is available from the @types/semver package.
       [
         'import {SemVer} from "semver"; type Test = SemVer;',
@@ -575,6 +583,10 @@ describe('TypeOrValueSpecifier', () => {
       [
         'import type {Node as TsNode} from "typescript"; type Test = TsNode;',
         { from: 'package', name: 'TsNode', package: 'typescript' },
+      ],
+      [
+        'type Test = URL;',
+        { from: 'package', name: 'URL', package: 'node:buffer' },
       ],
     ] as const satisfies [string, TypeOrValueSpecifier][])(
       "doesn't match a mismatched package specifier: %s\n\t%s",
@@ -782,6 +794,10 @@ describe('TypeOrValueSpecifier', () => {
           `const fs: typeof import("fs"); const module = fs;`,
           { from: 'package', name: 'fs', package: 'fs' },
         ],
+        [
+          'import { URL } from "node:url"; const value = URL;',
+          { from: 'package', name: 'URL', package: 'node:url' },
+        ],
       ])('matches a matching package specifier: %s', runTestPositive);
 
       it.each<[string, TypeOrValueSpecifier]>([
@@ -796,6 +812,10 @@ describe('TypeOrValueSpecifier', () => {
         [
           'const mock = 42; const hoge = mock;',
           { from: 'package', name: 'mock', package: 'node:test' },
+        ],
+        [
+          'const value = URL;',
+          { from: 'package', name: 'URL', package: 'node:buffer' },
         ],
       ])("doesn't match a mismatched package specifier: %s", runTestNegative);
     });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9608
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

Package-based `TypeOrValueSpecifier` checks currently inspect a type's declaration files. That misses globals such as Node's `URL`: `@types/node` exposes them through an ambient `node:url` module, but the symbol's declaration originates in a global declaration file rather than the module declaration itself.

This keeps the existing direct declaration-file fast paths and adds a narrow ambient-module export fallback. When the checked symbol is exported by the requested package module, its exported declarations are compared with that package's declaration files. This makes both the global `URL` type and imported `node:url` aliases match while preventing unrelated globals from matching another Node package.

Regression coverage includes positive global and imported-alias type cases, an imported runtime-value case, and negative global type/value cases for `node:buffer`.

Validation included the focused `TypeOrValueSpecifier` suite (163 tests), exact touched-file ESLint and Prettier checks, the focused type-utils TypeScript build, `git diff --check`, and the repository's lint-staged pre-commit hook.

AI assistance disclosure: I used Codex with GPT-5 to help trace TypeScript's symbol declarations and ambient-module exports, implement the scoped fallback, and draft the regression cases. I reviewed the complete diff, ran the validation listed above, understand the implementation, and can respond to review feedback.

💖
