### PR TITLE
chore: fix typos in comments and docs

### DIFF
--- a/docs/users/Dependency_Versions.mdx
+++ b/docs/users/Dependency_Versions.mdx
@@ -66,6 +66,6 @@ If you use a non-supported version of TypeScript, the parser will log a warning 
 If you want to disable this warning - or instead make the parser throw, so that unsupported versions fail your lint run (e.g., in CI) - you can configure this in your `parserOptions`.
 See: [Packages > Parser > `onUnsupportedTypeScriptVersion`](../packages/Parser.mdx#onunsupportedtypescriptversion).
 
-## Dependant Version Upgrades
+## Dependent Version Upgrades
 
 See [Maintenance > Dependent Version Upgrades](../maintenance/pull-requests/Dependency_Version_Upgrades.mdx) for maintenance steps to update these versions.

--- a/packages/typescript-eslint/tests/getTsconfigRootDirFromStack.test.ts
+++ b/packages/typescript-eslint/tests/getTsconfigRootDirFromStack.test.ts
@@ -39,7 +39,7 @@ describe(getTSConfigRootDirFromStack, () => {
     expect(notEslintConfig.get()).toBeUndefined();
   });
 
-  it('should work in the presence of a messed up strack trace string', () => {
+  it('should work in the presence of a messed up stack trace string', () => {
     const prepareStackTrace = Error.prepareStackTrace;
     const dummyFunction = () => {};
     Error.prepareStackTrace = dummyFunction;

--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -217,7 +217,7 @@ export class Converter {
   }
 
   /**
-   * Coverts body Nodes and add a directive field to StringLiterals
+   * Converts body Nodes and add a directive field to StringLiterals
    * @param nodes of ts.Node
    * @param parent parentNode
    * @returns Array of body statements

--- a/packages/utils/src/ts-utils/NoInfer.ts
+++ b/packages/utils/src/ts-utils/NoInfer.ts
@@ -1,5 +1,5 @@
 /**
- * We could use NoInfer typescript build-in utility
+ * We could use NoInfer typescript built-in utility
  * introduced in typescript 5.4, however at the moment of creation
  * the supported ts versions are >=4.8.4 <5.7.0
  * so for the moment we have to stick to this polyfill.


### PR DESCRIPTION
## PR Checklist

- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

Fix four small typos in comments, a docs heading, and a test description. No behavior change.

- `packages/utils/src/ts-utils/NoInfer.ts`: `build-in` -> `built-in`
- `packages/typescript-estree/src/convert.ts`: `Coverts` -> `Converts`
- `docs/users/Dependency_Versions.mdx`: heading `Dependant Version Upgrades` -> `Dependent Version Upgrades` (aligns with the "Dependent Version Upgrades" link right below it)
- `packages/typescript-eslint/tests/getTsconfigRootDirFromStack.test.ts`: test description `strack` -> `stack`

Typo candidates were found with spell-check tooling and AI assistance (Codex), and manually reviewed by a human before submitting.
