### PR TITLE
docs: remove unnecessary line breaks in contributor tiers table

### DIFF
--- a/docs/maintenance/Contributor_Tiers.mdx
+++ b/docs/maintenance/Contributor_Tiers.mdx
@@ -113,13 +113,10 @@ We treat both the creation and review of issues and PRs along the rough scale of
       <td>Small typos or single-file bugfixes</td>
       <td>1</td>
       <td>
-        <a href="https://github.com/typescript-eslint/typescript-eslint/pull/6976">
-          #6976
-        </a>
-        ,{' '}
-        <a href="https://github.com/typescript-eslint/typescript-eslint/issues/6992">
-          #6992
-        </a>
+        <!-- prettier-ignore-start -->
+        <a href="https://github.com/typescript-eslint/typescript-eslint/pull/6976">#6976</a>,{' '}
+        <a href="https://github.com/typescript-eslint/typescript-eslint/issues/6992">#6992</a>
+        <!-- prettier-ignore-end -->
       </td>
     </tr>
     <tr>
@@ -127,13 +124,10 @@ We treat both the creation and review of issues and PRs along the rough scale of
       <td>2-3 files at most, with minimal logical changes</td>
       <td>2</td>
       <td>
-        <a href="https://github.com/typescript-eslint/typescript-eslint/pull/6780">
-          #6780
-        </a>
-        ,{' '}
-        <a href="https://github.com/typescript-eslint/typescript-eslint/pull/6910">
-          #6910
-        </a>
+        <!-- prettier-ignore-start -->
+        <a href="https://github.com/typescript-eslint/typescript-eslint/pull/6780">#6780</a>,{' '}
+        <a href="https://github.com/typescript-eslint/typescript-eslint/pull/6910">#6910</a>
+        <!-- prettier-ignore-end -->
       </td>
     </tr>
     <tr>
@@ -141,13 +135,10 @@ We treat both the creation and review of issues and PRs along the rough scale of
       <td>Multi-file logical changes that require real review+thought</td>
       <td>3</td>
       <td>
-        <a href="https://github.com/typescript-eslint/typescript-eslint/pull/6107">
-          #6107
-        </a>
-        ,{' '}
-        <a href="https://github.com/typescript-eslint/typescript-eslint/pull/6907">
-          #6907
-        </a>
+        <!-- prettier-ignore-start -->
+        <a href="https://github.com/typescript-eslint/typescript-eslint/pull/6107">#6107</a>,{' '}
+        <a href="https://github.com/typescript-eslint/typescript-eslint/pull/6907">#6907</a>
+        <!-- prettier-ignore-end -->
       </td>
     </tr>
     <tr>
@@ -155,13 +146,10 @@ We treat both the creation and review of issues and PRs along the rough scale of
       <td>Dozen+ file logical changes that require deep investigation</td>
       <td>≥5*</td>
       <td>
-        <a href="https://github.com/typescript-eslint/typescript-eslint/pull/6084">
-          #6084
-        </a>
-        ,{' '}
-        <a href="https://github.com/typescript-eslint/typescript-eslint/pull/6777">
-          #6777
-        </a>
+        <!-- prettier-ignore-start -->
+        <a href="https://github.com/typescript-eslint/typescript-eslint/pull/6084">#6084</a>,{' '}
+        <a href="https://github.com/typescript-eslint/typescript-eslint/pull/6777">#6777</a>
+        <!-- prettier-ignore-end -->
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [X] Addresses an existing open issue: fixes #12837
- [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [X] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

Prettier adds new lines inside the `<a>`s and before/after the comma between them, which caused Docusaurus to generate `<p>`s

[Deploy Preview](https://deploy-preview-12839--typescript-eslint.netlify.app/maintenance/contributor-tiers/#pointing)
