### PR TITLE
fix(eslint-plugin): [no-useless-default-assignment] convert the fixer to a suggestion fixer

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-useless-default-assignment.mdx
+++ b/packages/eslint-plugin/docs/rules/no-useless-default-assignment.mdx
@@ -63,4 +63,4 @@ Without `strictNullChecks`, TypeScript essentially erases `undefined` and `null`
 If you use default values defensively against runtime values that bypass type checking, or for documentation purposes, you may want to disable this rule.
 
 In a few niche situations (e.g. [express.js error handler functions](https://expressjs.com/en/guide/error-handling.html)), the runtime [`.length`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/length) of a function may be important to you.
-In these rare cases, you may need to disable the fixes produced by this rule, which can affect function's `.length` value.
+In these rare cases, take care not to apply this rule's suggestions, as removing a default value can change a function's `.length` value.

--- a/packages/eslint-plugin/src/rules/no-useless-default-assignment.ts
+++ b/packages/eslint-plugin/src/rules/no-useless-default-assignment.ts
@@ -19,8 +19,10 @@ import {
 type MessageId =
   | 'noStrictNullCheck'
   | 'preferOptionalSyntax'
+  | 'removeDefaultAssignment'
   | 'uselessDefaultAssignment'
-  | 'uselessUndefined';
+  | 'uselessUndefined'
+  | 'useOptionalSyntax';
 
 type Options = [
   {
@@ -37,16 +39,18 @@ export default createRule<Options, MessageId>({
       recommended: 'strict',
       requiresTypeChecking: true,
     },
-    fixable: 'code',
+    hasSuggestions: true,
     messages: {
       noStrictNullCheck:
         'This rule requires the `strictNullChecks` compiler option to be turned on to function correctly.',
       preferOptionalSyntax:
-        'Using `= undefined` to make a parameter optional adds unnecessary runtime logic. Use the `?` optional syntax instead.',
+        'Using `= undefined` to make a parameter optional adds unnecessary runtime logic.',
+      removeDefaultAssignment: 'Remove the default value.',
       uselessDefaultAssignment:
         'Default value is useless because the {{ type }} is not optional.',
       uselessUndefined:
         'Default value is useless because it is undefined. Optional {{ type }}s are already undefined by default.',
+      useOptionalSyntax: 'Use the `?` optional syntax instead.',
     },
     schema: [
       {
@@ -357,7 +361,7 @@ export default createRule<Options, MessageId>({
         node: node.right,
         messageId: 'uselessDefaultAssignment',
         data: { type },
-        fix: fixer => removeDefault(fixer, node),
+        suggest: [removeDefaultSuggestion(node)],
       });
     }
 
@@ -369,7 +373,7 @@ export default createRule<Options, MessageId>({
         node: node.right,
         messageId: 'uselessUndefined',
         data: { type },
-        fix: fixer => removeDefault(fixer, node),
+        suggest: [removeDefaultSuggestion(node)],
       });
     }
 
@@ -379,6 +383,15 @@ export default createRule<Options, MessageId>({
       context.report({
         node: node.right,
         messageId: 'preferOptionalSyntax',
+        suggest: [useOptionalSyntaxSuggestion(node)],
+      });
+    }
+
+    function useOptionalSyntaxSuggestion(
+      node: TSESTree.AssignmentPattern,
+    ): TSESLint.SuggestionReportDescriptor<MessageId> {
+      return {
+        messageId: 'useOptionalSyntax',
         *fix(fixer) {
           yield removeDefault(fixer, node);
 
@@ -390,7 +403,16 @@ export default createRule<Options, MessageId>({
             );
           }
         },
-      });
+      };
+    }
+
+    function removeDefaultSuggestion(
+      node: TSESTree.AssignmentPattern,
+    ): TSESLint.SuggestionReportDescriptor<MessageId> {
+      return {
+        messageId: 'removeDefaultAssignment',
+        fix: fixer => removeDefault(fixer, node),
+      };
     }
 
     function removeDefault(

--- a/packages/eslint-plugin/tests/rules/no-useless-default-assignment.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-useless-default-assignment.test.ts
@@ -366,13 +366,19 @@ function Bar({ foo = '' }: { foo: string }) {
           endLine: 2,
           line: 2,
           messageId: 'uselessDefaultAssignment',
-        },
-      ],
-      output: `
+          suggestions: [
+            {
+              messageId: 'removeDefaultAssignment',
+              output: `
 function Bar({ foo }: { foo: string }) {
   return foo;
 }
       `,
+            },
+          ],
+        },
+      ],
+      output: null,
     },
     {
       code: `
@@ -390,15 +396,21 @@ class C {
           endLine: 3,
           line: 3,
           messageId: 'uselessDefaultAssignment',
-        },
-      ],
-      output: `
+          suggestions: [
+            {
+              messageId: 'removeDefaultAssignment',
+              output: `
 class C {
   public method({ foo }: { foo: string }) {
     return foo;
   }
 }
       `,
+            },
+          ],
+        },
+      ],
+      output: null,
     },
     {
       code: `
@@ -412,11 +424,17 @@ const { 'literal-key': literalKey = 'default' } = { 'literal-key': 'value' };
           endLine: 2,
           line: 2,
           messageId: 'uselessDefaultAssignment',
-        },
-      ],
-      output: `
+          suggestions: [
+            {
+              messageId: 'removeDefaultAssignment',
+              output: `
 const { 'literal-key': literalKey } = { 'literal-key': 'value' };
       `,
+            },
+          ],
+        },
+      ],
+      output: null,
     },
     {
       code: `
@@ -430,11 +448,17 @@ const { 'literal-key': literalKey } = { 'literal-key': 'value' };
           endLine: 2,
           line: 2,
           messageId: 'uselessDefaultAssignment',
-        },
-      ],
-      output: `
+          suggestions: [
+            {
+              messageId: 'removeDefaultAssignment',
+              output: `
 [1, 2, 3].map((a) => a + 1);
       `,
+            },
+          ],
+        },
+      ],
+      output: null,
     },
     {
       code: `
