### PR TITLE
fix(eslint-plugin): [unbound-method] apply ignoreStatic to constructor-side methods

### DIFF
--- a/packages/eslint-plugin/src/rules/unbound-method.ts
+++ b/packages/eslint-plugin/src/rules/unbound-method.ts
@@ -145,6 +145,7 @@ export default createRule<Options, MessageIds>({
     function checkIfMethodAndReport(
       node: TSESTree.Node,
       symbol: ts.Symbol | undefined,
+      isStaticLike = false,
     ): boolean {
       if (!symbol) {
         return false;
@@ -153,6 +154,7 @@ export default createRule<Options, MessageIds>({
       const { dangerous, firstParamIsThis } = checkIfMethod(
         symbol,
         ignoreStatic,
+        isStaticLike,
       );
       if (dangerous) {
         context.report({
@@ -178,6 +180,10 @@ export default createRule<Options, MessageIds>({
         const reported = checkIfMethodAndReport(
           reportNode,
           intersectionPart.getProperty(propertyName),
+          // e.g. `BufferConstructor` describes the constructor itself (it has
+          // `new` signatures), so methods reached through it - like
+          // `Buffer.compare` - are static-like and don't need an instance.
+          intersectionPart.getConstructSignatures().length > 0,
         );
         if (reported) {
           return true;
@@ -289,11 +295,13 @@ export default createRule<Options, MessageIds>({
 
           if (initNode) {
             if (!isNativelyBound(initNode, property.key)) {
+              const initType = services.getTypeAtLocation(initNode);
               const reported = checkIfMethodAndReport(
                 property.key,
-                services
-                  .getTypeAtLocation(initNode)
-                  .getProperty(property.key.name),
+                initType.getProperty(property.key.name),
+                // See the note in `checkUnionConstituentsAndReport`:
+                // methods reached through a constructor type are static-like.
+                initType.getConstructSignatures().length > 0,
               );
               if (reported) {
                 continue;
@@ -344,6 +352,7 @@ interface CheckMethodResult {
 function checkIfMethod(
   symbol: ts.Symbol,
   ignoreStatic: boolean,
+  isStaticLike: boolean,
 ): CheckMethodResult {
   const { valueDeclaration } = symbol;
   if (!valueDeclaration) {
@@ -365,13 +374,18 @@ function checkIfMethod(
           dangerous: false,
         };
       }
-      return checkMethod(assignee as ts.FunctionExpression, ignoreStatic);
+      return checkMethod(
+        assignee as ts.FunctionExpression,
+        ignoreStatic,
+        isStaticLike,
+      );
     }
     case ts.SyntaxKind.MethodDeclaration:
     case ts.SyntaxKind.MethodSignature: {
       return checkMethod(
         valueDeclaration as ts.MethodDeclaration | ts.MethodSignature,
         ignoreStatic,
+        isStaticLike,
       );
     }
   }
@@ -383,6 +397,7 @@ function checkMethod(
   valueDeclaration:
     ts.FunctionExpression | ts.MethodDeclaration | ts.MethodSignature,
   ignoreStatic: boolean,
+  isStaticLike: boolean,
 ): CheckMethodResult {
   const firstParam = valueDeclaration.parameters.at(0);
   const firstParamIsThis =
@@ -392,16 +407,15 @@ function checkMethod(
   const thisArgIsVoid =
     firstParamIsThis && firstParam.type?.kind === ts.SyntaxKind.VoidKeyword;
 
+  const isStatic =
+    isStaticLike ||
+    tsutils.includesModifier(
+      getModifiers(valueDeclaration),
+      ts.SyntaxKind.StaticKeyword,
+    );
+
   return {
-    dangerous:
-      !thisArgIsVoid &&
-      !(
-        ignoreStatic &&
-        tsutils.includesModifier(
-          getModifiers(valueDeclaration),
-          ts.SyntaxKind.StaticKeyword,
-        )
-      ),
+    dangerous: !thisArgIsVoid && !(ignoreStatic && isStatic),
     firstParamIsThis,
   };
 }

--- a/packages/eslint-plugin/tests/rules/unbound-method.test.ts
+++ b/packages/eslint-plugin/tests/rules/unbound-method.test.ts
@@ -8,6 +8,24 @@ ruleTester.run('unbound-method', rule, {
     'Promise.resolve().then(console.log);',
     "['1', '2', '3'].map(Number.parseInt);",
     '[5.2, 7.1, 3.6].map(Math.floor);',
+    {
+      // `Buffer` is typed in @types/node as a `var` of type `BufferConstructor`
+      // (an interface with `new` signatures), so `Buffer.compare` is a
+      // static-like method accessed on the constructor, not on an instance.
+      code: `
+const buf1 = Buffer.from('1234');
+const buf2 = Buffer.from('0123');
+const sorted = [buf1, buf2].sort(Buffer.compare);
+      `,
+      options: [{ ignoreStatic: true }],
+    },
+    {
+      code: `
+const { compare } = Buffer;
+compare(Buffer.from('1234'), Buffer.from('0123'));
+      `,
+      options: [{ ignoreStatic: true }],
+    },
     `
 const foo = Number;
 ['1', '2', '3'].map(foo.parseInt);
@@ -3169,6 +3187,46 @@ foo[1];
           messageId: 'unboundWithoutThisAnnotation',
         },
       ],
+    },
+    {
+      // Without `ignoreStatic`, constructor-side methods are still reported.
+      code: `
+const buf1 = Buffer.from('1234');
+const buf2 = Buffer.from('0123');
+const sorted = [buf1, buf2].sort(Buffer.compare);
+      `,
+      errors: [
+        {
+          column: 34,
+          endColumn: 48,
+          endLine: 4,
+          line: 4,
+          messageId: 'unboundWithoutThisAnnotation',
+        },
+      ],
+    },
+    {
+      // `ignoreStatic` must not suppress methods on a plain (non-constructor)
+      // interface type, since those are accessed on an instance.
+      code: `
+interface Foo {
+  bar(): void;
+}
+
+declare const foo: Foo;
+
+foo.bar;
+      `,
+      errors: [
+        {
+          column: 1,
+          endColumn: 8,
+          endLine: 8,
+          line: 8,
+          messageId: 'unboundWithoutThisAnnotation',
+        },
+      ],
+      options: [{ ignoreStatic: true }],
     },
   ],
 });


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #7893
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

`ignoreStatic` currently only suppresses methods declared with the `static` modifier. Built-ins like `Buffer` are typed in `@types/node` not as classes but as a `var` of an interface type that describes the constructor (e.g. `BufferConstructor`, which has `new` signatures). Methods reached through such a type - like `Buffer.compare` - are static-like, but they have no `static` modifier, so `ignoreStatic` didn't apply and the rule kept flagging `array.sort(Buffer.compare)`.

This PR makes `ignoreStatic` also apply to methods accessed through a type with construct signatures (the constructor side), which covers the `Buffer.compare` case as well as similar "var of a constructor interface" patterns. Instance-typed accesses are unaffected since instance types don't carry construct signatures.

Verified locally: the new `valid` cases (`Buffer.compare` as a sort callback and destructured from `Buffer`) fail without the change and pass with it; new `invalid` cases confirm `Buffer.compare` is still reported when `ignoreStatic` is off, and that a plain (non-constructor) interface's methods are still reported under `ignoreStatic`. The full `unbound-method` test file passes (215 tests).

💖
