### PR TITLE
fix(typescript-estree): add missing `<` token opening type arguments

### DIFF
--- a/packages/ast-spec/src/special/TSTypeParameterInstantiation/fixtures/type-argument-generic-function-type/fixture.ts
+++ b/packages/ast-spec/src/special/TSTypeParameterInstantiation/fixtures/type-argument-generic-function-type/fixture.ts
@@ -1,0 +1,4 @@
+type X = ReturnType<<T>(x: T) => number>;
+// prettier-ignore
+type Y = ReturnType <<T>(x: T) => number>;
+type Z = ReturnType/* c */ <<T>(x: T) => number>;

--- a/packages/ast-spec/src/special/TSTypeParameterInstantiation/fixtures/type-argument-generic-function-type/snapshots/1-TSESTree-AST.shot
+++ b/packages/ast-spec/src/special/TSTypeParameterInstantiation/fixtures/type-argument-generic-function-type/snapshots/1-TSESTree-AST.shot
@@ -1,0 +1,492 @@
+Program {
+  type: "Program",
+  body: [
+    TSTypeAliasDeclaration {
+      type: "TSTypeAliasDeclaration",
+      declare: false,
+      id: Identifier {
+        type: "Identifier",
+        decorators: [],
+        name: "X",
+        optional: false,
+
+        range: [5, 6],
+        loc: {
+          start: { column: 5, line: 1 },
+          end: { column: 6, line: 1 },
+        },
+      },
+      typeAnnotation: TSTypeReference {
+        type: "TSTypeReference",
+        typeArguments: TSTypeParameterInstantiation {
+          type: "TSTypeParameterInstantiation",
+          params: [
+            TSFunctionType {
+              type: "TSFunctionType",
+              params: [
+                Identifier {
+                  type: "Identifier",
+                  decorators: [],
+                  name: "x",
+                  optional: false,
+                  typeAnnotation: TSTypeAnnotation {
+                    type: "TSTypeAnnotation",
+                    typeAnnotation: TSTypeReference {
+                      type: "TSTypeReference",
+                      typeName: Identifier {
+                        type: "Identifier",
+                        decorators: [],
+                        name: "T",
+                        optional: false,
+
+                        range: [27, 28],
+                        loc: {
+                          start: { column: 27, line: 1 },
+                          end: { column: 28, line: 1 },
+                        },
+                      },
+
+                      range: [27, 28],
+                      loc: {
+                        start: { column: 27, line: 1 },
+                        end: { column: 28, line: 1 },
+                      },
+                    },
+
+                    range: [25, 28],
+                    loc: {
+                      start: { column: 25, line: 1 },
+                      end: { column: 28, line: 1 },
+                    },
+                  },
+
+                  range: [24, 28],
+                  loc: {
+                    start: { column: 24, line: 1 },
+                    end: { column: 28, line: 1 },
+                  },
+                },
+              ],
+              returnType: TSTypeAnnotation {
+                type: "TSTypeAnnotation",
+                typeAnnotation: TSNumberKeyword {
+                  type: "TSNumberKeyword",
+
+                  range: [33, 39],
+                  loc: {
+                    start: { column: 33, line: 1 },
+                    end: { column: 39, line: 1 },
+                  },
+                },
+
+                range: [30, 39],
+                loc: {
+                  start: { column: 30, line: 1 },
+                  end: { column: 39, line: 1 },
+                },
+              },
+              typeParameters: TSTypeParameterDeclaration {
+                type: "TSTypeParameterDeclaration",
+                params: [
+                  TSTypeParameter {
+                    type: "TSTypeParameter",
+                    const: false,
+                    in: false,
+                    name: Identifier {
+                      type: "Identifier",
+                      decorators: [],
+                      name: "T",
+                      optional: false,
+
+                      range: [21, 22],
+                      loc: {
+                        start: { column: 21, line: 1 },
+                        end: { column: 22, line: 1 },
+                      },
+                    },
+                    out: false,
+
+                    range: [21, 22],
+                    loc: {
+                      start: { column: 21, line: 1 },
+                      end: { column: 22, line: 1 },
+                    },
+                  },
+                ],
+
+                range: [20, 23],
+                loc: {
+                  start: { column: 20, line: 1 },
+                  end: { column: 23, line: 1 },
+                },
+              },
+
+              range: [20, 39],
+              loc: {
+                start: { column: 20, line: 1 },
+                end: { column: 39, line: 1 },
+              },
+            },
+          ],
+
+          range: [19, 40],
+          loc: {
+            start: { column: 19, line: 1 },
+            end: { column: 40, line: 1 },
+          },
+        },
+        typeName: Identifier {
+          type: "Identifier",
+          decorators: [],
+          name: "ReturnType",
+          optional: false,
+
+          range: [9, 19],
+          loc: {
+            start: { column: 9, line: 1 },
+            end: { column: 19, line: 1 },
+          },
+        },
+
+        range: [9, 40],
+        loc: {
+          start: { column: 9, line: 1 },
+          end: { column: 40, line: 1 },
+        },
+      },
+
+      range: [0, 41],
+      loc: {
+        start: { column: 0, line: 1 },
+        end: { column: 41, line: 1 },
+      },
+    },
+    TSTypeAliasDeclaration {
+      type: "TSTypeAliasDeclaration",
+      declare: false,
+      id: Identifier {
+        type: "Identifier",
+        decorators: [],
+        name: "Y",
+        optional: false,
+
+        range: [66, 67],
+        loc: {
+          start: { column: 5, line: 3 },
+          end: { column: 6, line: 3 },
+        },
+      },
+      typeAnnotation: TSTypeReference {
+        type: "TSTypeReference",
+        typeArguments: TSTypeParameterInstantiation {
+          type: "TSTypeParameterInstantiation",
+          params: [
+            TSFunctionType {
+              type: "TSFunctionType",
+              params: [
+                Identifier {
+                  type: "Identifier",
+                  decorators: [],
+                  name: "x",
+                  optional: false,
+                  typeAnnotation: TSTypeAnnotation {
+                    type: "TSTypeAnnotation",
+                    typeAnnotation: TSTypeReference {
+                      type: "TSTypeReference",
+                      typeName: Identifier {
+                        type: "Identifier",
+                        decorators: [],
+                        name: "T",
+                        optional: false,
+
+                        range: [89, 90],
+                        loc: {
+                          start: { column: 28, line: 3 },
+                          end: { column: 29, line: 3 },
+                        },
+                      },
+
+                      range: [89, 90],
+                      loc: {
+                        start: { column: 28, line: 3 },
+                        end: { column: 29, line: 3 },
+                      },
+                    },
+
+                    range: [87, 90],
+                    loc: {
+                      start: { column: 26, line: 3 },
+                      end: { column: 29, line: 3 },
+                    },
+                  },
+
+                  range: [86, 90],
+                  loc: {
+                    start: { column: 25, line: 3 },
+                    end: { column: 29, line: 3 },
+                  },
+                },
+              ],
+              returnType: TSTypeAnnotation {
+                type: "TSTypeAnnotation",
+                typeAnnotation: TSNumberKeyword {
+                  type: "TSNumberKeyword",
+
+                  range: [95, 101],
+                  loc: {
+                    start: { column: 34, line: 3 },
+                    end: { column: 40, line: 3 },
+                  },
+                },
+
+                range: [92, 101],
+                loc: {
+                  start: { column: 31, line: 3 },
+                  end: { column: 40, line: 3 },
+                },
+              },
+              typeParameters: TSTypeParameterDeclaration {
+                type: "TSTypeParameterDeclaration",
+                params: [
+                  TSTypeParameter {
+                    type: "TSTypeParameter",
+                    const: false,
+                    in: false,
+                    name: Identifier {
+                      type: "Identifier",
+                      decorators: [],
+                      name: "T",
+                      optional: false,
+
+                      range: [83, 84],
+                      loc: {
+                        start: { column: 22, line: 3 },
+                        end: { column: 23, line: 3 },
+                      },
+                    },
+                    out: false,
+
+                    range: [83, 84],
+                    loc: {
+                      start: { column: 22, line: 3 },
+                      end: { column: 23, line: 3 },
+                    },
+                  },
+                ],
+
+                range: [82, 85],
+                loc: {
+                  start: { column: 21, line: 3 },
+                  end: { column: 24, line: 3 },
+                },
+              },
+
+              range: [82, 101],
+              loc: {
+                start: { column: 21, line: 3 },
+                end: { column: 40, line: 3 },
+              },
+            },
+          ],
+
+          range: [81, 102],
+          loc: {
+            start: { column: 20, line: 3 },
+            end: { column: 41, line: 3 },
+          },
+        },
+        typeName: Identifier {
+          type: "Identifier",
+          decorators: [],
+          name: "ReturnType",
+          optional: false,
+
+          range: [70, 80],
+          loc: {
+            start: { column: 9, line: 3 },
+            end: { column: 19, line: 3 },
+          },
+        },
+
+        range: [70, 102],
+        loc: {
+          start: { column: 9, line: 3 },
+          end: { column: 41, line: 3 },
+        },
+      },
+
+      range: [61, 103],
+      loc: {
+        start: { column: 0, line: 3 },
+        end: { column: 42, line: 3 },
+      },
+    },
+    TSTypeAliasDeclaration {
+      type: "TSTypeAliasDeclaration",
+      declare: false,
+      id: Identifier {
+        type: "Identifier",
+        decorators: [],
+        name: "Z",
+        optional: false,
+
+        range: [109, 110],
+        loc: {
+          start: { column: 5, line: 4 },
+          end: { column: 6, line: 4 },
+        },
+      },
+      typeAnnotation: TSTypeReference {
+        type: "TSTypeReference",
+        typeArguments: TSTypeParameterInstantiation {
+          type: "TSTypeParameterInstantiation",
+          params: [
+            TSFunctionType {
+              type: "TSFunctionType",
+              params: [
+                Identifier {
+                  type: "Identifier",
+                  decorators: [],
+                  name: "x",
+                  optional: false,
+                  typeAnnotation: TSTypeAnnotation {
+                    type: "TSTypeAnnotation",
+                    typeAnnotation: TSTypeReference {
+                      type: "TSTypeReference",
+                      typeName: Identifier {
+                        type: "Identifier",
+                        decorators: [],
+                        name: "T",
+                        optional: false,
+
+                        range: [139, 140],
+                        loc: {
+                          start: { column: 35, line: 4 },
+                          end: { column: 36, line: 4 },
+                        },
+                      },
+
+                      range: [139, 140],
+                      loc: {
+                        start: { column: 35, line: 4 },
+                        end: { column: 36, line: 4 },
+                      },
+                    },
+
+                    range: [137, 140],
+                    loc: {
+                      start: { column: 33, line: 4 },
+                      end: { column: 36, line: 4 },
+                    },
+                  },
+
+                  range: [136, 140],
+                  loc: {
+                    start: { column: 32, line: 4 },
+                    end: { column: 36, line: 4 },
+                  },
+                },
+              ],
+              returnType: TSTypeAnnotation {
+                type: "TSTypeAnnotation",
+                typeAnnotation: TSNumberKeyword {
+                  type: "TSNumberKeyword",
+
+                  range: [145, 151],
+                  loc: {
+                    start: { column: 41, line: 4 },
+                    end: { column: 47, line: 4 },
+                  },
+                },
+
+                range: [142, 151],
+                loc: {
+                  start: { column: 38, line: 4 },
+                  end: { column: 47, line: 4 },
+                },
+              },
+              typeParameters: TSTypeParameterDeclaration {
+                type: "TSTypeParameterDeclaration",
+                params: [
+                  TSTypeParameter {
+                    type: "TSTypeParameter",
+                    const: false,
+                    in: false,
+                    name: Identifier {
+                      type: "Identifier",
+                      decorators: [],
+                      name: "T",
+                      optional: false,
+
+                      range: [133, 134],
+                      loc: {
+                        start: { column: 29, line: 4 },
+                        end: { column: 30, line: 4 },
+                      },
+                    },
+                    out: false,
+
+                    range: [133, 134],
+                    loc: {
+                      start: { column: 29, line: 4 },
+                      end: { column: 30, line: 4 },
+                    },
+                  },
+                ],
+
+                range: [132, 135],
+                loc: {
+                  start: { column: 28, line: 4 },
+                  end: { column: 31, line: 4 },
+                },
+              },
+
+              range: [132, 151],
+              loc: {
+                start: { column: 28, line: 4 },
+                end: { column: 47, line: 4 },
+              },
+            },
+          ],
+
+          range: [131, 152],
+          loc: {
+            start: { column: 27, line: 4 },
+            end: { column: 48, line: 4 },
+          },
+        },
+        typeName: Identifier {
+          type: "Identifier",
+          decorators: [],
+          name: "ReturnType",
+          optional: false,
+
+          range: [113, 123],
+          loc: {
+            start: { column: 9, line: 4 },
+            end: { column: 19, line: 4 },
+          },
+        },
+
+        range: [113, 152],
+        loc: {
+          start: { column: 9, line: 4 },
+          end: { column: 48, line: 4 },
+        },
+      },
+
+      range: [104, 153],
+      loc: {
+        start: { column: 0, line: 4 },
+        end: { column: 49, line: 4 },
+      },
+    },
+  ],
+  sourceType: "script",
+
+  range: [0, 154],
+  loc: {
+    start: { column: 0, line: 1 },
+    end: { column: 0, line: 5 },
+  },
+}

