### PR TITLE
fix(eslint-plugin): [unbound-method] treat Intl.Collator.prototype.compare as spec-bound

### DIFF
--- a/packages/eslint-plugin/src/rules/unbound-method.ts
+++ b/packages/eslint-plugin/src/rules/unbound-method.ts
@@ -84,6 +84,23 @@ const SUPPORTED_GLOBAL_TYPES = [
   'JSON',
 ];
 
+/**
+ * Methods on instances of built-in classes that are defined by the ECMAScript
+ * spec as *bound* to their instance (i.e. they are safe to call without their
+ * receiver), but whose TypeScript declarations don't model that binding - they
+ * are declared as plain methods that would require a `this` value.
+ *
+ * For example, `Intl.Collator.prototype.compare` is defined as a bound getter
+ * function per the ECMA-402 spec:
+ * https://tc39.es/ecma402/#sec-intl.collator.prototype.compare
+ * ...but `lib.es5.d.ts` declares it as a regular method, so this rule would
+ * otherwise incorrectly flag usages such as `array.sort(collator.compare)`.
+ */
+const SPEC_BOUND_INSTANCE_METHODS: ReadonlyMap<
+  string,
+  ReadonlySet<string>
+> = new Map([['Collator', new Set(['compare'])]]);
+
 const isNotImported = (
   symbol: ts.Symbol,
   currentSourceFile: ts.SourceFile | undefined,
@@ -99,6 +116,27 @@ const isNotImported = (
     currentSourceFile !== valueDeclaration.getSourceFile()
   );
 };
+
+/**
+ * Returns `true` if `propertyName` is a member of a built-in class instance
+ * that is defined by the spec as bound to that instance (see
+ * `SPEC_BOUND_INSTANCE_METHODS` above).
+ */
+function isSpecBoundBuiltinMethod(
+  program: ts.Program,
+  objectType: ts.Type,
+  propertyName: string,
+): boolean {
+  const symbol = objectType.getSymbol();
+  if (!symbol || !isSymbolFromDefaultLibrary(program, symbol)) {
+    return false;
+  }
+
+  return (
+    SPEC_BOUND_INSTANCE_METHODS.get(symbol.getName())?.has(propertyName) ??
+    false
+  );
+}
 
 const BASE_MESSAGE = [
   `A method that is not declared with \`this: void\` may cause unintentional scoping of \`this\` when separated from its object.`,
@@ -227,6 +265,15 @@ export default createRule<Options, MessageIds>({
         if (
           notImported &&
           nativelyBoundMembers.has(`${object.name}.${property.name}`)
+        ) {
+          return true;
+        }
+      }
+
+      if (property.type === AST_NODE_TYPES.Identifier) {
+        const objectType = services.getTypeAtLocation(object);
+        if (
+          isSpecBoundBuiltinMethod(services.program, objectType, property.name)
         ) {
           return true;
         }

--- a/packages/eslint-plugin/tests/rules/unbound-method.test.ts
+++ b/packages/eslint-plugin/tests/rules/unbound-method.test.ts
@@ -9,6 +9,14 @@ ruleTester.run('unbound-method', rule, {
     "['1', '2', '3'].map(Number.parseInt);",
     '[5.2, 7.1, 3.6].map(Math.floor);',
     `
+const collator = new Intl.Collator('en');
+['a', 'b'].sort(collator.compare);
+    `,
+    `
+const { compare } = new Intl.Collator('en');
+compare('a', 'b');
+    `,
+    `
 const foo = Number;
 ['1', '2', '3'].map(foo.parseInt);
     `,
@@ -3166,6 +3174,62 @@ foo[1];
           endColumn: 7,
           endLine: 6,
           line: 6,
+          messageId: 'unboundWithoutThisAnnotation',
+        },
+      ],
+    },
+    {
+      code: `
+const collator = new Intl.Collator('en');
+const f = collator.resolvedOptions;
+f();
+      `,
+      errors: [
+        {
+          column: 11,
+          endColumn: 35,
+          endLine: 3,
+          line: 3,
+          messageId: 'unboundWithoutThisAnnotation',
+        },
+      ],
+    },
+    {
+      code: `
+class Foo {
+  compare(a: string, b: string): number {
+    return a.length - b.length;
+  }
+}
+declare const foo: Foo;
+const f = foo.compare;
+      `,
+      errors: [
+        {
+          column: 11,
+          endColumn: 22,
+          endLine: 8,
+          line: 8,
+          messageId: 'unboundWithoutThisAnnotation',
+        },
+      ],
+    },
+    {
+      code: `
+class Collator {
+  compare(a: string, b: string): number {
+    return a.length - b.length;
+  }
+}
+declare const collator: Collator;
+const f = collator.compare;
+      `,
+      errors: [
+        {
+          column: 11,
+          endColumn: 27,
+          endLine: 8,
+          line: 8,
           messageId: 'unboundWithoutThisAnnotation',
         },
       ],


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #7098
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

`Intl.Collator.prototype.compare` is defined by the ECMA-402 spec as a bound getter function, so usages like `array.sort(collator.compare)` are safe. The TypeScript lib declarations (`lib.es5.d.ts`) don't model that binding and declare `compare` as a regular method, so `unbound-method` incorrectly flags these usages.

This PR adds a small allowlist of spec-bound instance methods on built-in classes (`Collator.compare` for now), guarded by the default-library checks already used in this rule, and consults it in `isNativelyBound`.

Verified locally: the two new `valid` cases fail without the change (the reported false positive) and pass with it; new `invalid` cases confirm `resolvedOptions`, user-defined `compare` methods, and user-defined classes named `Collator` are still reported. Full `unbound-method` test file passes (216 tests).

💖
