### PR TITLE
fix(type-utils): match package specifiers on whole path components

### DIFF
--- a/packages/type-utils/src/typeOrValueSpecifiers/typeDeclaredInPackageDeclarationFile.ts
+++ b/packages/type-utils/src/typeOrValueSpecifiers/typeDeclaredInPackageDeclarationFile.ts
@@ -28,6 +28,17 @@ function typeDeclaredInDeclareModule(
   );
 }
 
+/**
+ * Whether `packagePath` is `packageName` itself or something inside it, comparing
+ * whole path components: `semver` covers `semver` and `semver/classes/semver.d.ts`,
+ * but not `semver-compare` or `my-semver`.
+ */
+function pathIsInPackage(packagePath: string, packageName: string): boolean {
+  return (
+    packagePath === packageName || packagePath.startsWith(`${packageName}/`)
+  );
+}
+
 function typeDeclaredInDeclarationFile(
   packageName: string,
   declarationFiles: ts.SourceFile[],
@@ -36,12 +47,20 @@ function typeDeclaredInDeclarationFile(
   // Handle scoped packages: if the name starts with @, remove it and replace / with __
   const typesPackageName = packageName.replace(/^@([^/]+)\//, '$1__');
 
-  const matcher = new RegExp(`${packageName}|${typesPackageName}`);
   return declarationFiles.some(declaration => {
+    // A package id name is a path within the package, such as
+    // `typescript/lib/typescript.d.ts` or `@types/semver/classes/semver.d.ts`.
     const packageIdName = program.sourceFileToPackageName.get(declaration.path);
+    if (packageIdName == null) {
+      return false;
+    }
+
     return (
-      packageIdName != null &&
-      matcher.test(packageIdName) &&
+      (pathIsInPackage(packageIdName, packageName) ||
+        pathIsInPackage(
+          packageIdName.replace(/^@types\//, ''),
+          typesPackageName,
+        )) &&
       program.isSourceFileFromExternalLibrary(declaration)
     );
   });

--- a/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
+++ b/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
@@ -396,6 +396,19 @@ describe('TypeOrValueSpecifier', () => {
           package: '@babel/code-frame',
         },
       ],
+      // The @types package that provides the type can also be named directly.
+      [
+        'import {SemVer} from "semver"; type Test = SemVer;',
+        { from: 'package', name: 'SemVer', package: '@types/semver' },
+      ],
+      [
+        'import {BabelCodeFrameOptions} from "@babel/code-frame"; type Test = BabelCodeFrameOptions;',
+        {
+          from: 'package',
+          name: 'BabelCodeFrameOptions',
+          package: '@types/babel__code-frame',
+        },
+      ],
       // TODO: Skipped pending resolution of https://github.com/typescript-eslint/typescript-eslint/issues/11504
       //
       // The following type is available from the multi-file @types/node package.
@@ -575,6 +588,26 @@ describe('TypeOrValueSpecifier', () => {
       [
         'import type {Node as TsNode} from "typescript"; type Test = TsNode;',
         { from: 'package', name: 'TsNode', package: 'typescript' },
+      ],
+      // A package name must match whole path components, not any substring of the
+      // declaration file's package path.
+      [
+        'import type {Node} from "typescript"; type Test = Node;',
+        { from: 'package', name: 'Node', package: 'script' },
+      ],
+      [
+        'import {SemVer} from "semver"; type Test = SemVer;',
+        { from: 'package', name: 'SemVer', package: 'semve' },
+      ],
+      [
+        'import {SemVer} from "semver"; type Test = SemVer;',
+        { from: 'package', name: 'SemVer', package: 'sem' },
+      ],
+      // Package names are compared literally; regular expression syntax in them
+      // carries no special meaning.
+      [
+        'import {SemVer} from "semver"; type Test = SemVer;',
+        { from: 'package', name: 'SemVer', package: 's.mver' },
       ],
     ] as const satisfies [string, TypeOrValueSpecifier][])(
       "doesn't match a mismatched package specifier: %s\n\t%s",


### PR DESCRIPTION
## Overview

The current package matching uses an unanchored regular expression, so package names can match as substrings. For example, `@angular` can incorrectly match `@angularlol`.

This changes the matching to use whole path boundaries instead: the configured package name must either match the path component exactly or be followed by `/`.

The `@types` handling is kept explicitly because the declaration path can include forms such as `@types/semver/...`. The added tests cover the prefix-matching case and confirm that the existing `@types` cases still work.

## Checklist

- [x] Addresses an existing open issue: fixes #11946
- [x] That issue was marked as accepting prs
- [x] I have followed the steps in the Contributing guide
- [x] If this PR used AI assistance, I followed the AI Contribution Policy