@@ -452,15 +476,21 @@ function getValue({ value = '' }: { value: string } = {}): string | undefined {
           endLine: 4,
           line: 4,
           messageId: 'uselessDefaultAssignment',
-        },
-      ],
-      output: `
+          suggestions: [
+            {
+              messageId: 'removeDefaultAssignment',
+              output: `
 function getValue(): undefined;
 function getValue(box: { value: string }): string;
 function getValue({ value }: { value: string } = {}): string | undefined {
   return value;
 }
       `,
+            },
+          ],
+        },
+      ],
+      output: null,
     },
     {
       code: `
@@ -476,13 +506,19 @@ function getValue([value = '']: [string]) {
           endLine: 2,
           line: 2,
           messageId: 'uselessDefaultAssignment',
-        },
-      ],
-      output: `
+          suggestions: [
+            {
+              messageId: 'removeDefaultAssignment',
+              output: `
 function getValue([value]: [string]) {
   return value;
 }
       `,
+            },
+          ],
+        },
+      ],
+      output: null,
     },
     {
       code: `
@@ -500,15 +536,21 @@ const {
           endLine: 5,
           line: 5,
           messageId: 'uselessDefaultAssignment',
-        },
-      ],
-      output: `
+          suggestions: [
+            {
+              messageId: 'removeDefaultAssignment',
+              output: `
 declare const x: { hello: { world: string } };
 
 const {
   hello: { world },
 } = x;
       `,
+            },
+          ],
+        },
+      ],
+      output: null,
     },
     {
       code: `
@@ -526,15 +568,21 @@ const {
           endLine: 5,
           line: 5,
           messageId: 'uselessDefaultAssignment',
-        },
-      ],
-      output: `
+          suggestions: [
+            {
+              messageId: 'removeDefaultAssignment',
+              output: `
 declare const x: { hello: Array<{ world: string }> };
 
 const {
   hello: [{ world }],
 } = x;
       `,
+            },
+          ],
+        },
+      ],
+      output: null,
     },
     {
       code: `
@@ -554,9 +602,10 @@ const h: B = {
           endLine: 7,
           line: 7,
           messageId: 'uselessDefaultAssignment',
-        },
-      ],
-      output: `
+          suggestions: [
+            {
+              messageId: 'removeDefaultAssignment',
+              output: `
 interface B {
   foo: (b: boolean | string) => void;
 }
@@ -565,6 +614,11 @@ const h: B = {
   foo: (b) => {},
 };
       `,
+            },
+          ],
+        },
+      ],
+      output: null,
     },
     {
       code: `
