### PR TITLE
fix(eslint-plugin): [no-misused-spread] omit WeakMap spread suggestions

### DIFF
--- a/packages/eslint-plugin/src/rules/no-misused-spread.ts
+++ b/packages/eslint-plugin/src/rules/no-misused-spread.ts
@@ -118,7 +118,17 @@ export default createRule<Options, MessageIds>({
       type: ts.Type,
     ): TSESLint.ReportSuggestionArray<MessageIds> | null {
       const types = tsutils.unionConstituents(type);
-      if (types.some(t => !isMap(services.program, t))) {
+      if (
+        types.some(
+          t =>
+            !isTypeRecurser(t, part =>
+              isBuiltinSymbolLike(services.program, part, [
+                'Map',
+                'ReadonlyMap',
+              ]),
+            ),
+        )
+      ) {
         return null;
       }
 

--- a/packages/eslint-plugin/tests/rules/no-misused-spread.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-misused-spread.test.ts
@@ -969,17 +969,63 @@ const o = { ...map };
           endLine: 3,
           line: 3,
           messageId: 'noMapSpreadInObject',
-          suggestions: [
-            {
-              messageId: 'replaceMapSpreadInObject',
-              output: `
-declare const map: WeakMap<{ a: number }, string>;
-const o = Object.fromEntries(map);
-      `,
-            },
-          ],
+          suggestions: [],
         },
       ],
+    },
+    {
+      code: `
+declare const map: Map<object, string> | WeakMap<object, string>;
+const o = { other: 1, ...map };
+      `,
+      errors: [
+        {
+          column: 23,
+          endColumn: 29,
+          endLine: 3,
+          line: 3,
+          messageId: 'noMapSpreadInObject',
+          suggestions: [],
+        },
+      ],
+    },
+    {
+      code: `
+class CustomWeakMap extends WeakMap<object, string> {}
+declare const map: CustomWeakMap;
+const o = { ...map };
+      `,
+      errors: [
+        {
+          column: 13,
+          endColumn: 19,
+          endLine: 4,
+          line: 4,
+          messageId: 'noMapSpreadInObject',
+          suggestions: [],
+        },
+      ],
+    },
+    {
+      code: `
+declare const map: WeakMap<object, string>;
+const element = <Component {...map} />;
+      `,
+      errors: [
+        {
+          column: 28,
+          endColumn: 36,
+          endLine: 3,
+          line: 3,
+          messageId: 'noMapSpreadInObject',
+          suggestions: [],
+        },
+      ],
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: { jsx: true },
+        },
+      },
     },
     {
       code: `


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #12849
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

The no-misused-spread rule suggests Object.fromEntries() for WeakMap, but that replacement throws because WeakMap isn't iterable

This removes the invalid suggestion while keeping the spread warning. Suggestions for Map and ReadonlyMap remain unchanged

Added regression tests for WeakMap subclasses, unions containing WeakMap, and JSX spreads

Validation:
- All 134 rule tests passed
- Targeted ESLint passed
- Package typechecking passed