--- a/packages/ast-spec/src/special/TSTypeParameterInstantiation/fixtures/type-argument-generic-function-type/snapshots/2-TSESTree-Tokens.shot
+++ b/packages/ast-spec/src/special/TSTypeParameterInstantiation/fixtures/type-argument-generic-function-type/snapshots/2-TSESTree-Tokens.shot
@@ -1,0 +1,512 @@
+[
+  Identifier {
+    type: "Identifier",
+    value: "type",
+
+    range: [0, 4],
+    loc: {
+      start: { column: 0, line: 1 },
+      end: { column: 4, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "X",
+
+    range: [5, 6],
+    loc: {
+      start: { column: 5, line: 1 },
+      end: { column: 6, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "=",
+
+    range: [7, 8],
+    loc: {
+      start: { column: 7, line: 1 },
+      end: { column: 8, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "ReturnType",
+
+    range: [9, 19],
+    loc: {
+      start: { column: 9, line: 1 },
+      end: { column: 19, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "<",
+
+    range: [19, 20],
+    loc: {
+      start: { column: 19, line: 1 },
+      end: { column: 20, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "<",
+
+    range: [20, 21],
+    loc: {
+      start: { column: 20, line: 1 },
+      end: { column: 21, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "T",
+
+    range: [21, 22],
+    loc: {
+      start: { column: 21, line: 1 },
+      end: { column: 22, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ">",
+
+    range: [22, 23],
+    loc: {
+      start: { column: 22, line: 1 },
+      end: { column: 23, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "(",
+
+    range: [23, 24],
+    loc: {
+      start: { column: 23, line: 1 },
+      end: { column: 24, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "x",
+
+    range: [24, 25],
+    loc: {
+      start: { column: 24, line: 1 },
+      end: { column: 25, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ":",
+
+    range: [25, 26],
+    loc: {
+      start: { column: 25, line: 1 },
+      end: { column: 26, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "T",
+
+    range: [27, 28],
+    loc: {
+      start: { column: 27, line: 1 },
+      end: { column: 28, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ")",
+
+    range: [28, 29],
+    loc: {
+      start: { column: 28, line: 1 },
+      end: { column: 29, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "=>",
+
+    range: [30, 32],
+    loc: {
+      start: { column: 30, line: 1 },
+      end: { column: 32, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "number",
+
+    range: [33, 39],
+    loc: {
+      start: { column: 33, line: 1 },
+      end: { column: 39, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ">",
+
+    range: [39, 40],
+    loc: {
+      start: { column: 39, line: 1 },
+      end: { column: 40, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ";",
+
+    range: [40, 41],
+    loc: {
+      start: { column: 40, line: 1 },
+      end: { column: 41, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "type",
+
+    range: [61, 65],
+    loc: {
+      start: { column: 0, line: 3 },
+      end: { column: 4, line: 3 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "Y",
+
+    range: [66, 67],
+    loc: {
+      start: { column: 5, line: 3 },
+      end: { column: 6, line: 3 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "=",
+
+    range: [68, 69],
+    loc: {
+      start: { column: 7, line: 3 },
+      end: { column: 8, line: 3 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "ReturnType",
+
+    range: [70, 80],
+    loc: {
+      start: { column: 9, line: 3 },
+      end: { column: 19, line: 3 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "<",
+
+    range: [81, 82],
+    loc: {
+      start: { column: 20, line: 3 },
+      end: { column: 21, line: 3 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "<",
+
+    range: [82, 83],
+    loc: {
+      start: { column: 21, line: 3 },
+      end: { column: 22, line: 3 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "T",
+
+    range: [83, 84],
+    loc: {
+      start: { column: 22, line: 3 },
+      end: { column: 23, line: 3 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ">",
+
+    range: [84, 85],
+    loc: {
+      start: { column: 23, line: 3 },
+      end: { column: 24, line: 3 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "(",
+
+    range: [85, 86],
+    loc: {
+      start: { column: 24, line: 3 },
+      end: { column: 25, line: 3 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "x",
+
+    range: [86, 87],
+    loc: {
+      start: { column: 25, line: 3 },
+      end: { column: 26, line: 3 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ":",
+
+    range: [87, 88],
+    loc: {
+      start: { column: 26, line: 3 },
+      end: { column: 27, line: 3 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "T",
+
+    range: [89, 90],
+    loc: {
+      start: { column: 28, line: 3 },
+      end: { column: 29, line: 3 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ")",
+
+    range: [90, 91],
+    loc: {
+      start: { column: 29, line: 3 },
+      end: { column: 30, line: 3 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "=>",
+
+    range: [92, 94],
+    loc: {
+      start: { column: 31, line: 3 },
+      end: { column: 33, line: 3 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "number",
+
+    range: [95, 101],
+    loc: {
+      start: { column: 34, line: 3 },
+      end: { column: 40, line: 3 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ">",
+
+    range: [101, 102],
+    loc: {
+      start: { column: 40, line: 3 },
+      end: { column: 41, line: 3 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ";",
+
+    range: [102, 103],
+    loc: {
+      start: { column: 41, line: 3 },
+      end: { column: 42, line: 3 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "type",
+
+    range: [104, 108],
+    loc: {
+      start: { column: 0, line: 4 },
+      end: { column: 4, line: 4 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "Z",
+
+    range: [109, 110],
+    loc: {
+      start: { column: 5, line: 4 },
+      end: { column: 6, line: 4 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "=",
+
+    range: [111, 112],
+    loc: {
+      start: { column: 7, line: 4 },
+      end: { column: 8, line: 4 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "ReturnType",
+
+    range: [113, 123],
+    loc: {
+      start: { column: 9, line: 4 },
+      end: { column: 19, line: 4 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "<",
+
+    range: [131, 132],
+    loc: {
+      start: { column: 27, line: 4 },
+      end: { column: 28, line: 4 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "<",
+
+    range: [132, 133],
+    loc: {
+      start: { column: 28, line: 4 },
+      end: { column: 29, line: 4 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "T",
+
+    range: [133, 134],
+    loc: {
+      start: { column: 29, line: 4 },
+      end: { column: 30, line: 4 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ">",
+
+    range: [134, 135],
+    loc: {
+      start: { column: 30, line: 4 },
+      end: { column: 31, line: 4 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "(",
+
+    range: [135, 136],
+    loc: {
+      start: { column: 31, line: 4 },
+      end: { column: 32, line: 4 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "x",
+
+    range: [136, 137],
+    loc: {
+      start: { column: 32, line: 4 },
+      end: { column: 33, line: 4 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ":",
+
+    range: [137, 138],
+    loc: {
+      start: { column: 33, line: 4 },
+      end: { column: 34, line: 4 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "T",
+
+    range: [139, 140],
+    loc: {
+      start: { column: 35, line: 4 },
+      end: { column: 36, line: 4 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ")",
+
+    range: [140, 141],
+    loc: {
+      start: { column: 36, line: 4 },
+      end: { column: 37, line: 4 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "=>",
+
+    range: [142, 144],
+    loc: {
+      start: { column: 38, line: 4 },
+      end: { column: 40, line: 4 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "number",
+
+    range: [145, 151],
+    loc: {
+      start: { column: 41, line: 4 },
+      end: { column: 47, line: 4 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ">",
+
+    range: [151, 152],
+    loc: {
+      start: { column: 47, line: 4 },
+      end: { column: 48, line: 4 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ";",
+
+    range: [152, 153],
+    loc: {
+      start: { column: 48, line: 4 },
+      end: { column: 49, line: 4 },
+    },
+  },
+]

--- a/packages/ast-spec/src/special/TSTypeParameterInstantiation/fixtures/type-argument-generic-function-type/snapshots/3-Babel-AST.shot
+++ b/packages/ast-spec/src/special/TSTypeParameterInstantiation/fixtures/type-argument-generic-function-type/snapshots/3-Babel-AST.shot
@@ -1,0 +1,492 @@
+Program {
+  type: "Program",
+  body: [
+    TSTypeAliasDeclaration {
+      type: "TSTypeAliasDeclaration",
+      declare: false,
+      id: Identifier {
+        type: "Identifier",
+        decorators: [],
+        name: "X",
+        optional: false,
+
+        range: [5, 6],
+        loc: {
+          start: { column: 5, line: 1 },
+          end: { column: 6, line: 1 },
+        },
+      },
+      typeAnnotation: TSTypeReference {
+        type: "TSTypeReference",
+        typeArguments: TSTypeParameterInstantiation {
+          type: "TSTypeParameterInstantiation",
+          params: [
+            TSFunctionType {
+              type: "TSFunctionType",
+              params: [
+                Identifier {
+                  type: "Identifier",
+                  decorators: [],
+                  name: "x",
+                  optional: false,
+                  typeAnnotation: TSTypeAnnotation {
+                    type: "TSTypeAnnotation",
+                    typeAnnotation: TSTypeReference {
+                      type: "TSTypeReference",
+                      typeName: Identifier {
+                        type: "Identifier",
+                        decorators: [],
+                        name: "T",
+                        optional: false,
+
+                        range: [27, 28],
+                        loc: {
+                          start: { column: 27, line: 1 },
+                          end: { column: 28, line: 1 },
+                        },
+                      },
+
+                      range: [27, 28],
+                      loc: {
+                        start: { column: 27, line: 1 },
+                        end: { column: 28, line: 1 },
+                      },
+                    },
+
+                    range: [25, 28],
+                    loc: {
+                      start: { column: 25, line: 1 },
+                      end: { column: 28, line: 1 },
+                    },
+                  },
+
+                  range: [24, 28],
+                  loc: {
+                    start: { column: 24, line: 1 },
+                    end: { column: 28, line: 1 },
+                  },
+                },
+              ],
+              returnType: TSTypeAnnotation {
+                type: "TSTypeAnnotation",
+                typeAnnotation: TSNumberKeyword {
+                  type: "TSNumberKeyword",
+
+                  range: [33, 39],
+                  loc: {
+                    start: { column: 33, line: 1 },
+                    end: { column: 39, line: 1 },
+                  },
+                },
+
+                range: [30, 39],
+                loc: {
+                  start: { column: 30, line: 1 },
+                  end: { column: 39, line: 1 },
+                },
+              },
+              typeParameters: TSTypeParameterDeclaration {
+                type: "TSTypeParameterDeclaration",
+                params: [
+                  TSTypeParameter {
+                    type: "TSTypeParameter",
+                    const: false,
+                    in: false,
+                    name: Identifier {
+                      type: "Identifier",
+                      decorators: [],
+                      name: "T",
+                      optional: false,
+
+                      range: [21, 22],
+                      loc: {
+                        start: { column: 21, line: 1 },
+                        end: { column: 22, line: 1 },
+                      },
+                    },
+                    out: false,
+
+                    range: [21, 22],
+                    loc: {
+                      start: { column: 21, line: 1 },
+                      end: { column: 22, line: 1 },
+                    },
+                  },
+                ],
+
+                range: [20, 23],
+                loc: {
+                  start: { column: 20, line: 1 },
+                  end: { column: 23, line: 1 },
+                },
+              },
+
+              range: [20, 39],
+              loc: {
+                start: { column: 20, line: 1 },
+                end: { column: 39, line: 1 },
+              },
+            },
+          ],
+
+          range: [19, 40],
+          loc: {
+            start: { column: 19, line: 1 },
+            end: { column: 40, line: 1 },
+          },
+        },
+        typeName: Identifier {
+          type: "Identifier",
+          decorators: [],
+          name: "ReturnType",
+          optional: false,
+
+          range: [9, 19],
+          loc: {
+            start: { column: 9, line: 1 },
+            end: { column: 19, line: 1 },
+          },
+        },
+
+        range: [9, 40],
+        loc: {
+          start: { column: 9, line: 1 },
+          end: { column: 40, line: 1 },
+        },
+      },
+
+      range: [0, 41],
+      loc: {
+        start: { column: 0, line: 1 },
+        end: { column: 41, line: 1 },
+      },
+    },
+    TSTypeAliasDeclaration {
+      type: "TSTypeAliasDeclaration",
+      declare: false,
+      id: Identifier {
+        type: "Identifier",
+        decorators: [],
+        name: "Y",
+        optional: false,
+
+        range: [66, 67],
+        loc: {
+          start: { column: 5, line: 3 },
+          end: { column: 6, line: 3 },
+        },
+      },
+      typeAnnotation: TSTypeReference {
+        type: "TSTypeReference",
+        typeArguments: TSTypeParameterInstantiation {
+          type: "TSTypeParameterInstantiation",
+          params: [
+            TSFunctionType {
+              type: "TSFunctionType",
+              params: [
+                Identifier {
+                  type: "Identifier",
+                  decorators: [],
+                  name: "x",
+                  optional: false,
+                  typeAnnotation: TSTypeAnnotation {
+                    type: "TSTypeAnnotation",
+                    typeAnnotation: TSTypeReference {
+                      type: "TSTypeReference",
+                      typeName: Identifier {
+                        type: "Identifier",
+                        decorators: [],
+                        name: "T",
+                        optional: false,
+
+                        range: [89, 90],
+                        loc: {
+                          start: { column: 28, line: 3 },
+                          end: { column: 29, line: 3 },
+                        },
+                      },
+
+                      range: [89, 90],
+                      loc: {
+                        start: { column: 28, line: 3 },
+                        end: { column: 29, line: 3 },
+                      },
+                    },
+
+                    range: [87, 90],
+                    loc: {
+                      start: { column: 26, line: 3 },
+                      end: { column: 29, line: 3 },
+                    },
+                  },
+
+                  range: [86, 90],
+                  loc: {
+                    start: { column: 25, line: 3 },
+                    end: { column: 29, line: 3 },
+                  },
+                },
+              ],
+              returnType: TSTypeAnnotation {
+                type: "TSTypeAnnotation",
+                typeAnnotation: TSNumberKeyword {
+                  type: "TSNumberKeyword",
+
+                  range: [95, 101],
+                  loc: {
+                    start: { column: 34, line: 3 },
+                    end: { column: 40, line: 3 },
+                  },
+                },
+
+                range: [92, 101],
+                loc: {
+                  start: { column: 31, line: 3 },
+                  end: { column: 40, line: 3 },
+                },
+              },
+              typeParameters: TSTypeParameterDeclaration {
+                type: "TSTypeParameterDeclaration",
+                params: [
+                  TSTypeParameter {
+                    type: "TSTypeParameter",
+                    const: false,
+                    in: false,
+                    name: Identifier {
+                      type: "Identifier",
+                      decorators: [],
+                      name: "T",
+                      optional: false,
+
+                      range: [83, 84],
+                      loc: {
+                        start: { column: 22, line: 3 },
+                        end: { column: 23, line: 3 },
+                      },
+                    },
+                    out: false,
+
+                    range: [83, 84],
+                    loc: {
+                      start: { column: 22, line: 3 },
+                      end: { column: 23, line: 3 },
+                    },
+                  },
+                ],
+
+                range: [82, 85],
+                loc: {
+                  start: { column: 21, line: 3 },
+                  end: { column: 24, line: 3 },
+                },
+              },
+
+              range: [82, 101],
+              loc: {
+                start: { column: 21, line: 3 },
+                end: { column: 40, line: 3 },
+              },
+            },
+          ],
+
+          range: [81, 102],
+          loc: {
+            start: { column: 20, line: 3 },
+            end: { column: 41, line: 3 },
+          },
+        },
+        typeName: Identifier {
+          type: "Identifier",
+          decorators: [],
+          name: "ReturnType",
+          optional: false,
+
+          range: [70, 80],
+          loc: {
+            start: { column: 9, line: 3 },
+            end: { column: 19, line: 3 },
+          },
+        },
+
+        range: [70, 102],
+        loc: {
+          start: { column: 9, line: 3 },
+          end: { column: 41, line: 3 },
+        },
+      },
+
+      range: [61, 103],
+      loc: {
+        start: { column: 0, line: 3 },
+        end: { column: 42, line: 3 },
+      },
+    },
+    TSTypeAliasDeclaration {
+      type: "TSTypeAliasDeclaration",
+      declare: false,
+      id: Identifier {
+        type: "Identifier",
+        decorators: [],
+        name: "Z",
+        optional: false,
+
+        range: [109, 110],
+        loc: {
+          start: { column: 5, line: 4 },
+          end: { column: 6, line: 4 },
+        },
+      },
+      typeAnnotation: TSTypeReference {
+        type: "TSTypeReference",
+        typeArguments: TSTypeParameterInstantiation {
+          type: "TSTypeParameterInstantiation",
+          params: [
+            TSFunctionType {
+              type: "TSFunctionType",
+              params: [
+                Identifier {
+                  type: "Identifier",
+                  decorators: [],
+                  name: "x",
+                  optional: false,
+                  typeAnnotation: TSTypeAnnotation {
+                    type: "TSTypeAnnotation",
+                    typeAnnotation: TSTypeReference {
+                      type: "TSTypeReference",
+                      typeName: Identifier {
+                        type: "Identifier",
+                        decorators: [],
+                        name: "T",
+                        optional: false,
+
+                        range: [139, 140],
+                        loc: {
+                          start: { column: 35, line: 4 },
+                          end: { column: 36, line: 4 },
+                        },
+                      },
+
+                      range: [139, 140],
+                      loc: {
+                        start: { column: 35, line: 4 },
+                        end: { column: 36, line: 4 },
+                      },
+                    },
+
+                    range: [137, 140],
+                    loc: {
+                      start: { column: 33, line: 4 },
+                      end: { column: 36, line: 4 },
+                    },
+                  },
+
+                  range: [136, 140],
+                  loc: {
+                    start: { column: 32, line: 4 },
+                    end: { column: 36, line: 4 },
+                  },
+                },
+              ],
+              returnType: TSTypeAnnotation {
+                type: "TSTypeAnnotation",
+                typeAnnotation: TSNumberKeyword {
+                  type: "TSNumberKeyword",
+
+                  range: [145, 151],
+                  loc: {
+                    start: { column: 41, line: 4 },
+                    end: { column: 47, line: 4 },
+                  },
+                },
+
+                range: [142, 151],
+                loc: {
+                  start: { column: 38, line: 4 },
+                  end: { column: 47, line: 4 },
+                },
+              },
+              typeParameters: TSTypeParameterDeclaration {
+                type: "TSTypeParameterDeclaration",
+                params: [
+                  TSTypeParameter {
+                    type: "TSTypeParameter",
+                    const: false,
+                    in: false,
+                    name: Identifier {
+                      type: "Identifier",
+                      decorators: [],
+                      name: "T",
+                      optional: false,
+
+                      range: [133, 134],
+                      loc: {
+                        start: { column: 29, line: 4 },
+                        end: { column: 30, line: 4 },
+                      },
+                    },
+                    out: false,
+
+                    range: [133, 134],
+                    loc: {
+                      start: { column: 29, line: 4 },
+                      end: { column: 30, line: 4 },
+                    },
+                  },
+                ],
+
+                range: [132, 135],
+                loc: {
+                  start: { column: 28, line: 4 },
+                  end: { column: 31, line: 4 },
+                },
+              },
+
+              range: [132, 151],
+              loc: {
+                start: { column: 28, line: 4 },
+                end: { column: 47, line: 4 },
+              },
+            },
+          ],
+
+          range: [131, 152],
+          loc: {
+            start: { column: 27, line: 4 },
+            end: { column: 48, line: 4 },
+          },
+        },
+        typeName: Identifier {
+          type: "Identifier",
+          decorators: [],
+          name: "ReturnType",
+          optional: false,
+
+          range: [113, 123],
+          loc: {
+            start: { column: 9, line: 4 },
+            end: { column: 19, line: 4 },
+          },
+        },
+
+        range: [113, 152],
+        loc: {
+          start: { column: 9, line: 4 },
+          end: { column: 48, line: 4 },
+        },
+      },
+
+      range: [104, 153],
+      loc: {
+        start: { column: 0, line: 4 },
+        end: { column: 49, line: 4 },
+      },
+    },
+  ],
+  sourceType: "script",
+
+  range: [0, 154],
+  loc: {
+    start: { column: 0, line: 1 },
+    end: { column: 0, line: 5 },
+  },
+}

--- a/packages/ast-spec/src/special/TSTypeParameterInstantiation/fixtures/type-argument-generic-function-type/snapshots/4-Babel-Tokens.shot
+++ b/packages/ast-spec/src/special/TSTypeParameterInstantiation/fixtures/type-argument-generic-function-type/snapshots/4-Babel-Tokens.shot
@@ -1,0 +1,512 @@
+[
+  Identifier {
+    type: "Identifier",
+    value: "type",
+
+    range: [0, 4],
+    loc: {
+      start: { column: 0, line: 1 },
+      end: { column: 4, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "X",
+
+    range: [5, 6],
+    loc: {
+      start: { column: 5, line: 1 },
+      end: { column: 6, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "=",
+
+    range: [7, 8],
+    loc: {
+      start: { column: 7, line: 1 },
+      end: { column: 8, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "ReturnType",
+
+    range: [9, 19],
+    loc: {
+      start: { column: 9, line: 1 },
+      end: { column: 19, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "<",
+
+    range: [19, 20],
+    loc: {
+      start: { column: 19, line: 1 },
+      end: { column: 20, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "<",
+
+    range: [20, 21],
+    loc: {
+      start: { column: 20, line: 1 },
+      end: { column: 21, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "T",
+
+    range: [21, 22],
+    loc: {
+      start: { column: 21, line: 1 },
+      end: { column: 22, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ">",
+
+    range: [22, 23],
+    loc: {
+      start: { column: 22, line: 1 },
+      end: { column: 23, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "(",
+
+    range: [23, 24],
+    loc: {
+      start: { column: 23, line: 1 },
+      end: { column: 24, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "x",
+
+    range: [24, 25],
+    loc: {
+      start: { column: 24, line: 1 },
+      end: { column: 25, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ":",
+
+    range: [25, 26],
+    loc: {
+      start: { column: 25, line: 1 },
+      end: { column: 26, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "T",
+
+    range: [27, 28],
+    loc: {
+      start: { column: 27, line: 1 },
+      end: { column: 28, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ")",
+
+    range: [28, 29],
+    loc: {
+      start: { column: 28, line: 1 },
+      end: { column: 29, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "=>",
+
+    range: [30, 32],
+    loc: {
+      start: { column: 30, line: 1 },
+      end: { column: 32, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "number",
+
+    range: [33, 39],
+    loc: {
+      start: { column: 33, line: 1 },
+      end: { column: 39, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ">",
+
+    range: [39, 40],
+    loc: {
+      start: { column: 39, line: 1 },
+      end: { column: 40, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ";",
+
+    range: [40, 41],
+    loc: {
+      start: { column: 40, line: 1 },
+      end: { column: 41, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "type",
+
+    range: [61, 65],
+    loc: {
+      start: { column: 0, line: 3 },
+      end: { column: 4, line: 3 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "Y",
+
+    range: [66, 67],
+    loc: {
+      start: { column: 5, line: 3 },
+      end: { column: 6, line: 3 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "=",
+
+    range: [68, 69],
+    loc: {
+      start: { column: 7, line: 3 },
+      end: { column: 8, line: 3 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "ReturnType",
+
+    range: [70, 80],
+    loc: {
+      start: { column: 9, line: 3 },
+      end: { column: 19, line: 3 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "<",
+
+    range: [81, 82],
+    loc: {
+      start: { column: 20, line: 3 },
+      end: { column: 21, line: 3 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "<",
+
+    range: [82, 83],
+    loc: {
+      start: { column: 21, line: 3 },
+      end: { column: 22, line: 3 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "T",
+
+    range: [83, 84],
+    loc: {
+      start: { column: 22, line: 3 },
+      end: { column: 23, line: 3 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ">",
+
+    range: [84, 85],
+    loc: {
+      start: { column: 23, line: 3 },
+      end: { column: 24, line: 3 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "(",
+
+    range: [85, 86],
+    loc: {
+      start: { column: 24, line: 3 },
+      end: { column: 25, line: 3 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "x",
+
+    range: [86, 87],
+    loc: {
+      start: { column: 25, line: 3 },
+      end: { column: 26, line: 3 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ":",
+
+    range: [87, 88],
+    loc: {
+      start: { column: 26, line: 3 },
+      end: { column: 27, line: 3 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "T",
+
+    range: [89, 90],
+    loc: {
+      start: { column: 28, line: 3 },
+      end: { column: 29, line: 3 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ")",
+
+    range: [90, 91],
+    loc: {
+      start: { column: 29, line: 3 },
+      end: { column: 30, line: 3 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "=>",
+
+    range: [92, 94],
+    loc: {
+      start: { column: 31, line: 3 },
+      end: { column: 33, line: 3 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "number",
+
+    range: [95, 101],
+    loc: {
+      start: { column: 34, line: 3 },
+      end: { column: 40, line: 3 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ">",
+
+    range: [101, 102],
+    loc: {
+      start: { column: 40, line: 3 },
+      end: { column: 41, line: 3 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ";",
+
+    range: [102, 103],
+    loc: {
+      start: { column: 41, line: 3 },
+      end: { column: 42, line: 3 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "type",
+
+    range: [104, 108],
+    loc: {
+      start: { column: 0, line: 4 },
+      end: { column: 4, line: 4 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "Z",
+
+    range: [109, 110],
+    loc: {
+      start: { column: 5, line: 4 },
+      end: { column: 6, line: 4 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "=",
+
+    range: [111, 112],
+    loc: {
+      start: { column: 7, line: 4 },
+      end: { column: 8, line: 4 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "ReturnType",
+
+    range: [113, 123],
+    loc: {
+      start: { column: 9, line: 4 },
+      end: { column: 19, line: 4 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "<",
+
+    range: [131, 132],
+    loc: {
+      start: { column: 27, line: 4 },
+      end: { column: 28, line: 4 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "<",
+
+    range: [132, 133],
+    loc: {
+      start: { column: 28, line: 4 },
+      end: { column: 29, line: 4 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "T",
+
+    range: [133, 134],
+    loc: {
+      start: { column: 29, line: 4 },
+      end: { column: 30, line: 4 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ">",
+
+    range: [134, 135],
+    loc: {
+      start: { column: 30, line: 4 },
+      end: { column: 31, line: 4 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "(",
+
+    range: [135, 136],
+    loc: {
+      start: { column: 31, line: 4 },
+      end: { column: 32, line: 4 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "x",
+
+    range: [136, 137],
+    loc: {
+      start: { column: 32, line: 4 },
+      end: { column: 33, line: 4 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ":",
+
+    range: [137, 138],
+    loc: {
+      start: { column: 33, line: 4 },
+      end: { column: 34, line: 4 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "T",
+
+    range: [139, 140],
+    loc: {
+      start: { column: 35, line: 4 },
+      end: { column: 36, line: 4 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ")",
+
+    range: [140, 141],
+    loc: {
+      start: { column: 36, line: 4 },
+      end: { column: 37, line: 4 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "=>",
+
+    range: [142, 144],
+    loc: {
+      start: { column: 38, line: 4 },
+      end: { column: 40, line: 4 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "number",
+
+    range: [145, 151],
+    loc: {
+      start: { column: 41, line: 4 },
+      end: { column: 47, line: 4 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ">",
+
+    range: [151, 152],
+    loc: {
+      start: { column: 47, line: 4 },
+      end: { column: 48, line: 4 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ";",
+
+    range: [152, 153],
+    loc: {
+      start: { column: 48, line: 4 },
+      end: { column: 49, line: 4 },
+    },
+  },
+]

--- a/packages/typescript-estree/src/node-utils.ts
+++ b/packages/typescript-estree/src/node-utils.ts
@@ -623,14 +623,70 @@ export function convertTokens(ast: ts.SourceFile): TSESTree.Token[] {
       return;
     }
 
-    if (isToken(node) && node.kind !== SyntaxKind.EndOfFileToken) {
-      result.push(convertToken(node, ast));
+    const { kind } = node;
+    if (isToken(node) && kind !== SyntaxKind.EndOfFileToken) {
+      const token = convertToken(node, ast);
+
+      // TypeScript drops first half of a `<<` in some cases.
+      // Gating on `kind` (a cheap check) keeps the rest of the check,
+      // which has to look at the text, off the hot path.
+      if (kind === SyntaxKind.LessThanToken) {
+        addMissingLessThanToken(result, token, ast);
+      }
+
+      result.push(token);
     } else {
       node.getChildren(ast).forEach(walk);
     }
   }
   walk(ast);
   return result;
+}
+
+/**
+ * TypeScript recovers the tokens its parser did not keep as children of a node
+ * (`<` and `>` of a type argument list, for instance) by re-scanning the source
+ * text in the gaps between the children it did keep, and discards any token
+ * that runs past the end of the gap being filled.
+ *
+ * Its scanner produces `<<` as a single token, which the parser splits back
+ * apart when the second `<` opens a type parameter list, as in
+ * `ReturnType<<T>(x: T) => number>`. The re-scan is not aware of that split,
+ * so the `<<` it scans overruns the gap left by the first `<`, and that token
+ * is dropped from `getChildren()` entirely.
+ *
+ * Text skipped in front of a token can otherwise only be trivia, and no trivia
+ * can end in a `<`: line comments, shebangs and conflict markers all run to the
+ * end of a line, and block comments all end in `*` + `/`. So a `<` sitting
+ * directly in front of a token, with anything at all skipped before it,
+ * is unambiguously a token TypeScript lost.
+ *
+ * Only ever called for a `<` token — see the caller.
+ */
+function addMissingLessThanToken(
+  result: TSESTree.Token[],
+  token: TSESTree.Token,
+  ast: ts.SourceFile,
+): void {
+  if (result.length === 0) {
+    return;
+  }
+
+  const currentTokenStart = token.range[0];
+  const previousTokenEnd = result[result.length - 1].range[1];
+
+  if (
+    currentTokenStart > previousTokenEnd &&
+    ast.text[currentTokenStart - 1] === '<'
+  ) {
+    const range: TSESTree.Range = [currentTokenStart - 1, currentTokenStart];
+    result.push({
+      type: AST_TOKEN_TYPES.Punctuator,
+      loc: getLocFor(range, ast),
+      range,
+      value: '<',
+    });
+  }
 }
 
 export class TSError extends Error {

--- a/packages/typescript-estree/tests/lib/node-utils.test.ts
+++ b/packages/typescript-estree/tests/lib/node-utils.test.ts
@@ -1,4 +1,163 @@
-import { unescapeStringLiteralText } from '../../src/node-utils';
+import * as ts from 'typescript';
+
+import { convertTokens, unescapeStringLiteralText } from '../../src/node-utils';
+
+describe(convertTokens, () => {
+  function getTokens(code: string): string[] {
+    const sourceFile = ts.createSourceFile(
+      'test.ts',
+      code,
+      { languageVersion: ts.ScriptTarget.ESNext },
+      /* setParentNodes */ true,
+    );
+
+    return convertTokens(sourceFile).map(
+      token =>
+        `${token.type} ${JSON.stringify(token.value)} [${token.range.join(', ')}]`,
+    );
+  }
+
+  it('includes the `<` opening a type argument list that is followed by another `<`', () => {
+    expect(getTokens('type Bar = ReturnType<<T>(x: T) => number>;'))
+      .toMatchInlineSnapshot(`
+        [
+          "Identifier "type" [0, 4]",
+          "Identifier "Bar" [5, 8]",
+          "Punctuator "=" [9, 10]",
+          "Identifier "ReturnType" [11, 21]",
+          "Punctuator "<" [21, 22]",
+          "Punctuator "<" [22, 23]",
+          "Identifier "T" [23, 24]",
+          "Punctuator ">" [24, 25]",
+          "Punctuator "(" [25, 26]",
+          "Identifier "x" [26, 27]",
+          "Punctuator ":" [27, 28]",
+          "Identifier "T" [29, 30]",
+          "Punctuator ")" [30, 31]",
+          "Punctuator "=>" [32, 34]",
+          "Identifier "number" [35, 41]",
+          "Punctuator ">" [41, 42]",
+          "Punctuator ";" [42, 43]",
+        ]
+      `);
+  });
+
+  it('includes the `<` opening the type arguments of a call expression that is followed by another `<`', () => {
+    expect(getTokens('const bar = foo<<T>(x: T) => number>();'))
+      .toMatchInlineSnapshot(`
+        [
+          "Keyword "const" [0, 5]",
+          "Identifier "bar" [6, 9]",
+          "Punctuator "=" [10, 11]",
+          "Identifier "foo" [12, 15]",
+          "Punctuator "<" [15, 16]",
+          "Punctuator "<" [16, 17]",
+          "Identifier "T" [17, 18]",
+          "Punctuator ">" [18, 19]",
+          "Punctuator "(" [19, 20]",
+          "Identifier "x" [20, 21]",
+          "Punctuator ":" [21, 22]",
+          "Identifier "T" [23, 24]",
+          "Punctuator ")" [24, 25]",
+          "Punctuator "=>" [26, 28]",
+          "Identifier "number" [29, 35]",
+          "Punctuator ">" [35, 36]",
+          "Punctuator "(" [36, 37]",
+          "Punctuator ")" [37, 38]",
+          "Punctuator ";" [38, 39]",
+        ]
+      `);
+  });
+
+  it('includes the `<` opening a type argument list that is separated from the identifier by a space', () => {
+    expect(getTokens('type Bar = ReturnType <<T>(x: T) => number>;'))
+      .toMatchInlineSnapshot(`
+        [
+          "Identifier "type" [0, 4]",
+          "Identifier "Bar" [5, 8]",
+          "Punctuator "=" [9, 10]",
+          "Identifier "ReturnType" [11, 21]",
+          "Punctuator "<" [22, 23]",
+          "Punctuator "<" [23, 24]",
+          "Identifier "T" [24, 25]",
+          "Punctuator ">" [25, 26]",
+          "Punctuator "(" [26, 27]",
+          "Identifier "x" [27, 28]",
+          "Punctuator ":" [28, 29]",
+          "Identifier "T" [30, 31]",
+          "Punctuator ")" [31, 32]",
+          "Punctuator "=>" [33, 35]",
+          "Identifier "number" [36, 42]",
+          "Punctuator ">" [42, 43]",
+          "Punctuator ";" [43, 44]",
+        ]
+      `);
+  });
+
+  it('includes the `<` opening a type argument list that is separated from the identifier by a comment', () => {
+    expect(getTokens('type Bar = ReturnType /* c */ <<T>(x: T) => number>;'))
+      .toMatchInlineSnapshot(`
+        [
+          "Identifier "type" [0, 4]",
+          "Identifier "Bar" [5, 8]",
+          "Punctuator "=" [9, 10]",
+          "Identifier "ReturnType" [11, 21]",
+          "Punctuator "<" [30, 31]",
+          "Punctuator "<" [31, 32]",
+          "Identifier "T" [32, 33]",
+          "Punctuator ">" [33, 34]",
+          "Punctuator "(" [34, 35]",
+          "Identifier "x" [35, 36]",
+          "Punctuator ":" [36, 37]",
+          "Identifier "T" [38, 39]",
+          "Punctuator ")" [39, 40]",
+          "Punctuator "=>" [41, 43]",
+          "Identifier "number" [44, 50]",
+          "Punctuator ">" [50, 51]",
+          "Punctuator ";" [51, 52]",
+        ]
+      `);
+  });
+
+  it('does not duplicate the `<` opening a type argument list that is separated from the next `<` by a space', () => {
+    expect(getTokens('type Bar = ReturnType< <T>(x: T) => number>;'))
+      .toMatchInlineSnapshot(`
+        [
+          "Identifier "type" [0, 4]",
+          "Identifier "Bar" [5, 8]",
+          "Punctuator "=" [9, 10]",
+          "Identifier "ReturnType" [11, 21]",
+          "Punctuator "<" [21, 22]",
+          "Punctuator "<" [23, 24]",
+          "Identifier "T" [24, 25]",
+          "Punctuator ">" [25, 26]",
+          "Punctuator "(" [26, 27]",
+          "Identifier "x" [27, 28]",
+          "Punctuator ":" [28, 29]",
+          "Identifier "T" [30, 31]",
+          "Punctuator ")" [31, 32]",
+          "Punctuator "=>" [33, 35]",
+          "Identifier "number" [36, 42]",
+          "Punctuator ">" [42, 43]",
+          "Punctuator ";" [43, 44]",
+        ]
+      `);
+  });
+
+  it('keeps a `<<` operator as a single token', () => {
+    expect(getTokens('const bar = 1 << 2;')).toMatchInlineSnapshot(`
+      [
+        "Keyword "const" [0, 5]",
+        "Identifier "bar" [6, 9]",
+        "Punctuator "=" [10, 11]",
+        "Numeric "1" [12, 13]",
+        "Punctuator "<<" [14, 16]",
+        "Numeric "2" [17, 18]",
+        "Punctuator ";" [18, 19]",
+      ]
+    `);
+  });
+});
 
 describe(unescapeStringLiteralText, () => {
   it('should not modify content', () => {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #12820
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

Fixes #12820.

### Root cause upstream

The root cause is in TypeScript, in `getChildren()`'s token recovery (`addSyntheticNodes` in `src/services/services.ts`). The scanner emits `<<` as one token, only the parser splits it back into two, and the recovery re-scan discards any token that overruns the gap it is filling. So the first `<` disappears.

### The fix

`convertTokens` now re-inserts the token when it detects the hole:

```ts
if (
  currentTokenStart > previousTokenEnd &&
  ast.text[currentTokenStart - 1] === '<'
) {
  const range: TSESTree.Range = [currentTokenStart - 1, currentTokenStart];
  result.push({
    type: AST_TOKEN_TYPES.Punctuator,
    loc: getLocFor(range, ast),
    range,
    value: '<',
  });
}
```

The condition cannot produce a false positive, because **no trivia can end in a `<`**:

- Line comments, shebangs and conflict markers all run to the end of a line, so the character before the next token is a line break or whitespace.
- Block comments all end in `*/`.
- Whitespace is not `<`.

So a `<` sitting directly in front of a token must be a `<` token TypeScript lost.

### Performance

`convertTokens` is a hot path, so the added work is gated on the token kind. The dropped token is always the first half of a `<<`, so a `<` is the only token it can ever precede:

```ts
const { kind } = node;
if (isToken(node) && kind !== SyntaxKind.EndOfFileToken) {
  const token = convertToken(node, ast);

  if (kind === SyntaxKind.LessThanToken) {
    addMissingLessThanToken(result, token, ast);
  }

  result.push(token);
}
```

`LessThanToken` is **0.33%** of tokens (792 of 239,103 across `packages/eslint-plugin/src` and `packages/typescript-estree/src`), so the text-inspecting part of the check runs extremely rarely. Every other token pays one integer comparison against an already-loaded `kind`.

Measured on `convertTokens` in isolation - 275 files, 236,290 tokens per pass, 14 interleaved rounds per variant, min and median of per-round minima:

| variant                          | min          | median       | vs baseline       |
| -------------------------------- | ------------ | ------------ | ----------------- |
| baseline (no fix)                | 64.58 ms     | 65.34 ms     | -                 |
| **fix (this PR)**                | **65.66 ms** | **66.20 ms** | **+1.7% / +1.3%** |

End to end - `parse(code, { tokens: true })` over the same corpus - the difference is below the noise floor (238.1 ms baseline vs 238.1 ms fixed across repeats).