### PR TITLE
fix(eslint-plugin): [no-generated-empty-object-type] don't report a mapped type whose keys are not resolved yet

### DIFF
--- a/packages/eslint-plugin/src/rules/no-generated-empty-object-type.ts
+++ b/packages/eslint-plugin/src/rules/no-generated-empty-object-type.ts
@@ -39,8 +39,12 @@ export default createRule({
         type.getCallSignatures().length === 0 &&
         type.getConstructSignatures().length === 0 &&
         // Types still awaiting type arguments, such as `Record<T, unknown>`
-        // inside a generic declaration, also have no members yet.
-        checker.isTypeAssignableTo(checker.getNumberType(), type)
+        // inside a generic declaration, also have no members yet. Every
+        // primitive is assignable to `{}`, so probing with more than one of
+        // them rules those out: a mapped type whose keys are not resolved yet,
+        // such as `{ [K in Keys<T>]: K }`, accepts `number` but not `string`.
+        checker.isTypeAssignableTo(checker.getNumberType(), type) &&
+        checker.isTypeAssignableTo(checker.getStringType(), type)
       );
     }
 

--- a/packages/eslint-plugin/tests/rules/no-generated-empty-object-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-generated-empty-object-type.test.ts
@@ -64,6 +64,28 @@ type MakeRequired<Base, Key extends keyof Base> = Omit<Base, Key> &
     `
 type Emptied<T> = Omit<T, keyof T>;
     `,
+    `
+type Keys<T> = T extends infer U ? keyof U : never;
+type Mapped<T extends object> = { [Key in Keys<T>]: Key };
+type Referenced<T extends object> = Mapped<T>;
+    `,
+    `
+type Keys<T> = T extends infer U ? keyof U : never;
+type Mapped<T extends object> = { [Key in Keys<T>]: Key };
+type Indexed<T extends object> = Mapped<T>[Keys<T>];
+    `,
+    `
+type Keys<T> = T extends infer U ? keyof U : never;
+type Remapped<T extends object> = {
+  [Key in Keys<T> as \`get\${string & Key}\`]: () => void;
+};
+type Referenced<T extends object> = Remapped<T>;
+    `,
+    `
+type Keys<T> = T extends infer U ? keyof U : never;
+type ReadonlyMapped<T extends object> = { readonly [Key in Keys<T>]: number };
+type Referenced<T extends object> = ReadonlyMapped<T>;
+    `,
   ],
   invalid: [
     {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #12853
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

`isEmptyObjectType` already guards against types that only look memberless because they are still waiting
on type arguments, by checking that `number` is assignable to them. A mapped type whose key set is not
resolved yet — `{ [Key in Keys<T>]: Key }` where `Keys<T>` is a deferred conditional — passes that guard,
so the rule reports it as `{}` even though every instantiation of it is a real object type.

`number` turns out to be the one primitive that does not discriminate here. The empty object type accepts
every non-nullish primitive, but such a deferred mapped type accepts `number` and rejects `string`, so
probing with `string` as well separates the two:

|                                       | `number` | `string` |
| ------------------------------------- | -------- | -------- |
| `{}`, `Omit<null \| Data, 'name'>`, …  | yes      | yes      |
| `{ [Key in Keys<T>]: Key }`            | yes      | no       |

This adds the second probe. Since it is a new conjunct it can only ever make the rule report less, so no
previously-valid code can start reporting; all the existing `invalid` cases still report.

Four `valid` cases cover the shapes I checked: a plain deferred mapped type, one indexed with the same key
set, one remapped with an `as` clause, and a `readonly` one.

I found this through `type-fest`'s `ConditionalKeys`, which resolves through nested deferred conditionals.
A "map, then index" key filter written on top of it is reported even though its type tests assert the
instantiated type is the correct key union.

One thing worth a maintainer's opinion: this keeps the existing "probe with a primitive" approach and just
strengthens it. The alternative is to detect the deferred case directly — the false positives all carry
`ObjectFlags.Mapped` together with `CouldContainTypeVariables`, which reads more precisely, but that flag
is internal and not in the public type definitions. Happy to switch if you would rather go that way.
