### PR TITLE
test(eslint-plugin): [member-ordering] use `RuleTester` directly in `optionalMembers` tests

### DIFF
--- a/packages/eslint-plugin/tests/rules/member-ordering/member-ordering-optionalMembers.test.ts
+++ b/packages/eslint-plugin/tests/rules/member-ordering/member-ordering-optionalMembers.test.ts
@@ -1,14 +1,10 @@
-import type { RunTests } from '@typescript-eslint/rule-tester';
-
 import { RuleTester } from '@typescript-eslint/rule-tester';
-
-import type { MessageIds, Options } from '../../../src/rules/member-ordering';
 
 import rule from '../../../src/rules/member-ordering';
 
 const ruleTester = new RuleTester();
 
-const grouped: RunTests<MessageIds, Options> = {
+ruleTester.run('member-ordering-required', rule, {
   valid: [
     // optionalityOrder - required-first
     {
@@ -265,6 +261,8 @@ interface X {
             beforeMember: 'd',
             member: 'b',
           },
+          endColumn: 14,
+          endLine: 5,
           line: 5,
           messageId: 'incorrectOrder',
         },
@@ -294,6 +292,8 @@ interface X {
             member: 'b',
             optionalOrRequired: 'required',
           },
+          endColumn: 14,
+          endLine: 4,
           line: 4,
           messageId: 'incorrectRequiredMembersOrder',
         },
@@ -323,6 +323,8 @@ class X {
             member: 'a',
             optionalOrRequired: 'required',
           },
+          endColumn: 14,
+          endLine: 3,
           line: 3,
           messageId: 'incorrectRequiredMembersOrder',
         },
@@ -352,6 +354,8 @@ class X {
             member: 'a',
             optionalOrRequired: 'required',
           },
+          endColumn: 13,
+          endLine: 4,
           line: 4,
           messageId: 'incorrectOrder',
         },
@@ -378,6 +382,8 @@ interface X {
       errors: [
         {
           column: 3,
+          endColumn: 14,
+          endLine: 4,
           line: 4,
           messageId: 'incorrectOrder',
         },
@@ -407,6 +413,8 @@ interface X {
             member: 'b',
             optionalOrRequired: 'optional',
           },
+          endColumn: 13,
+          endLine: 4,
           line: 4,
           messageId: 'incorrectRequiredMembersOrder',
         },
@@ -440,6 +448,8 @@ class Test {
             member: 'f',
             optionalOrRequired: 'optional',
           },
+          endColumn: 13,
+          endLine: 5,
           line: 5,
           messageId: 'incorrectRequiredMembersOrder',
         },
@@ -471,6 +481,8 @@ class Test {
             member: 'a',
             optionalOrRequired: 'optional',
           },
+          endColumn: 13,
+          endLine: 3,
           line: 3,
           messageId: 'incorrectRequiredMembersOrder',
         },
@@ -486,6 +498,4 @@ class Test {
       ],
     },
   ],
-};
-
-ruleTester.run('member-ordering-required', rule, grouped);
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #12814
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

Move the optional member-ordering cases into the `RuleTester.run` call directly, matching the repository's current test structure and enabling complete error locations required by the test lint rules.

Tests: `vitest run packages/eslint-plugin/tests/rules/member-ordering/member-ordering-optionalMembers.test.ts`, ESLint, Prettier, TypeScript typecheck, and `git diff --check`.

💖