@@ -578,11 +632,17 @@ function foo(a = undefined) {}
           endLine: 2,
           line: 2,
           messageId: 'uselessUndefined',
-        },
-      ],
-      output: `
+          suggestions: [
+            {
+              messageId: 'removeDefaultAssignment',
+              output: `
 function foo(a) {}
       `,
+            },
+          ],
+        },
+      ],
+      output: null,
     },
     {
       code: `
@@ -596,11 +656,17 @@ const { a = undefined } = {};
           endLine: 2,
           line: 2,
           messageId: 'uselessUndefined',
-        },
-      ],
-      output: `
+          suggestions: [
+            {
+              messageId: 'removeDefaultAssignment',
+              output: `
 const { a } = {};
       `,
+            },
+          ],
+        },
+      ],
+      output: null,
     },
     {
       code: `
@@ -614,11 +680,17 @@ const [a = undefined] = [];
           endLine: 2,
           line: 2,
           messageId: 'uselessUndefined',
-        },
-      ],
-      output: `
+          suggestions: [
+            {
+              messageId: 'removeDefaultAssignment',
+              output: `
 const [a] = [];
       `,
+            },
+          ],
+        },
+      ],
+      output: null,
     },
     {
       code: `
@@ -632,11 +704,17 @@ function foo({ a = undefined }) {}
           endLine: 2,
           line: 2,
           messageId: 'uselessUndefined',
-        },
-      ],
-      output: `
+          suggestions: [
+            {
+              messageId: 'removeDefaultAssignment',
+              output: `
 function foo({ a }) {}
       `,
+            },
+          ],
+        },
+      ],
+      output: null,
     },
     // https://github.com/typescript-eslint/typescript-eslint/issues/11847
     {
@@ -652,13 +730,19 @@ function myFunction(p1: string, p2: number | undefined = undefined) {
           endLine: 2,
           line: 2,
           messageId: 'preferOptionalSyntax',
-        },
-      ],
-      output: `
+          suggestions: [
+            {
+              messageId: 'useOptionalSyntax',
+              output: `
 function myFunction(p1: string, p2?: number | undefined) {
   console.log(p1, p2);
 }
       `,
+            },
+          ],
+        },
+      ],
+      output: null,
     },
     {
       code: `
@@ -674,14 +758,20 @@ function f(
           endLine: 4,
           line: 4,
           messageId: 'preferOptionalSyntax',
-        },
-      ],
-      output: `
+          suggestions: [
+            {
+              messageId: 'useOptionalSyntax',
+              output: `
 type SomeType = number | undefined;
 function f(
   /* comment */ x? /* comment 2 */ : /* comment 3 */ SomeType,
 ) {}
       `,
+            },
+          ],
+        },
+      ],
+      output: null,
     },
     // noStrictNullCheck tests
     {
@@ -705,6 +795,16 @@ function Bar({ foo = '' }: { foo: string }) {
           endLine: 2,
           line: 2,
           messageId: 'uselessDefaultAssignment',
+          suggestions: [
+            {
+              messageId: 'removeDefaultAssignment',
+              output: `
+function Bar({ foo }: { foo: string }) {
+  return foo;
+}
+      `,
+            },
+          ],
         },
       ],
       languageOptions: {
@@ -712,11 +812,7 @@ function Bar({ foo = '' }: { foo: string }) {
           tsconfigRootDir: path.join(rootDir, 'unstrict'),
         },
       },
-      output: `
-function Bar({ foo }: { foo: string }) {
-  return foo;
-}
-      `,
+      output: null,
     },
     {
       code: `
@@ -737,6 +833,14 @@ function foo(a = undefined) {}
           endLine: 2,
           line: 2,
           messageId: 'uselessUndefined',
+          suggestions: [
+            {
+              messageId: 'removeDefaultAssignment',
+              output: `
+function foo(a) {}
+      `,
+            },
+          ],
         },
       ],
       languageOptions: {
@@ -744,9 +848,7 @@ function foo(a = undefined) {}
           tsconfigRootDir: path.join(rootDir, 'unstrict'),
         },
       },
-      output: `
-function foo(a) {}
-      `,
+      output: null,
     },
     {
       code: `
@@ -762,6 +864,16 @@ function Bar({ foo = '' }: { foo: string }) {
           endLine: 2,
           line: 2,
           messageId: 'uselessDefaultAssignment',
+          suggestions: [
+            {
+              messageId: 'removeDefaultAssignment',
+              output: `
+function Bar({ foo }: { foo: string }) {
+  return foo;
+}
+      `,
+            },
+          ],
         },
       ],
       languageOptions: {
@@ -774,11 +886,7 @@ function Bar({ foo = '' }: { foo: string }) {
           allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing: true,
         },
       ],
