### PR TITLE
fix(eslint-plugin): [no-unnecessary-type-assertion] don't report number-to-enum assertions

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -205,6 +205,15 @@ export default createRule<Options, MessageIds>({
         return true;
       }
 
+      // TypeScript lets `number` be assigned to a numeric enum (and vice versa)
+      // for compatibility, so the two are mutually assignable without being the
+      // same type. An assertion between them (`+value as Color`) does change
+      // the type and must not be treated as unchanged.
+      // https://github.com/typescript-eslint/typescript-eslint/issues/12271
+      if (containsEnumType(uncast) !== containsEnumType(cast)) {
+        return false;
+      }
+
       if (
         node.typeAnnotation.type === AST_NODE_TYPES.TSIntersectionType &&
         containsTypeVariable(cast)
@@ -337,6 +346,12 @@ export default createRule<Options, MessageIds>({
       return typeContains(type, t =>
         isTypeFlagSet(t, ts.TypeFlags.TypeVariable | ts.TypeFlags.Index),
       );
+    }
+
+    function containsEnumType(type: ts.Type): boolean {
+      return tsutils
+        .unionConstituents(type)
+        .some(part => isTypeFlagSet(part, ts.TypeFlags.EnumLike));
     }
 
     function hasPhantomTypeArguments(type: ts.Type): boolean {

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -941,6 +941,75 @@ enum E {
 }
 const x: E | undefined = o?.fn(n => n | 0, 0 as E);
     `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/12271
+    `
+enum Color {
+  Red,
+  Green,
+  Blue,
+}
+const values: Record<Color, string> = {
+  [Color.Red]: '#f00',
+  [Color.Green]: '#0f0',
+  [Color.Blue]: '#00f',
+};
+
+function update(valueStr: string) {
+  const color = +valueStr as Color;
+  values[color] = 'updated';
+}
+    `,
+    `
+enum Color {
+  Red,
+  Green,
+  Blue,
+}
+const values: Record<Color, string> = {
+  [Color.Red]: '#f00',
+  [Color.Green]: '#0f0',
+  [Color.Blue]: '#00f',
+};
+
+function update(valueStr: string) {
+  values[+valueStr as Color] = 'updated';
+}
+    `,
+    `
+enum Color {
+  Red,
+  Green,
+  Blue,
+}
+declare const value: number;
+const color = value as Color;
+    `,
+    `
+enum Color {
+  Red,
+  Green,
+  Blue,
+}
+declare const value: number | undefined;
+const color = value as Color | undefined;
+    `,
+    `
+enum Color {
+  Red,
+  Green,
+  Blue,
+}
+declare const color: Color;
+const value = color as number;
+    `,
+    `
+declare enum StatusCodes {
+  OK = 200,
+  NOT_FOUND = 404,
+}
+declare const status: number;
+const isOk = (status as StatusCodes) === StatusCodes.OK;
+    `,
   ],
 
   invalid: [
@@ -3343,6 +3412,65 @@ maybeFn?.(s as string | number);
 declare const maybeFn: ((arg: string | number) => void) | undefined;
 declare const s: string;
 maybeFn?.(s);
+      `,
+    },
+    // https://github.com/typescript-eslint/typescript-eslint/issues/12271
+    {
+      code: `
+enum Color {
+  Red,
+  Green,
+  Blue,
+}
+declare const color: Color;
+const same = color as Color;
+      `,
+      errors: [
+        {
+          column: 14,
+          endColumn: 28,
+          endLine: 8,
+          line: 8,
+          messageId: 'unnecessaryAssertion',
+        },
+      ],
+      output: `
+enum Color {
+  Red,
+  Green,
+  Blue,
+}
+declare const color: Color;
+const same = color;
+      `,
+    },
+    {
+      code: `
+enum Color {
+  Red,
+  Green,
+  Blue,
+}
+declare const color: Color | undefined;
+const same = color as Color | undefined;
+      `,
+      errors: [
+        {
+          column: 14,
+          endColumn: 40,
+          endLine: 8,
+          line: 8,
+          messageId: 'unnecessaryAssertion',
+        },
+      ],
+      output: `
+enum Color {
+  Red,
+  Green,
+  Blue,
+}
+declare const color: Color | undefined;
+const same = color;
       `,
     },
   ],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #12271
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

Since #11789 (8.59.0), `isTypeUnchanged` falls back to mutual assignability. TypeScript allows `number` to be assigned to a numeric enum and vice versa, so `number` and `Color` are mutually assignable even though they are different types. That made `+valueStr as Color` report as unnecessary, and the autofix produced a type error (`values[+valueStr] = ...` is rejected by tsc).

The fix adds one early bail in `isTypeUnchanged`: if exactly one side of the assertion contains an enum type, the assertion changes the type and is not reported. Assertions where both sides are the enum (`color as Color`, `a as T.Value1`) still go through the existing checks and are still reported.

Tests cover the three cases from the issue, the union case (`number | undefined` as `Color | undefined`), the reverse direction (`color as number`), a `declare enum`, and two invalid cases proving enum-to-same-enum is still reported.

AI disclosure: this change was made with Claude Code. I reviewed the rule's history and the diff, and I ran the rule's test suite locally before and after the change (the new valid cases fail on `main` and pass with the fix).

💖
