### PR TITLE
fix(eslint-plugin): [no-meaningless-void-operator] allow void on assignments

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-meaningless-void-operator.mdx
+++ b/packages/eslint-plugin/docs/rules/no-meaningless-void-operator.mdx
@@ -15,7 +15,7 @@ For example, it is recommended as one way of suppressing [`@typescript-eslint/no
 
 This rule helps authors catch API changes where previously a value was being discarded at a call site, but the callee changed so it no longer returns a value.
 When combined with [no-unused-expressions](https://eslint.org/docs/rules/no-unused-expressions), it also helps _readers_ of the code by ensuring consistency: a statement that looks like `void foo();` is **always** discarding a return value, and a statement that looks like `foo();` is **never** discarding a return value.
-This rule reports `void` on a non-call expression (except thenables such as promises) and on a call whose return type is already `void` or `undefined`.
+This rule reports `void` on a non-call expression (except thenables such as promises, and assignment expressions such as `void (x = 1)`) and on a call whose return type is already `void` or `undefined`.
 
 ## Examples
 
@@ -56,6 +56,9 @@ void 0;
 
 declare const promise: Promise<number>;
 void promise;
+
+declare let x: number;
+() => void (x = 1);
 ```
 
 </TabItem>

--- a/packages/eslint-plugin/src/rules/no-meaningless-void-operator.ts
+++ b/packages/eslint-plugin/src/rules/no-meaningless-void-operator.ts
@@ -64,6 +64,11 @@ export default createRule<
         };
 
         const inner = unwrapVoidArgument(node.argument);
+        // `void (x = value)` discards the assignment result so the
+        // expression evaluates to undefined (e.g. `() => void (x = 1)`).
+        if (inner.type === AST_NODE_TYPES.AssignmentExpression) {
+          return;
+        }
         if (inner.type !== AST_NODE_TYPES.CallExpression) {
           // `void 0` is a common undefined idiom, not a discarded call.
           if (inner.type === AST_NODE_TYPES.Literal && inner.value === 0) {

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-meaningless-void-operator.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-meaningless-void-operator.shot
@@ -35,3 +35,6 @@ void 0;
 
 declare const promise: Promise<number>;
 void promise;
+
+declare let x: number;
+() => void (x = 1);

--- a/packages/eslint-plugin/tests/rules/no-meaningless-void-operator.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-meaningless-void-operator.test.ts
@@ -71,6 +71,23 @@ declare function fn(): void;
 declare function getValue(): string;
 void (fn(), getValue());
     `,
+    `
+declare let x: number;
+void (x = 1);
+    `,
+    `
+declare let x: number;
+() => void (x = 1);
+    `,
+    `
+declare const box: { value: string };
+void (box.value = 'ok');
+    `,
+    `
+declare let x: number;
+declare function getValue(): number;
+void (x = getValue());
+    `,
   ],
   invalid: [
     {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #12852
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

`no-meaningless-void-operator` currently flags assignment expressions such as `void (x = 1)` / `() => void (x = 1)` as meaningless non-call uses of `void`. That pattern is intentional: `void` discards the assigned value so the whole expression is `undefined` (important for arrow functions that must not return the RHS).

This change skips reporting when the void operand unwraps to an `AssignmentExpression`, adds regression tests, and updates the rule docs example.

Verified with:
`nx run eslint-plugin:test -- no-meaningless-void-operator`