-      output: `
-function Bar({ foo }: { foo: string }) {
-  return foo;
-}
-      `,
+      output: null,
     },
     // https://github.com/typescript-eslint/typescript-eslint/issues/11980
     {
@@ -792,11 +900,17 @@ const { a = 'baz' } = Math.random() < 0.5 ? { a: 'foo' } : { a: 'bar' };
           endLine: 2,
           line: 2,
           messageId: 'uselessDefaultAssignment',
-        },
-      ],
-      output: `
+          suggestions: [
+            {
+              messageId: 'removeDefaultAssignment',
+              output: `
 const { a } = Math.random() < 0.5 ? { a: 'foo' } : { a: 'bar' };
       `,
+            },
+          ],
+        },
+      ],
+      output: null,
     },
     {
       code: `
@@ -814,9 +928,10 @@ const { a = 'baz' } =
           endLine: 2,
           line: 2,
           messageId: 'uselessDefaultAssignment',
-        },
-      ],
-      output: `
+          suggestions: [
+            {
+              messageId: 'removeDefaultAssignment',
+              output: `
 const { a } =
   Math.random() < 0.5
     ? { a: 'foo' }
@@ -824,6 +939,11 @@ const { a } =
       ? { a: 'bar' }
       : { a: 'qux' };
       `,
+            },
+          ],
+        },
+      ],
+      output: null,
     },
     {
       code: `
@@ -836,11 +956,17 @@ const { a = 'baz' } = cond ? { ['a']: 'foo' } : { ['a']: 'bar' };
           endLine: 2,
           line: 2,
           messageId: 'uselessDefaultAssignment',
-        },
-      ],
-      output: `
+          suggestions: [
+            {
+              messageId: 'removeDefaultAssignment',
+              output: `
 const { a } = cond ? { ['a']: 'foo' } : { ['a']: 'bar' };
       `,
+            },
+          ],
+        },
+      ],
+      output: null,
     },
     {
       code: `
@@ -853,11 +979,17 @@ const { a = 'baz' } = cond ? { a() {} } : { a: 'bar' };
           endLine: 2,
           line: 2,
           messageId: 'uselessDefaultAssignment',
-        },
-      ],
-      output: `
+          suggestions: [
+            {
+              messageId: 'removeDefaultAssignment',
+              output: `
 const { a } = cond ? { a() {} } : { a: 'bar' };
       `,
+            },
+          ],
+        },
+      ],
+      output: null,
     },
     {
       code: `
@@ -870,11 +1002,17 @@ const { a = 'b' } = Math.random() < 0.5 ? { [\`a\`]: 'a' } : { a: 'b' };
           endLine: 2,
           line: 2,
           messageId: 'uselessDefaultAssignment',
-        },
-      ],
-      output: `
+          suggestions: [
+            {
+              messageId: 'removeDefaultAssignment',
+              output: `
 const { a } = Math.random() < 0.5 ? { [\`a\`]: 'a' } : { a: 'b' };
       `,
+            },
+          ],
+        },
+      ],
+      output: null,
     },
   ],
 });


### PR DESCRIPTION

<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #12822 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview


Swaps `meta.fixable` for `meta.hasSuggestions` and moves all three reports onto `suggest`. Removing a default value deletes code that can matter at runtime, so it shouldn't happen under `--fix`

I did `uselessUndefined` and `preferOptionalSyntax` too, not just `uselessDefaultAssignment`. All three end up deleting the same ` = ...`, and having `--fix` silently handle some of them but not others seemed worse than not fixing at all. Happy to narrow it down to `uselessDefaultAssignment` if you'd rather keep the other two auto-fixable

Also trimmed "Use the `?` optional syntax instead." off the end of the `preferOptionalSyntax` message since the suggestion label now says it