### PR TITLE
feat(eslint-plugin): [no-redundant-default-arguments] add new rule

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-redundant-default-arguments.mdx
+++ b/packages/eslint-plugin/docs/rules/no-redundant-default-arguments.mdx
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 
 Function parameters can supply default values when arguments are omitted. Explicitly passing those defaults can obscure the arguments that customize a call.
 
-This rule reports matching trailing arguments and matching optional properties in directly destructured object parameters. It offers editor suggestions instead of automatic fixes, so each removal can be reviewed.
+This rule reports matching trailing arguments and matching optional properties in directly destructured object parameters, including JSX component props. It offers editor suggestions instead of automatic fixes, so each removal can be reviewed.
 
 ## Examples
 
@@ -32,6 +32,14 @@ function configure({ retries = 3 }: { retries?: number }) {
 }
 
 configure({ retries: 3 });
+```
+
+```tsx
+function Button({ enabled = true }) {
+  return <button disabled={!enabled} />;
+}
+
+<Button enabled />;
 ```
 
 </TabItem>
@@ -55,6 +63,15 @@ configure({});
 configure({ retries: 5 });
 ```
 
+```tsx
+function Button({ enabled = true }) {
+  return <button disabled={!enabled} />;
+}
+
+<Button />;
+<Button enabled={false} />;
+```
+
 </TabItem>
 </Tabs>
 
@@ -62,17 +79,22 @@ configure({ retries: 5 });
 
 The rule checks function declarations, directly initialized `const` function expressions and arrows, and direct function-expression calls. Named, renamed, default, and re-exported imports are supported when TypeScript resolves them to supported source implementations. Declaration-only dependencies do not expose runtime defaults and are skipped.
 
-Values must be primitive literals: strings, numbers, booleans, `null`, bigints, or templates without substitutions. Signed numeric literals and parentheses are supported. Positive and negative zero are distinct. Identifiers, including `undefined`, are not evaluated; assertions, `satisfies`, and other type-affecting wrappers are skipped.
+Values must be primitive literals: strings, numbers, booleans, `null`, bigints, or templates without substitutions. Signed numeric literals, parentheses, and `as const` assertions on primitives are supported. Positive and negative zero are distinct. Identifiers, including `undefined`, are not evaluated; other assertions, `satisfies`, and other type-affecting wrappers are skipped.
 
 Matching positional arguments must form a trailing suffix. Removing an earlier argument must not shift a retained argument. For object arguments, the rule checks one level of ordinary properties, including renamed bindings. Required properties are retained, and removing the last property preserves the empty object argument. Suggestions that would delete comments are omitted.
+
+Functions with rest parameters can have matching object properties removed from their fixed arguments. A later call spread is allowed only when it starts at or after the rest parameter. Positional arguments are never removed from calls with spreads or rest parameters.
+
+JSX components use the same function-origin checks, including for imports. The component must have one directly destructured props parameter. Literal expressions, string attributes, and boolean shorthand attributes are checked. Each matching prop receives its own removal suggestion.
 
 ## Limitations
 
 The rule deliberately skips:
 
-- Object and class methods, namespace-import member calls, `import =` aliases, optional calls, constructors, tagged templates, and JSX elements. Ordinary calls in TSX files are checked.
+- Object and class methods, namespace-import member calls, `import =` aliases, optional calls, constructors, and tagged templates.
 - Generic functions and functions inside generic function/class contexts, overloads, structural callable annotations, local aliases, callbacks, factories, and ambiguous callable origins.
-- Mutable function variables, known local binding writes, imports that resolve back to the current file, spreads in calls, and rest parameters.
+- Mutable function variables, known local binding writes, and imports that resolve back to the current file.
+- JSX intrinsic elements, member or namespaced component names, components with a `defaultProps` property, and elements containing spread or duplicate attributes. Component names must start with an uppercase letter. The special props `key`, `ref`, and `children` are retained.
 - Nested object patterns, computed or numeric keys, duplicate keys, shorthand properties, accessors, methods, spreads, rest bindings, and names inherited from `Object.prototype`, such as `toString` and `__proto__`.
 - Implementations containing identifiers named `arguments` or `eval`, including in parameter initializers and nested functions. These conservative checks can skip harmless uses of those names.
 

--- a/packages/eslint-plugin/docs/rules/no-redundant-default-arguments.mdx
+++ b/packages/eslint-plugin/docs/rules/no-redundant-default-arguments.mdx
@@ -1,0 +1,83 @@
+---
+description: 'Disallow arguments that match their declared default values.'
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+> 🛑 This file is source code, not the primary documentation location! 🛑
+>
+> See **https://typescript-eslint.io/rules/no-redundant-default-arguments** for documentation.
+
+Function parameters can supply default values when arguments are omitted. Explicitly passing those defaults can obscure the arguments that customize a call.
+
+This rule reports matching trailing arguments and matching optional properties in directly destructured object parameters. It offers editor suggestions instead of automatic fixes, so each removal can be reviewed.
+
+## Examples
+
+<Tabs>
+<TabItem value="❌ Incorrect">
+
+```ts
+function select(value = 0) {
+  return value;
+}
+
+select(0);
+```
+
+```ts
+function configure({ retries = 3 }: { retries?: number }) {
+  return retries;
+}
+
+configure({ retries: 3 });
+```
+
+</TabItem>
+<TabItem value="✅ Correct">
+
+```ts
+function select(value = 0) {
+  return value;
+}
+
+select();
+select(1);
+```
+
+```ts
+function configure({ retries = 3 }: { retries?: number }) {
+  return retries;
+}
+
+configure({});
+configure({ retries: 5 });
+```
+
+</TabItem>
+</Tabs>
+
+## Supported Calls
+
+The rule checks function declarations, directly initialized `const` function expressions and arrows, and direct function-expression calls. Named, renamed, default, and re-exported imports are supported when TypeScript resolves them to supported source implementations. Declaration-only dependencies do not expose runtime defaults and are skipped.
+
+Values must be primitive literals: strings, numbers, booleans, `null`, bigints, or templates without substitutions. Signed numeric literals and parentheses are supported. Positive and negative zero are distinct. Identifiers, including `undefined`, are not evaluated; assertions, `satisfies`, and other type-affecting wrappers are skipped.
+
+Matching positional arguments must form a trailing suffix. Removing an earlier argument must not shift a retained argument. For object arguments, the rule checks one level of ordinary properties, including renamed bindings. Required properties are retained, and removing the last property preserves the empty object argument. Suggestions that would delete comments are omitted.
+
+## Limitations
+
+The rule deliberately skips:
+
+- Object and class methods, namespace-import member calls, `import =` aliases, optional calls, constructors, tagged templates, and JSX elements. Ordinary calls in TSX files are checked.
+- Generic functions and functions inside generic function/class contexts, overloads, structural callable annotations, local aliases, callbacks, factories, and ambiguous callable origins.
+- Mutable function variables, known local binding writes, imports that resolve back to the current file, spreads in calls, and rest parameters.
+- Nested object patterns, computed or numeric keys, duplicate keys, shorthand properties, accessors, methods, spreads, rest bindings, and names inherited from `Object.prototype`, such as `toString` and `__proto__`.
+- Implementations containing identifiers named `arguments` or `eval`, including in parameter initializers and nested functions. These conservative checks can skip harmless uses of those names.
+
+A resolved declaration is not a proof of runtime behavior. Imported function declarations are checked assuming their defining modules do not secretly reassign them. Runtime wrappers, proxies, and changes to built-in object prototypes are outside this analysis. Projects using those techniques should review suggestions accordingly.
+
+## When Not To Use It
+
+If your project prefers explicitly spelling out default values at call sites, you can leave this rule disabled.

--- a/packages/eslint-plugin/src/configs/eslintrc/all.ts
+++ b/packages/eslint-plugin/src/configs/eslintrc/all.ts
@@ -81,6 +81,7 @@ export = {
     '@typescript-eslint/no-non-null-assertion': 'error',
     'no-redeclare': 'off',
     '@typescript-eslint/no-redeclare': 'error',
+    '@typescript-eslint/no-redundant-default-arguments': 'error',
     '@typescript-eslint/no-redundant-type-constituents': 'error',
     '@typescript-eslint/no-require-imports': 'error',
     '@typescript-eslint/no-restricted-types': 'error',

--- a/packages/eslint-plugin/src/configs/eslintrc/disable-type-checked.ts
+++ b/packages/eslint-plugin/src/configs/eslintrc/disable-type-checked.ts
@@ -28,6 +28,7 @@ export = {
     '@typescript-eslint/no-misused-promises': 'off',
     '@typescript-eslint/no-misused-spread': 'off',
     '@typescript-eslint/no-mixed-enums': 'off',
+    '@typescript-eslint/no-redundant-default-arguments': 'off',
     '@typescript-eslint/no-redundant-type-constituents': 'off',
     '@typescript-eslint/no-unnecessary-boolean-literal-compare': 'off',
     '@typescript-eslint/no-unnecessary-condition': 'off',

--- a/packages/eslint-plugin/src/configs/flat/all.ts
+++ b/packages/eslint-plugin/src/configs/flat/all.ts
@@ -94,6 +94,7 @@ export default (
       '@typescript-eslint/no-non-null-assertion': 'error',
       'no-redeclare': 'off',
       '@typescript-eslint/no-redeclare': 'error',
+      '@typescript-eslint/no-redundant-default-arguments': 'error',
       '@typescript-eslint/no-redundant-type-constituents': 'error',
       '@typescript-eslint/no-require-imports': 'error',
       '@typescript-eslint/no-restricted-types': 'error',

--- a/packages/eslint-plugin/src/configs/flat/disable-type-checked.ts
+++ b/packages/eslint-plugin/src/configs/flat/disable-type-checked.ts
@@ -35,6 +35,7 @@ export default (
     '@typescript-eslint/no-misused-promises': 'off',
     '@typescript-eslint/no-misused-spread': 'off',
     '@typescript-eslint/no-mixed-enums': 'off',
+    '@typescript-eslint/no-redundant-default-arguments': 'off',
     '@typescript-eslint/no-redundant-type-constituents': 'off',
     '@typescript-eslint/no-unnecessary-boolean-literal-compare': 'off',
     '@typescript-eslint/no-unnecessary-condition': 'off',

--- a/packages/eslint-plugin/src/rules/index.ts
+++ b/packages/eslint-plugin/src/rules/index.ts
@@ -61,6 +61,7 @@ import noNonNullAssertedNullishCoalescing from './no-non-null-asserted-nullish-c
 import noNonNullAssertedOptionalChain from './no-non-null-asserted-optional-chain';
 import noNonNullAssertion from './no-non-null-assertion';
 import noRedeclare from './no-redeclare';
+import noRedundantDefaultArguments from './no-redundant-default-arguments';
 import noRedundantTypeConstituents from './no-redundant-type-constituents';
 import noRequireImports from './no-require-imports';
 import noRestrictedImports from './no-restricted-imports';
@@ -198,6 +199,7 @@ const rules = {
   'no-non-null-asserted-optional-chain': noNonNullAssertedOptionalChain,
   'no-non-null-assertion': noNonNullAssertion,
   'no-redeclare': noRedeclare,
+  'no-redundant-default-arguments': noRedundantDefaultArguments,
   'no-redundant-type-constituents': noRedundantTypeConstituents,
   'no-require-imports': noRequireImports,
   'no-restricted-imports': noRestrictedImports,

--- a/packages/eslint-plugin/src/rules/no-redundant-default-arguments.ts
+++ b/packages/eslint-plugin/src/rules/no-redundant-default-arguments.ts
@@ -352,7 +352,8 @@ export default createRule<[], MessageIds>({
             (!binding ||
               !ts.isVariableDeclaration(binding) ||
               binding.type ||
-              binding.initializer !== declaration ||
+              !binding.initializer ||
+              unwrapParentheses(binding.initializer) !== declaration ||
               !(binding.parent.flags & ts.NodeFlags.Const))
           ) {
             return;

--- a/packages/eslint-plugin/src/rules/no-redundant-default-arguments.ts
+++ b/packages/eslint-plugin/src/rules/no-redundant-default-arguments.ts
@@ -1,0 +1,498 @@
+import type { TSESTree } from '@typescript-eslint/utils';
+
+import { AST_NODE_TYPES, ASTUtils } from '@typescript-eslint/utils';
+import * as tsutils from 'ts-api-utils';
+import * as ts from 'typescript';
+
+import {
+  createRule,
+  getParserServices,
+  isCommaToken,
+  nullThrows,
+  NullThrowsReasons,
+} from '../util';
+
+type MessageIds =
+  | 'redundantArguments'
+  | 'redundantProperty'
+  | 'removeArguments'
+  | 'removeProperty';
+
+// Omitting these own properties exposes an inherited value instead of the default.
+const inheritedPropertyNames = new Set([
+  '__defineGetter__',
+  '__defineSetter__',
+  '__lookupGetter__',
+  '__lookupSetter__',
+  '__proto__',
+  'constructor',
+  'hasOwnProperty',
+  'isPrototypeOf',
+  'propertyIsEnumerable',
+  'toLocaleString',
+  'toString',
+  'valueOf',
+]);
+
+function unwrapParentheses(node: ts.Node): ts.Node {
+  while (ts.isParenthesizedExpression(node)) {
+    node = node.expression;
+  }
+  return node;
+}
+
+function readPrimitive(
+  node: ts.Node | undefined,
+): { value: bigint | boolean | number | string | null } | undefined {
+  if (!node) {
+    return undefined;
+  }
+  node = unwrapParentheses(node);
+  if (ts.isNumericLiteral(node)) {
+    return { value: Number(node.text) };
+  }
+  if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+    return { value: node.text };
+  }
+  if (ts.isBigIntLiteral(node)) {
+    return { value: BigInt(node.text.replaceAll('_', '').slice(0, -1)) };
+  }
+  if (
+    node.kind === ts.SyntaxKind.TrueKeyword ||
+    node.kind === ts.SyntaxKind.FalseKeyword
+  ) {
+    return { value: node.kind === ts.SyntaxKind.TrueKeyword };
+  }
+  if (node.kind === ts.SyntaxKind.NullKeyword) {
+    return { value: null };
+  }
+  if (ts.isPrefixUnaryExpression(node)) {
+    const operand = readPrimitive(node.operand);
+    if (
+      operand &&
+      (typeof operand.value === 'number' || typeof operand.value === 'bigint')
+    ) {
+      if (node.operator === ts.SyntaxKind.MinusToken) {
+        return { value: -operand.value };
+      }
+      if (
+        node.operator === ts.SyntaxKind.PlusToken &&
+        typeof operand.value === 'number'
+      ) {
+        return operand;
+      }
+    }
+  }
+  return undefined;
+}
+
+function observesArguments(node: ts.Node): boolean {
+  return (
+    (ts.isIdentifier(node) &&
+      (node.text === 'arguments' || node.text === 'eval')) ||
+    !!ts.forEachChild(node, child => observesArguments(child) || undefined)
+  );
+}
+
+function propertyName(node: ts.Node) {
+  return ts.isIdentifier(node) || ts.isStringLiteral(node)
+    ? node.text
+    : undefined;
+}
+
+function readProperties(parameter: ts.ParameterDeclaration) {
+  if (!ts.isObjectBindingPattern(parameter.name)) {
+    return undefined;
+  }
+  const properties = new Map<string, ReturnType<typeof readPrimitive>>();
+  for (const binding of parameter.name.elements) {
+    const name = propertyName(binding.propertyName ?? binding.name);
+    if (
+      name == null ||
+      inheritedPropertyNames.has(name) ||
+      binding.dotDotDotToken ||
+      !ts.isIdentifier(binding.name) ||
+      properties.has(name)
+    ) {
+      return undefined;
+    }
+    properties.set(name, readPrimitive(binding.initializer));
+  }
+  return properties;
+}
+
+export default createRule<[], MessageIds>({
+  name: 'no-redundant-default-arguments',
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Disallow arguments that match their declared default values',
+      requiresTypeChecking: true,
+    },
+    hasSuggestions: true,
+    messages: {
+      redundantArguments:
+        'These trailing arguments match their declared default values.',
+      redundantProperty:
+        "Property '{{name}}' matches its declared default value.",
+      removeArguments: 'Remove the matching trailing arguments.',
+      removeProperty: "Remove property '{{name}}'.",
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    const services = getParserServices(context);
+    const checker = services.program.getTypeChecker();
+    const defaults = new WeakMap<
+      ts.SignatureDeclaration,
+      {
+        parameters: {
+          declaration: ts.ParameterDeclaration;
+          value: ReturnType<typeof readPrimitive>;
+          properties: ReturnType<typeof readProperties>;
+        }[];
+        minimumArguments: number;
+      } | null
+    >();
+    const writes = new WeakMap<ts.Symbol, boolean>();
+    const genericContexts = new WeakMap<ts.Node, boolean>();
+    const parameterTypes = new WeakMap<ts.ParameterDeclaration, ts.Type>();
+    const optionalPropertyTypes = new WeakMap<
+      ts.ParameterDeclaration,
+      Map<string, ts.Type | null>
+    >();
+
+    function inGenericContext(node: ts.Node): boolean {
+      const cached = genericContexts.get(node);
+      if (cached != null) {
+        return cached;
+      }
+      const generic =
+        !!(
+          (ts.isFunctionLike(node) || ts.isClassLike(node)) &&
+          node.typeParameters?.length
+        ) ||
+        (!ts.isSourceFile(node) && inGenericContext(node.parent));
+      genericContexts.set(node, generic);
+      return generic;
+    }
+
+    function getArgumentProperties(argument: TSESTree.ObjectExpression) {
+      const properties = new Map<string, TSESTree.Property>();
+      for (const property of argument.properties) {
+        if (
+          property.type !== AST_NODE_TYPES.Property ||
+          property.computed ||
+          property.method ||
+          property.shorthand ||
+          property.kind !== 'init'
+        ) {
+          return undefined;
+        }
+        const name = propertyName(
+          services.esTreeNodeToTSNodeMap.get(property.key),
+        );
+        if (
+          name == null ||
+          inheritedPropertyNames.has(name) ||
+          properties.has(name)
+        ) {
+          return undefined;
+        }
+        properties.set(name, property);
+      }
+      return properties;
+    }
+
+    function getParameterType(parameter: ts.ParameterDeclaration) {
+      let type = parameterTypes.get(parameter);
+      if (!type) {
+        type = checker.getTypeAtLocation(parameter);
+        parameterTypes.set(parameter, type);
+      }
+      return type;
+    }
+
+    function getOptionalPropertyType(
+      parameter: ts.ParameterDeclaration,
+      name: string,
+    ) {
+      let properties = optionalPropertyTypes.get(parameter);
+      if (!properties) {
+        properties = new Map();
+        optionalPropertyTypes.set(parameter, properties);
+      }
+      if (!properties.has(name)) {
+        const type = getParameterType(parameter);
+        const symbol = tsutils.isTypeFlagSet(type, ts.TypeFlags.Object)
+          ? checker.getPropertyOfType(type, name)
+          : undefined;
+        properties.set(
+          name,
+          symbol && tsutils.isSymbolFlagSet(symbol, ts.SymbolFlags.Optional)
+            ? checker.getTypeOfSymbolAtLocation(symbol, parameter)
+            : null,
+        );
+      }
+      return properties.get(name);
+    }
+
+    function getDefaults(declaration: ts.SignatureDeclaration) {
+      if (!defaults.has(declaration)) {
+        if (
+          !(
+            ts.isFunctionDeclaration(declaration) ||
+            ts.isFunctionExpression(declaration) ||
+            ts.isArrowFunction(declaration)
+          ) ||
+          !declaration.body ||
+          inGenericContext(declaration) ||
+          declaration.parameters.some(parameter => parameter.dotDotDotToken) ||
+          observesArguments(declaration)
+        ) {
+          defaults.set(declaration, null);
+        } else {
+          const runtimeParameters = declaration.parameters.filter(
+            parameter =>
+              !(
+                ts.isIdentifier(parameter.name) &&
+                parameter.name.text === 'this'
+              ),
+          );
+          let minimumArguments = 0;
+          const parameters = runtimeParameters.map((parameter, index) => {
+            if (!parameter.initializer && !parameter.questionToken) {
+              minimumArguments = index + 1;
+            }
+            return {
+              declaration: parameter,
+              properties: readProperties(parameter),
+              value: readPrimitive(parameter.initializer),
+            };
+          });
+          defaults.set(declaration, { minimumArguments, parameters });
+        }
+      }
+      return defaults.get(declaration);
+    }
+
+    return {
+      CallExpression(node) {
+        if (
+          !node.arguments.length ||
+          node.optional ||
+          node.arguments.some(
+            argument => argument.type === AST_NODE_TYPES.SpreadElement,
+          ) ||
+          (node.callee.type !== AST_NODE_TYPES.Identifier &&
+            node.callee.type !== AST_NODE_TYPES.FunctionExpression &&
+            node.callee.type !== AST_NODE_TYPES.ArrowFunctionExpression)
+        ) {
+          return;
+        }
+        const argumentValues = node.arguments.map(argument =>
+          readPrimitive(services.esTreeNodeToTSNodeMap.get(argument)),
+        );
+        if (
+          argumentValues.at(-1) == null &&
+          !node.arguments.some(
+            argument => argument.type === AST_NODE_TYPES.ObjectExpression,
+          )
+        ) {
+          return;
+        }
+        const declaration = services
+          .getResolvedSignature(node)
+          ?.getDeclaration();
+        const callee = unwrapParentheses(
+          services.esTreeNodeToTSNodeMap.get(node.callee),
+        );
+        if (!declaration) {
+          return;
+        }
+        if (ts.isIdentifier(callee)) {
+          let symbol = checker.getSymbolAtLocation(callee);
+          if (symbol) {
+            if (!writes.has(symbol)) {
+              const variable = ASTUtils.findVariable(
+                context.sourceCode.getScope(node),
+                callee.text,
+              );
+              writes.set(
+                symbol,
+                variable?.references.some(
+                  reference => reference.isWrite() && !reference.init,
+                ) ?? false,
+              );
+            }
+            if (writes.get(symbol)) {
+              return;
+            }
+          }
+          if (symbol && tsutils.isSymbolFlagSet(symbol, ts.SymbolFlags.Alias)) {
+            if (
+              declaration.getSourceFile() === callee.getSourceFile() ||
+              !symbol
+                .getDeclarations()
+                ?.every(
+                  declaration =>
+                    ts.isImportSpecifier(declaration) ||
+                    ts.isImportClause(declaration),
+                )
+            ) {
+              return;
+            }
+            symbol = checker.getAliasedSymbol(symbol);
+          }
+          const binding = symbol?.valueDeclaration;
+          if (
+            binding !== declaration &&
+            (!binding ||
+              !ts.isVariableDeclaration(binding) ||
+              binding.type ||
+              binding.initializer !== declaration ||
+              !(binding.parent.flags & ts.NodeFlags.Const))
+          ) {
+            return;
+          }
+        } else if (callee !== declaration) {
+          return;
+        }
+        const metadata = getDefaults(declaration);
+        if (
+          !metadata ||
+          node.arguments.length < metadata.minimumArguments ||
+          node.arguments.length > metadata.parameters.length
+        ) {
+          return;
+        }
+        const { parameters } = metadata;
+        for (const [index, argument] of node.arguments.entries()) {
+          const parameter = parameters[index].declaration;
+          if (
+            argument.type !== AST_NODE_TYPES.ObjectExpression ||
+            !parameters[index].properties
+          ) {
+            continue;
+          }
+          const properties = getArgumentProperties(argument);
+          if (!properties) {
+            continue;
+          }
+          for (const [name, property] of properties) {
+            const initializer = parameters[index].properties.get(name);
+            const value = readPrimitive(
+              services.esTreeNodeToTSNodeMap.get(property.value),
+            );
+            if (
+              !initializer ||
+              !value ||
+              !Object.is(initializer.value, value.value)
+            ) {
+              continue;
+            }
+            const type = getOptionalPropertyType(parameter, name);
+            if (
+              !type ||
+              !checker.isTypeAssignableTo(
+                services.getTypeAtLocation(property.value),
+                type,
+              )
+            ) {
+              continue;
+            }
+            let start = nullThrows(
+              context.sourceCode.getFirstToken(property),
+              NullThrowsReasons.MissingToken('property', 'object'),
+            );
+            let end = nullThrows(
+              context.sourceCode.getLastToken(property),
+              NullThrowsReasons.MissingToken('property', 'object'),
+            );
+            const after = context.sourceCode.getTokenAfter(property);
+            const before = context.sourceCode.getTokenBefore(property);
+            if (after && isCommaToken(after)) {
+              end = after;
+            } else if (before && isCommaToken(before)) {
+              start = before;
+            }
+            context.report({
+              node: property,
+              messageId: 'redundantProperty',
+              data: { name },
+              suggest: context.sourceCode.commentsExistBetween(start, end)
+                ? []
+                : [
+                    {
+                      messageId: 'removeProperty',
+                      data: { name },
+                      fix: fixer =>
+                        fixer.removeRange([start.range[0], end.range[1]]),
+                    },
+                  ],
+            });
+          }
+        }
+        let first = node.arguments.length;
+        while (first > 0) {
+          const initializer = parameters[first - 1]?.value;
+          const expression = argumentValues[first - 1];
+          if (
+            !initializer ||
+            !expression ||
+            !Object.is(initializer.value, expression.value) ||
+            !checker.isTypeAssignableTo(
+              services.getTypeAtLocation(node.arguments[first - 1]),
+              getParameterType(parameters[first - 1].declaration),
+            )
+          ) {
+            break;
+          }
+          first--;
+        }
+        if (first === node.arguments.length) {
+          return;
+        }
+        const argument = node.arguments[first];
+        const last = node.arguments[node.arguments.length - 1];
+        const call = services.esTreeNodeToTSNodeMap.get(node);
+        const firstToken = nullThrows(
+          context.sourceCode.getTokenByRangeStart(
+            call.arguments[first].getStart(),
+          ),
+          NullThrowsReasons.MissingToken('argument', 'call'),
+        );
+        const start =
+          first === 0
+            ? firstToken
+            : nullThrows(
+                context.sourceCode.getTokenBefore(firstToken),
+                NullThrowsReasons.MissingToken(',', 'argument'),
+              );
+        const closing = nullThrows(
+          context.sourceCode.getLastToken(node),
+          NullThrowsReasons.MissingToken(')', 'call'),
+        );
+        const end = nullThrows(
+          context.sourceCode.getTokenBefore(closing),
+          NullThrowsReasons.MissingToken('argument', 'call'),
+        );
+        context.report({
+          loc: { start: argument.loc.start, end: last.loc.end },
+          messageId: 'redundantArguments',
+          suggest: context.sourceCode.commentsExistBetween(start, end)
+            ? []
+            : [
+                {
+                  messageId: 'removeArguments',
+                  fix: fixer =>
+                    fixer.removeRange([start.range[0], end.range[1]]),
+                },
+              ],
+        });
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin/src/rules/no-redundant-default-arguments.ts
+++ b/packages/eslint-plugin/src/rules/no-redundant-default-arguments.ts
@@ -48,6 +48,14 @@ function readPrimitive(
     return undefined;
   }
   node = unwrapParentheses(node);
+  if (
+    ts.isAsExpression(node) &&
+    ts.isTypeReferenceNode(node.type) &&
+    ts.isIdentifier(node.type.typeName) &&
+    node.type.typeName.text === 'const'
+  ) {
+    return readPrimitive(node.expression);
+  }
   if (ts.isNumericLiteral(node)) {
     return { value: Number(node.text) };
   }
@@ -154,6 +162,7 @@ export default createRule<[], MessageIds>({
           properties: ReturnType<typeof readProperties>;
         }[];
         minimumArguments: number;
+        restIndex: number;
       } | null
     >();
     const writes = new WeakMap<ts.Symbol, boolean>();
@@ -249,7 +258,6 @@ export default createRule<[], MessageIds>({
           ) ||
           !declaration.body ||
           inGenericContext(declaration) ||
-          declaration.parameters.some(parameter => parameter.dotDotDotToken) ||
           observesArguments(declaration)
         ) {
           defaults.set(declaration, null);
@@ -263,7 +271,11 @@ export default createRule<[], MessageIds>({
           );
           let minimumArguments = 0;
           const parameters = runtimeParameters.map((parameter, index) => {
-            if (!parameter.initializer && !parameter.questionToken) {
+            if (
+              !parameter.initializer &&
+              !parameter.questionToken &&
+              !parameter.dotDotDotToken
+            ) {
               minimumArguments = index + 1;
             }
             return {
@@ -272,10 +284,81 @@ export default createRule<[], MessageIds>({
               value: readPrimitive(parameter.initializer),
             };
           });
-          defaults.set(declaration, { minimumArguments, parameters });
+          defaults.set(declaration, {
+            minimumArguments,
+            parameters,
+            restIndex: runtimeParameters.findIndex(
+              parameter => !!parameter.dotDotDotToken,
+            ),
+          });
         }
       }
       return defaults.get(declaration);
+    }
+
+    function getDeclaration(
+      node: TSESTree.CallExpression | TSESTree.JSXOpeningElement,
+      calleeNode: TSESTree.Node,
+    ) {
+      const declaration = checker
+        .getResolvedSignature(services.esTreeNodeToTSNodeMap.get(node))
+        ?.getDeclaration();
+      const callee = unwrapParentheses(
+        services.esTreeNodeToTSNodeMap.get(calleeNode),
+      );
+      if (!declaration) {
+        return;
+      }
+      if (ts.isIdentifier(callee)) {
+        let symbol = checker.getSymbolAtLocation(callee);
+        if (symbol) {
+          if (!writes.has(symbol)) {
+            const variable = ASTUtils.findVariable(
+              context.sourceCode.getScope(node),
+              callee.text,
+            );
+            writes.set(
+              symbol,
+              variable?.references.some(
+                reference => reference.isWrite() && !reference.init,
+              ) ?? false,
+            );
+          }
+          if (writes.get(symbol)) {
+            return;
+          }
+        }
+        if (symbol && tsutils.isSymbolFlagSet(symbol, ts.SymbolFlags.Alias)) {
+          if (
+            declaration.getSourceFile() === callee.getSourceFile() ||
+            !symbol
+              .getDeclarations()
+              ?.every(
+                declaration =>
+                  ts.isImportSpecifier(declaration) ||
+                  ts.isImportClause(declaration),
+              )
+          ) {
+            return;
+          }
+          symbol = checker.getAliasedSymbol(symbol);
+        }
+        const binding = symbol?.valueDeclaration;
+        if (
+          binding !== declaration &&
+          (!binding ||
+            !ts.isVariableDeclaration(binding) ||
+            binding.type ||
+            !binding.initializer ||
+            unwrapParentheses(binding.initializer) !== declaration ||
+            !(binding.parent.flags & ts.NodeFlags.Const))
+        ) {
+          return;
+        }
+      } else if (callee !== declaration) {
+        return;
+      }
+      return declaration;
     }
 
     return {
@@ -283,9 +366,6 @@ export default createRule<[], MessageIds>({
         if (
           !node.arguments.length ||
           node.optional ||
-          node.arguments.some(
-            argument => argument.type === AST_NODE_TYPES.SpreadElement,
-          ) ||
           (node.callee.type !== AST_NODE_TYPES.Identifier &&
             node.callee.type !== AST_NODE_TYPES.FunctionExpression &&
             node.callee.type !== AST_NODE_TYPES.ArrowFunctionExpression)
@@ -303,74 +383,29 @@ export default createRule<[], MessageIds>({
         ) {
           return;
         }
-        const declaration = services
-          .getResolvedSignature(node)
-          ?.getDeclaration();
-        const callee = unwrapParentheses(
-          services.esTreeNodeToTSNodeMap.get(node.callee),
-        );
+        const declaration = getDeclaration(node, node.callee);
         if (!declaration) {
           return;
         }
-        if (ts.isIdentifier(callee)) {
-          let symbol = checker.getSymbolAtLocation(callee);
-          if (symbol) {
-            if (!writes.has(symbol)) {
-              const variable = ASTUtils.findVariable(
-                context.sourceCode.getScope(node),
-                callee.text,
-              );
-              writes.set(
-                symbol,
-                variable?.references.some(
-                  reference => reference.isWrite() && !reference.init,
-                ) ?? false,
-              );
-            }
-            if (writes.get(symbol)) {
-              return;
-            }
-          }
-          if (symbol && tsutils.isSymbolFlagSet(symbol, ts.SymbolFlags.Alias)) {
-            if (
-              declaration.getSourceFile() === callee.getSourceFile() ||
-              !symbol
-                .getDeclarations()
-                ?.every(
-                  declaration =>
-                    ts.isImportSpecifier(declaration) ||
-                    ts.isImportClause(declaration),
-                )
-            ) {
-              return;
-            }
-            symbol = checker.getAliasedSymbol(symbol);
-          }
-          const binding = symbol?.valueDeclaration;
-          if (
-            binding !== declaration &&
-            (!binding ||
-              !ts.isVariableDeclaration(binding) ||
-              binding.type ||
-              !binding.initializer ||
-              unwrapParentheses(binding.initializer) !== declaration ||
-              !(binding.parent.flags & ts.NodeFlags.Const))
-          ) {
-            return;
-          }
-        } else if (callee !== declaration) {
-          return;
-        }
         const metadata = getDefaults(declaration);
+        const spreadIndex = node.arguments.findIndex(
+          argument => argument.type === AST_NODE_TYPES.SpreadElement,
+        );
         if (
           !metadata ||
           node.arguments.length < metadata.minimumArguments ||
-          node.arguments.length > metadata.parameters.length
+          (metadata.restIndex === -1 &&
+            (spreadIndex !== -1 ||
+              node.arguments.length > metadata.parameters.length)) ||
+          (spreadIndex !== -1 && spreadIndex < metadata.restIndex)
         ) {
           return;
         }
         const { parameters } = metadata;
         for (const [index, argument] of node.arguments.entries()) {
+          if (index === metadata.restIndex || index === spreadIndex) {
+            break;
+          }
           const parameter = parameters[index].declaration;
           if (
             argument.type !== AST_NODE_TYPES.ObjectExpression ||
@@ -436,6 +471,9 @@ export default createRule<[], MessageIds>({
             });
           }
         }
+        if (metadata.restIndex !== -1 || spreadIndex !== -1) {
+          return;
+        }
         let first = node.arguments.length;
         while (first > 0) {
           const initializer = parameters[first - 1]?.value;
@@ -493,6 +531,103 @@ export default createRule<[], MessageIds>({
                 },
               ],
         });
+      },
+      JSXOpeningElement(node) {
+        if (
+          node.name.type !== AST_NODE_TYPES.JSXIdentifier ||
+          !/^[A-Z]/u.test(node.name.name) ||
+          !node.attributes.length
+        ) {
+          return;
+        }
+        const attributes = new Map<string, TSESTree.JSXAttribute>();
+        for (const attribute of node.attributes) {
+          if (
+            attribute.type !== AST_NODE_TYPES.JSXAttribute ||
+            attribute.name.type !== AST_NODE_TYPES.JSXIdentifier ||
+            attributes.has(attribute.name.name)
+          ) {
+            return;
+          }
+          attributes.set(attribute.name.name, attribute);
+        }
+        const declaration = getDeclaration(node, node.name);
+        if (!declaration) {
+          return;
+        }
+        const metadata = getDefaults(declaration);
+        if (metadata?.parameters.length !== 1) {
+          return;
+        }
+        const parameter = metadata.parameters[0];
+        if (!parameter.properties) {
+          return;
+        }
+        for (const [name, attribute] of attributes) {
+          if (name === 'key' || name === 'ref' || name === 'children') {
+            continue;
+          }
+          const initializer = parameter.properties.get(name);
+          const expression =
+            attribute.value?.type === AST_NODE_TYPES.JSXExpressionContainer
+              ? attribute.value.expression
+              : attribute.value;
+          const value = !expression
+            ? { value: true }
+            : expression.type === AST_NODE_TYPES.Literal &&
+                typeof expression.value === 'string'
+              ? { value: expression.value }
+              : readPrimitive(services.esTreeNodeToTSNodeMap.get(expression));
+          if (
+            !initializer ||
+            !value ||
+            !Object.is(initializer.value, value.value)
+          ) {
+            continue;
+          }
+          const type = getOptionalPropertyType(parameter.declaration, name);
+          if (
+            !type ||
+            !checker.isTypeAssignableTo(
+              expression
+                ? services.getTypeAtLocation(expression)
+                : checker.getTrueType(),
+              type,
+            )
+          ) {
+            continue;
+          }
+          if (
+            checker.getPropertyOfType(
+              services.getTypeAtLocation(node.name),
+              'defaultProps',
+            )
+          ) {
+            return;
+          }
+          const start = nullThrows(
+            context.sourceCode.getFirstToken(attribute),
+            NullThrowsReasons.MissingToken('attribute', 'JSX element'),
+          );
+          const end = nullThrows(
+            context.sourceCode.getLastToken(attribute),
+            NullThrowsReasons.MissingToken('attribute', 'JSX element'),
+          );
+          context.report({
+            node: attribute,
+            messageId: 'redundantProperty',
+            data: { name },
+            suggest: context.sourceCode.commentsExistBetween(start, end)
+              ? []
+              : [
+                  {
+                    messageId: 'removeProperty',
+                    data: { name },
+                    fix: fixer => fixer.remove(attribute),
+                  },
+                ],
+          });
+        }
       },
     };
   },

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-redundant-default-arguments.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-redundant-default-arguments.shot
@@ -16,6 +16,15 @@ function configure({ retries = 3 }: { retries?: number }) {
 configure({ retries: 3 });
             ~~~~~~~~~~ Property 'retries' matches its declared default value.
 
+Incorrect
+
+function Button({ enabled = true }) {
+  return <button disabled={!enabled} />;
+}
+
+<Button enabled />;
+        ~~~~~~~ Property 'enabled' matches its declared default value.
+
 Correct
 
 function select(value = 0) {
@@ -33,3 +42,12 @@ function configure({ retries = 3 }: { retries?: number }) {
 
 configure({});
 configure({ retries: 5 });
+
+Correct
+
+function Button({ enabled = true }) {
+  return <button disabled={!enabled} />;
+}
+
+<Button />;
+<Button enabled={false} />;

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-redundant-default-arguments.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-redundant-default-arguments.shot
@@ -1,0 +1,35 @@
+Incorrect
+
+function select(value = 0) {
+  return value;
+}
+
+select(0);
+       ~ These trailing arguments match their declared default values.
+
+Incorrect
+
+function configure({ retries = 3 }: { retries?: number }) {
+  return retries;
+}
+
+configure({ retries: 3 });
+            ~~~~~~~~~~ Property 'retries' matches its declared default value.
+
+Correct
+
+function select(value = 0) {
+  return value;
+}
+
+select();
+select(1);
+
+Correct
+
+function configure({ retries = 3 }: { retries?: number }) {
+  return retries;
+}
+
+configure({});
+configure({ retries: 5 });

--- a/packages/eslint-plugin/tests/fixtures/no-redundant-default-arguments/ambient.d.ts
+++ b/packages/eslint-plugin/tests/fixtures/no-redundant-default-arguments/ambient.d.ts
@@ -1,0 +1,1 @@
+export declare function select(value?: number): number;

--- a/packages/eslint-plugin/tests/fixtures/no-redundant-default-arguments/barrel.ts
+++ b/packages/eslint-plugin/tests/fixtures/no-redundant-default-arguments/barrel.ts
@@ -1,0 +1,1 @@
+export { select as forwarded } from './source';

--- a/packages/eslint-plugin/tests/fixtures/no-redundant-default-arguments/source.ts
+++ b/packages/eslint-plugin/tests/fixtures/no-redundant-default-arguments/source.ts
@@ -4,6 +4,12 @@ export function select(value = 0) {
 
 export const arrow = (value = 0) => value;
 
+// prettier-ignore
+export const parenthesizedArrow = (((value = 0) => value));
+
+// prettier-ignore
+export const parenthesizedExpression = (function (value = 0) { return value; });
+
 export const expression = function (value = 0) {
   return value;
 };

--- a/packages/eslint-plugin/tests/fixtures/no-redundant-default-arguments/source.ts
+++ b/packages/eslint-plugin/tests/fixtures/no-redundant-default-arguments/source.ts
@@ -1,0 +1,22 @@
+export function select(value = 0) {
+  return value;
+}
+
+export const arrow = (value = 0) => value;
+
+export const expression = function (value = 0) {
+  return value;
+};
+
+export function options({ value = 0 }: { value?: number }) {
+  return value;
+}
+
+export let mutable = (value = 0) => value;
+mutable = (value = 1) => value;
+
+export const conditional = Math.random() ? select : mutable;
+
+export default function defaultFunction(value = 0) {
+  return value;
+}

--- a/packages/eslint-plugin/tests/fixtures/no-redundant-default-arguments/source.ts
+++ b/packages/eslint-plugin/tests/fixtures/no-redundant-default-arguments/source.ts
@@ -18,6 +18,10 @@ export function options({ value = 0 }: { value?: number }) {
   return value;
 }
 
+export function Component({ value = 5 }) {
+  return null;
+}
+
 export let mutable = (value = 0) => value;
 mutable = (value = 1) => value;
 

--- a/packages/eslint-plugin/tests/fixtures/tsconfig.no-redundant-default-arguments.json
+++ b/packages/eslint-plugin/tests/fixtures/tsconfig.no-redundant-default-arguments.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "target": "es2020"
+  }
+}

--- a/packages/eslint-plugin/tests/rules/no-redundant-default-arguments.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-redundant-default-arguments.test.ts
@@ -7,6 +7,23 @@ const ruleTester = createRuleTesterWithTypes();
 
 ruleTester.run('no-redundant-default-arguments', rule, {
   valid: [
+    noFormat`
+const original = (value = 0) => value;
+const select = ((original));
+select(0);
+    `,
+    noFormat`
+const select = (((value = 0) => value) as (value?: number) => number);
+select(0);
+    `,
+    noFormat`
+const select = (((value = 0) => value) satisfies (value?: number) => number);
+select(0);
+    `,
+    noFormat`
+let select = (((value = 0) => value));
+select(0);
+    `,
     // A self-import must not hide an invalid local function reassignment.
     `
 import { select as imported } from './file';
@@ -396,6 +413,106 @@ selected(0);
     `,
   ],
   invalid: [
+    {
+      code: noFormat`
+const select = (function (value = 0) { return value; });
+select(0);
+      `,
+      errors: [
+        {
+          column: 8,
+          endColumn: 9,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantArguments',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+const select = (function (value = 0) { return value; });
+select();
+      `,
+            },
+          ],
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+import { parenthesizedArrow as select } from './no-redundant-default-arguments/source';
+select(0);
+      `,
+      errors: [
+        {
+          column: 8,
+          endColumn: 9,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantArguments',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+import { parenthesizedArrow as select } from './no-redundant-default-arguments/source';
+select();
+      `,
+            },
+          ],
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+import { parenthesizedExpression as select } from './no-redundant-default-arguments/source';
+select(0);
+      `,
+      errors: [
+        {
+          column: 8,
+          endColumn: 9,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantArguments',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+import { parenthesizedExpression as select } from './no-redundant-default-arguments/source';
+select();
+      `,
+            },
+          ],
+        },
+      ],
+      output: null,
+    },
+    {
+      code: noFormat`
+const select = (((value = 0) => value));
+select(0);
+      `,
+      errors: [
+        {
+          column: 8,
+          endColumn: 9,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantArguments',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+const select = (((value = 0) => value));
+select();
+      `,
+            },
+          ],
+        },
+      ],
+      output: null,
+    },
     {
       code: `
 function select({ first = 0, middle = 1, last = 2 }) {}

--- a/packages/eslint-plugin/tests/rules/no-redundant-default-arguments.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-redundant-default-arguments.test.ts
@@ -7,6 +7,206 @@ const ruleTester = createRuleTesterWithTypes();
 
 ruleTester.run('no-redundant-default-arguments', rule, {
   valid: [
+    {
+      code: `
+function Component({ value = 5 }) {
+  return null;
+}
+<Component value={6} />;
+      `,
+      languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+    },
+    {
+      code: `
+function Component({ value = 5 }) {
+  return null;
+}
+const value = 5;
+<Component value={value} />;
+      `,
+      languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+    },
+    {
+      code: `
+function Component({ value = 5 }) {
+  return null;
+}
+const props = { value: 6 };
+<Component {...props} value={5} />;
+      `,
+      languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+    },
+    {
+      code: `
+function Component({ value = 5 }) {
+  return null;
+}
+const props = { value: 6 };
+<Component value={5} {...props} />;
+      `,
+      languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+    },
+    {
+      code: `
+function div({ title = 'hello' }) {
+  return null;
+}
+<div title="hello" />;
+      `,
+      languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+    },
+    {
+      code: `
+const components = { Component: ({ value = 5 }) => null };
+<components.Component value={5} />;
+      `,
+      languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+    },
+    {
+      code: `
+declare const Component: (props: { value?: number }) => null;
+<Component value={5} />;
+      `,
+      languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+    },
+    {
+      code: `
+function Component({ value = 5 }: { value: number }) {
+  return null;
+}
+<Component value={5} />;
+      `,
+      languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+    },
+    {
+      code: `
+function Component<T>({ value = 5 }: { value?: number }) {
+  return null;
+}
+<Component value={5} />;
+      `,
+      languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+    },
+    {
+      code: `
+let Component = ({ value = 5 }) => null;
+<Component value={5} />;
+      `,
+      languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+    },
+    {
+      code: `
+function Component({ ref = null }) {
+  return null;
+}
+<Component ref={null} />;
+      `,
+      languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+    },
+    {
+      code: `
+function Component({ children = 'hello' }) {
+  return null;
+}
+<Component children="hello" />;
+      `,
+      languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+    },
+    {
+      code: `
+function Component({ value = 5 }) {
+  return null;
+}
+<Component />;
+      `,
+      languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+    },
+    {
+      code: `
+function Component(props: { value?: number }) {
+  return null;
+}
+<Component value={5} />;
+      `,
+      languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+    },
+    {
+      code: `
+function Component() {
+  return null;
+}
+<Component />;
+      `,
+      languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+    },
+    {
+      code: `
+function Component({ value = 5 }) {
+  return null;
+}
+<Component value={5 as number} />;
+      `,
+      languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+    },
+    {
+      code: `
+function Component({ enabled = false }) {
+  return null;
+}
+<Component enabled />;
+      `,
+      languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+    },
+    {
+      code: `
+function Component({ value = 5 }) {
+  return null;
+}
+<Component value={5} value={6} />;
+      `,
+      languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+    },
+    {
+      code: `
+function Component({ value = 5 }) {
+  return null;
+}
+Component.defaultProps = { value: 6 };
+<Component value={5} />;
+      `,
+      languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+    },
+    {
+      code: `
+function Component({ key = 'item' }) {
+  return null;
+}
+<Component key="item" />;
+      `,
+      languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+    },
+    `
+function select({ value = 5 }, ...rest: number[]) {}
+const values: [] = [];
+select(...values, { value: 5 });
+    `,
+    `
+function select(value = 5, ...rest: number[]) {}
+const values = [1, 2];
+select(5, ...values);
+    `,
+    `
+function select(...rest: { value?: number }[]) {}
+select({ value: 5 });
+    `,
+    `
+function select(value: number = 5 as const) {}
+select(4 as const);
+    `,
+    `
+function select(value = 5 as number) {}
+select(5 as const);
+    `,
     noFormat`
 const original = (value = 0) => value;
 const select = ((original));
@@ -413,6 +613,361 @@ selected(0);
     `,
   ],
   invalid: [
+    {
+      code: `
+function Component({ first = 1, second = 2 }) {
+  return null;
+}
+<Component first={1} second={2} />;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: { name: 'first' },
+          endColumn: 21,
+          endLine: 5,
+          line: 5,
+          messageId: 'redundantProperty',
+          suggestions: [
+            {
+              data: { name: 'first' },
+              messageId: 'removeProperty',
+              output: `
+function Component({ first = 1, second = 2 }) {
+  return null;
+}
+<Component  second={2} />;
+      `,
+            },
+          ],
+        },
+        {
+          column: 22,
+          data: { name: 'second' },
+          endColumn: 32,
+          endLine: 5,
+          line: 5,
+          messageId: 'redundantProperty',
+          suggestions: [
+            {
+              data: { name: 'second' },
+              messageId: 'removeProperty',
+              output: `
+function Component({ first = 1, second = 2 }) {
+  return null;
+}
+<Component first={1}  />;
+      `,
+            },
+          ],
+        },
+      ],
+      languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+      output: null,
+    },
+    {
+      code: `
+function select({ value = 5 }, ...rest: number[]) {}
+select({ value: 5 }, 1, 2);
+      `,
+      errors: [
+        {
+          column: 10,
+          data: { name: 'value' },
+          endColumn: 18,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantProperty',
+          suggestions: [
+            {
+              data: { name: 'value' },
+              messageId: 'removeProperty',
+              output: `
+function select({ value = 5 }, ...rest: number[]) {}
+select({  }, 1, 2);
+      `,
+            },
+          ],
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+import { Component } from './no-redundant-default-arguments/source';
+<Component value={5} />;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: { name: 'value' },
+          endColumn: 21,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantProperty',
+          suggestions: [
+            {
+              data: { name: 'value' },
+              messageId: 'removeProperty',
+              output: `
+import { Component } from './no-redundant-default-arguments/source';
+<Component  />;
+      `,
+            },
+          ],
+        },
+      ],
+      languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+      output: null,
+    },
+    {
+      code: `
+function Component({ value = 5 } = {}) {
+  return null;
+}
+<Component value={5}></Component>;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: { name: 'value' },
+          endColumn: 21,
+          endLine: 5,
+          line: 5,
+          messageId: 'redundantProperty',
+          suggestions: [
+            {
+              data: { name: 'value' },
+              messageId: 'removeProperty',
+              output: `
+function Component({ value = 5 } = {}) {
+  return null;
+}
+<Component ></Component>;
+      `,
+            },
+          ],
+        },
+      ],
+      languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+      output: null,
+    },
+    {
+      code: `
+const Component = function ({ label = 'a&b' }) {
+  return null;
+};
+<Component label="a&amp;b" />;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: { name: 'label' },
+          endColumn: 27,
+          endLine: 5,
+          line: 5,
+          messageId: 'redundantProperty',
+          suggestions: [
+            {
+              data: { name: 'label' },
+              messageId: 'removeProperty',
+              output: `
+const Component = function ({ label = 'a&b' }) {
+  return null;
+};
+<Component  />;
+      `,
+            },
+          ],
+        },
+      ],
+      languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+      output: null,
+    },
+    {
+      code: `
+function Component({ value = 5 }) {
+  return null;
+}
+<Component value={/* keep */ 5} />;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: { name: 'value' },
+          endColumn: 32,
+          endLine: 5,
+          line: 5,
+          messageId: 'redundantProperty',
+          suggestions: [],
+        },
+      ],
+      languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+      output: null,
+    },
+    {
+      code: `
+function Component({ enabled = true }) {
+  return null;
+}
+<Component enabled />;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: { name: 'enabled' },
+          endColumn: 19,
+          endLine: 5,
+          line: 5,
+          messageId: 'redundantProperty',
+          suggestions: [
+            {
+              data: { name: 'enabled' },
+              messageId: 'removeProperty',
+              output: `
+function Component({ enabled = true }) {
+  return null;
+}
+<Component  />;
+      `,
+            },
+          ],
+        },
+      ],
+      languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+      output: null,
+    },
+    {
+      code: `
+const Component = ({ label = 'hello' }) => null;
+<Component label="hello" />;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: { name: 'label' },
+          endColumn: 25,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantProperty',
+          suggestions: [
+            {
+              data: { name: 'label' },
+              messageId: 'removeProperty',
+              output: `
+const Component = ({ label = 'hello' }) => null;
+<Component  />;
+      `,
+            },
+          ],
+        },
+      ],
+      languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+      output: null,
+    },
+    {
+      code: `
+function Component({ value = 5 }) {
+  return null;
+}
+<Component value={5} />;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: { name: 'value' },
+          endColumn: 21,
+          endLine: 5,
+          line: 5,
+          messageId: 'redundantProperty',
+          suggestions: [
+            {
+              data: { name: 'value' },
+              messageId: 'removeProperty',
+              output: `
+function Component({ value = 5 }) {
+  return null;
+}
+<Component  />;
+      `,
+            },
+          ],
+        },
+      ],
+      languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+      output: null,
+    },
+    {
+      code: `
+function select({ value = 5 }, ...rest: number[]) {}
+const values = [1, 2];
+select({ value: 5 }, ...values);
+      `,
+      errors: [
+        {
+          column: 10,
+          data: { name: 'value' },
+          endColumn: 18,
+          endLine: 4,
+          line: 4,
+          messageId: 'redundantProperty',
+          suggestions: [
+            {
+              data: { name: 'value' },
+              messageId: 'removeProperty',
+              output: `
+function select({ value = 5 }, ...rest: number[]) {}
+const values = [1, 2];
+select({  }, ...values);
+      `,
+            },
+          ],
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+function select(value = 5 as const) {}
+select(5 /* keep */ as const);
+      `,
+      errors: [
+        {
+          column: 8,
+          endColumn: 29,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantArguments',
+          suggestions: [],
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+const select = (value = 5 as const) => value;
+select(5 as const);
+      `,
+      errors: [
+        {
+          column: 8,
+          endColumn: 18,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantArguments',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+const select = (value = 5 as const) => value;
+select();
+      `,
+            },
+          ],
+        },
+      ],
+      output: null,
+    },
     {
       code: noFormat`
 const select = (function (value = 0) { return value; });

--- a/packages/eslint-plugin/tests/rules/no-redundant-default-arguments.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-redundant-default-arguments.test.ts
@@ -1,0 +1,1534 @@
+import { noFormat } from '@typescript-eslint/rule-tester';
+
+import rule from '../../src/rules/no-redundant-default-arguments';
+import { createRuleTesterWithTypes } from '../RuleTester';
+
+const ruleTester = createRuleTesterWithTypes();
+
+ruleTester.run('no-redundant-default-arguments', rule, {
+  valid: [
+    // A self-import must not hide an invalid local function reassignment.
+    `
+import { select as imported } from './file';
+export function select(value = 0) {
+  return value;
+}
+select = (value = 1) => value;
+imported(0);
+    `,
+    `
+function select({ toString = 0 }) {
+  return toString;
+}
+select({ toString: 0 });
+    `,
+    `
+namespace Functions {
+  export function select(value = 0) {
+    return value;
+  }
+}
+Functions.select = (value = 1) => value;
+import select = Functions.select;
+select(0);
+    `,
+    {
+      code: `
+export {};
+function select(value = 0) {
+  return value;
+}
+const view = <div>{select(1)}</div>;
+      `,
+      languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+    },
+    // TypeScript error recovery must not expose implementation defaults as a valid call contract.
+    `
+function select(value: 1 = 0) {}
+select(0);
+    `,
+    `
+function select({ value = 0 }: { value?: 1 }) {}
+select({ value: 0 });
+    `,
+    `
+function select(value = 0) {}
+select(0, 1);
+    `,
+    `
+function select({ value = 0 }, required: number) {}
+select({ value: 0 });
+    `,
+    `
+declare const select: unknown;
+select(0);
+    `,
+    `
+import { select } from './missing-default-arguments-source';
+select(0);
+    `,
+    `
+function select({ value = 0 }) {}
+select({ value: 0, value: 1 });
+    `,
+    `
+function select({ value = 0, value: repeated = 1 }) {}
+select({ value: 0 });
+    `,
+    `
+function select(value = 0, other = arguments.length) {}
+select(0, 1);
+    `,
+    `
+import { select } from './no-redundant-default-arguments/ambient';
+select(0);
+    `,
+    `
+import { mutable } from './no-redundant-default-arguments/source';
+mutable(0);
+    `,
+    `
+import { conditional } from './no-redundant-default-arguments/source';
+conditional(0);
+    `,
+    `
+import * as source from './no-redundant-default-arguments/source';
+source.select(0);
+    `,
+    `
+function select(value = 0) {}
+select(1);
+    `,
+    `
+function select(value = 0) {
+  return arguments.length;
+}
+select(0);
+    `,
+    `
+let select = (value = 0) => value;
+select = (value = 1) => value;
+select(0);
+    `,
+    `
+function select(value = 0) {}
+select = (value = 1) => {};
+select(0);
+    `,
+    `
+function select<T>(value = 0) {}
+select(0);
+    `,
+    `
+function select({ value = 0 }: { value: number }) {}
+select({ value: 0 });
+    `,
+    `
+function select(value = 0) {}
+select();
+    `,
+    `
+function select(value: number) {}
+select(0);
+    `,
+    `
+function select(first = 0, second = 1) {}
+select(0, 2);
+    `,
+    `
+const select = (value = 0) => value;
+const alias = select;
+alias(0);
+    `,
+    `
+const select: (value?: number) => number = (value = 0) => value;
+select(0);
+    `,
+    `
+const select: typeof original = (value = 0) => value;
+function original(value = 0) {
+  return value;
+}
+select(0);
+    `,
+    `
+function select(value = 0) {}
+function invoke(callback: typeof select) {
+  callback(0);
+}
+    `,
+    `
+const select = (value = 0) => value;
+function factory() {
+  return select;
+}
+factory()(0);
+    `,
+    `
+const object = { select(value = 0) {} };
+object.select(0);
+    `,
+    `
+class Base {
+  select(value = 0) {}
+}
+class Child extends Base {
+  override select(value = 1) {}
+}
+const object: Base = new Child();
+object.select(0);
+    `,
+    `
+const object = Math.random()
+  ? { select(value = 0) {} }
+  : { select(value = 1) {} };
+object.select(0);
+    `,
+    `
+function select(value = 0) {}
+select?.(0);
+    `,
+    `
+function select(value = 0) {}
+select(...[0]);
+    `,
+    `
+function select(value = 0, ...rest: number[]) {}
+select(0);
+    `,
+    `
+function select<T>() {
+  function inner(value = 0) {}
+  inner(0);
+}
+    `,
+    `
+class Container<T> {
+  run() {
+    function select(value = 0) {}
+    select(0);
+  }
+}
+    `,
+    `
+function select(value: number): number;
+function select(): string;
+function select(value = 0): number | string {
+  return value;
+}
+select(0);
+    `,
+    `
+function select<T = string>(value: T = '' as T): T {
+  return value;
+}
+select('');
+    `,
+    `
+function select<T extends { value?: number }>({ value = 0 }: T) {}
+select({ value: 0 });
+    `,
+    `
+function first(value = 0) {}
+function second(value = 1) {}
+declare const select: typeof first | typeof second;
+select(0);
+    `,
+    `
+function first(value = 0) {}
+function second(value = 1) {}
+declare const select: typeof first & typeof second;
+select(0);
+    `,
+    `
+declare function select(value?: number): void;
+select(0);
+    `,
+    `
+declare const select: any;
+select(0);
+    `,
+    `
+function select(value = -0) {}
+select(0);
+    `,
+    `
+function select(value = 0) {}
+select(-0);
+    `,
+    `
+function select(value = undefined) {}
+select(undefined);
+    `,
+    `
+function outer(undefined: number) {
+  function select(value = undefined) {}
+  select(undefined);
+}
+    `,
+    `
+function select(value = void 0) {}
+select(void 0);
+    `,
+    `
+const value = 0;
+function select(input = value) {}
+select(0);
+    `,
+    `
+function select(value = 0) {}
+select(0 as number);
+    `,
+    `
+function select(value = 0) {}
+select(0!);
+    `,
+    `
+function select(value = 0) {}
+select(0 satisfies number);
+    `,
+    `
+function select(value = 0) {}
+select(Number(0));
+    `,
+    `
+function select(value = /pattern/) {}
+select(/pattern/);
+    `,
+    `
+function select(value = [0]) {}
+select([0]);
+    `,
+    `
+function select(value = {}) {}
+select({});
+    `,
+    `
+function select({ value = 0 }) {}
+select({ value: 1 });
+    `,
+    `
+function select({ value = 0 }) {}
+select({ value: 0, ...{} });
+    `,
+    `
+function select({ value = 0 }) {}
+select({ ['value']: 0 });
+    `,
+    `
+function select({ value = 0 }) {}
+select({
+  get value() {
+    return 0;
+  },
+});
+    `,
+    `
+function select({ value = 0 }) {}
+const value = 0;
+select({ value });
+    `,
+    `
+function select({ ['value']: value = 0 }) {}
+select({ value: 0 });
+    `,
+    `
+function select({ 0: value = 0 }) {}
+select({ 0: 0 });
+    `,
+    `
+function select({ value: { inner = 0 } }) {}
+select({ value: { inner: 0 } });
+    `,
+    `
+function select({ value = 0, ...rest }) {}
+select({ value: 0 });
+    `,
+    `
+function select({ __proto__ = 0 }) {}
+select({ __proto__: 0 });
+    `,
+    `
+function select({
+  value = 0,
+}: { value?: number } | { value?: number; other?: string }) {}
+select({ value: 0 });
+    `,
+    `
+function select({ value = 0 }: { value?: number } & { other?: string }) {}
+select({ value: 0 });
+    `,
+    `
+function select({ value = 0 }: any) {}
+select({ value: 0 });
+    `,
+    `
+function select(value = 0) {
+  return () => arguments.length;
+}
+select(0);
+    `,
+    `
+function select(value = 0) {
+  return eval('value');
+}
+select(0);
+    `,
+    `
+function select(value = 0) {
+  function nested() {
+    return arguments.length;
+  }
+}
+select(0);
+    `,
+    `
+function select(value = 0) {
+  const object = { eval: value };
+}
+select(0);
+    `,
+    `
+const first = (value = 0) => value;
+const second = (value = 1) => value;
+const selected = Math.random() ? first : second;
+selected(0);
+    `,
+  ],
+  invalid: [
+    {
+      code: `
+function select({ first = 0, middle = 1, last = 2 }) {}
+select({ first: 3, middle: 1, last: 4 });
+      `,
+      errors: [
+        {
+          column: 20,
+          data: { name: 'middle' },
+          endColumn: 29,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantProperty',
+          suggestions: [
+            {
+              data: { name: 'middle' },
+              messageId: 'removeProperty',
+              output: `
+function select({ first = 0, middle = 1, last = 2 }) {}
+select({ first: 3,  last: 4 });
+      `,
+            },
+          ],
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+function select({ value = 0, other = 1 }) {}
+select({ value: 0 /* keep */, other: 2 });
+      `,
+      errors: [
+        {
+          column: 10,
+          data: { name: 'value' },
+          endColumn: 18,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantProperty',
+          suggestions: [],
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+function select(first: number, second = 1) {}
+select(0, /* keep */ 1);
+      `,
+      errors: [
+        {
+          column: 22,
+          endColumn: 23,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantArguments',
+          suggestions: [],
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+function select({ value = 0 }, trailing = 1) {}
+const value = 0;
+select({ value }, 1);
+      `,
+      errors: [
+        {
+          column: 19,
+          endColumn: 20,
+          endLine: 4,
+          line: 4,
+          messageId: 'redundantArguments',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+function select({ value = 0 }, trailing = 1) {}
+const value = 0;
+select({ value });
+      `,
+            },
+          ],
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+import {
+  options,
+  options as renamed,
+} from './no-redundant-default-arguments/source';
+options({ value: 0 });
+renamed({ value: 0 });
+      `,
+      errors: [
+        {
+          column: 11,
+          data: { name: 'value' },
+          endColumn: 19,
+          endLine: 6,
+          line: 6,
+          messageId: 'redundantProperty',
+          suggestions: [
+            {
+              data: { name: 'value' },
+              messageId: 'removeProperty',
+              output: `
+import {
+  options,
+  options as renamed,
+} from './no-redundant-default-arguments/source';
+options({  });
+renamed({ value: 0 });
+      `,
+            },
+          ],
+        },
+        {
+          column: 11,
+          data: { name: 'value' },
+          endColumn: 19,
+          endLine: 7,
+          line: 7,
+          messageId: 'redundantProperty',
+          suggestions: [
+            {
+              data: { name: 'value' },
+              messageId: 'removeProperty',
+              output: `
+import {
+  options,
+  options as renamed,
+} from './no-redundant-default-arguments/source';
+options({ value: 0 });
+renamed({  });
+      `,
+            },
+          ],
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+import { arrow, select } from './no-redundant-default-arguments/source';
+arrow(0);
+select(0);
+      `,
+      errors: [
+        {
+          column: 7,
+          endColumn: 8,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantArguments',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+import { arrow, select } from './no-redundant-default-arguments/source';
+arrow();
+select(0);
+      `,
+            },
+          ],
+        },
+        {
+          column: 8,
+          endColumn: 9,
+          endLine: 4,
+          line: 4,
+          messageId: 'redundantArguments',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+import { arrow, select } from './no-redundant-default-arguments/source';
+arrow(0);
+select();
+      `,
+            },
+          ],
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+function select({ value = 0, other = 1 }) {}
+select({ value: 0, other: 1 });
+      `,
+      errors: [
+        {
+          column: 10,
+          data: { name: 'value' },
+          endColumn: 18,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantProperty',
+          suggestions: [
+            {
+              data: { name: 'value' },
+              messageId: 'removeProperty',
+              output: `
+function select({ value = 0, other = 1 }) {}
+select({  other: 1 });
+      `,
+            },
+          ],
+        },
+        {
+          column: 20,
+          data: { name: 'other' },
+          endColumn: 28,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantProperty',
+          suggestions: [
+            {
+              data: { name: 'other' },
+              messageId: 'removeProperty',
+              output: `
+function select({ value = 0, other = 1 }) {}
+select({ value: 0 });
+      `,
+            },
+          ],
+        },
+      ],
+      output: null,
+    },
+    {
+      code: noFormat`
+function select(value = (0)) {}
+select(0);
+      `,
+      errors: [
+        {
+          column: 8,
+          endColumn: 9,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantArguments',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+function select(value = (0)) {}
+select();
+      `,
+            },
+          ],
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+const select = (value = 0) => value;
+select(0);
+      `,
+      errors: [
+        {
+          column: 8,
+          endColumn: 9,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantArguments',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+const select = (value = 0) => value;
+select();
+      `,
+            },
+          ],
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+const select = function (value = 0) {
+  return value;
+};
+select(0);
+      `,
+      errors: [
+        {
+          column: 8,
+          endColumn: 9,
+          endLine: 5,
+          line: 5,
+          messageId: 'redundantArguments',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+const select = function (value = 0) {
+  return value;
+};
+select();
+      `,
+            },
+          ],
+        },
+      ],
+      output: null,
+    },
+    {
+      code: '(function (value = 0) {})(0);',
+      errors: [
+        {
+          column: 27,
+          endColumn: 28,
+          endLine: 1,
+          line: 1,
+          messageId: 'redundantArguments',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: '(function (value = 0) {})();',
+            },
+          ],
+        },
+      ],
+      output: null,
+    },
+    {
+      code: '((value = 0) => value)(0);',
+      errors: [
+        {
+          column: 24,
+          endColumn: 25,
+          endLine: 1,
+          line: 1,
+          messageId: 'redundantArguments',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: '((value = 0) => value)();',
+            },
+          ],
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+select(0);
+function select(value = 0) {}
+      `,
+      errors: [
+        {
+          column: 8,
+          endColumn: 9,
+          endLine: 2,
+          line: 2,
+          messageId: 'redundantArguments',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+select();
+function select(value = 0) {}
+      `,
+            },
+          ],
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+function select(value = 1) {}
+function outer() {
+  function select(value = 0) {}
+  select(0);
+}
+      `,
+      errors: [
+        {
+          column: 10,
+          endColumn: 11,
+          endLine: 5,
+          line: 5,
+          messageId: 'redundantArguments',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+function select(value = 1) {}
+function outer() {
+  function select(value = 0) {}
+  select();
+}
+      `,
+            },
+          ],
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+import { select } from './no-redundant-default-arguments/source';
+select(0);
+      `,
+      errors: [
+        {
+          column: 8,
+          endColumn: 9,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantArguments',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+import { select } from './no-redundant-default-arguments/source';
+select();
+      `,
+            },
+          ],
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+import select from './no-redundant-default-arguments/source';
+select(0);
+      `,
+      errors: [
+        {
+          column: 8,
+          endColumn: 9,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantArguments',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+import select from './no-redundant-default-arguments/source';
+select();
+      `,
+            },
+          ],
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+import { forwarded } from './no-redundant-default-arguments/barrel';
+forwarded(0);
+      `,
+      errors: [
+        {
+          column: 11,
+          endColumn: 12,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantArguments',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+import { forwarded } from './no-redundant-default-arguments/barrel';
+forwarded();
+      `,
+            },
+          ],
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+import { arrow } from './no-redundant-default-arguments/source';
+arrow(0);
+      `,
+      errors: [
+        {
+          column: 7,
+          endColumn: 8,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantArguments',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+import { arrow } from './no-redundant-default-arguments/source';
+arrow();
+      `,
+            },
+          ],
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+import { expression } from './no-redundant-default-arguments/source';
+expression(0);
+      `,
+      errors: [
+        {
+          column: 12,
+          endColumn: 13,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantArguments',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+import { expression } from './no-redundant-default-arguments/source';
+expression();
+      `,
+            },
+          ],
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+import { options } from './no-redundant-default-arguments/source';
+options({ value: 0 });
+      `,
+      errors: [
+        {
+          column: 11,
+          data: { name: 'value' },
+          endColumn: 19,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantProperty',
+          suggestions: [
+            {
+              data: { name: 'value' },
+              messageId: 'removeProperty',
+              output: `
+import { options } from './no-redundant-default-arguments/source';
+options({  });
+      `,
+            },
+          ],
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+function select(value = 0) {}
+select(0);
+function invoke(callback: typeof select) {
+  callback(0);
+}
+      `,
+      errors: [
+        {
+          column: 8,
+          endColumn: 9,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantArguments',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+function select(value = 0) {}
+select();
+function invoke(callback: typeof select) {
+  callback(0);
+}
+      `,
+            },
+          ],
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+function select(value = 0) {}
+function invoke(callback: typeof select) {
+  callback(0);
+}
+select(0);
+      `,
+      errors: [
+        {
+          column: 8,
+          endColumn: 9,
+          endLine: 6,
+          line: 6,
+          messageId: 'redundantArguments',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+function select(value = 0) {}
+function invoke(callback: typeof select) {
+  callback(0);
+}
+select();
+      `,
+            },
+          ],
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+function select({ value: renamed = 0 }) {}
+select({ value: 0 });
+      `,
+      errors: [
+        {
+          column: 10,
+          data: { name: 'value' },
+          endColumn: 18,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantProperty',
+          suggestions: [
+            {
+              data: { name: 'value' },
+              messageId: 'removeProperty',
+              output: `
+function select({ value: renamed = 0 }) {}
+select({  });
+      `,
+            },
+          ],
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+function select({ value = 0, other = 1 }) {}
+select({ value: 0, other: 2 });
+      `,
+      errors: [
+        {
+          column: 10,
+          data: { name: 'value' },
+          endColumn: 18,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantProperty',
+          suggestions: [
+            {
+              data: { name: 'value' },
+              messageId: 'removeProperty',
+              output: `
+function select({ value = 0, other = 1 }) {}
+select({  other: 2 });
+      `,
+            },
+          ],
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+function select({ value = 0 }) {}
+select({ value: /* keep */ 0 });
+      `,
+      errors: [
+        {
+          column: 10,
+          data: { name: 'value' },
+          endColumn: 29,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantProperty',
+          suggestions: [],
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+export {};
+function select(value = 0) {
+  return value;
+}
+const view = <div>{select(0)}</div>;
+      `,
+      errors: [
+        {
+          column: 27,
+          endColumn: 28,
+          endLine: 6,
+          line: 6,
+          messageId: 'redundantArguments',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+export {};
+function select(value = 0) {
+  return value;
+}
+const view = <div>{select()}</div>;
+      `,
+            },
+          ],
+        },
+      ],
+      languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+      output: null,
+    },
+    {
+      code: `
+import { select as renamed } from './no-redundant-default-arguments/source';
+renamed(0);
+      `,
+      errors: [
+        {
+          column: 9,
+          endColumn: 10,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantArguments',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+import { select as renamed } from './no-redundant-default-arguments/source';
+renamed();
+      `,
+            },
+          ],
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+function select(this: void, value = 0) {}
+select(0);
+      `,
+      errors: [
+        {
+          column: 8,
+          endColumn: 9,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantArguments',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+function select(this: void, value = 0) {}
+select();
+      `,
+            },
+          ],
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+function select(value = true) {}
+select(true);
+      `,
+      errors: [
+        {
+          column: 8,
+          endColumn: 12,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantArguments',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+function select(value = true) {}
+select();
+      `,
+            },
+          ],
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+function select(value = false) {}
+select(false);
+      `,
+      errors: [
+        {
+          column: 8,
+          endColumn: 13,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantArguments',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+function select(value = false) {}
+select();
+      `,
+            },
+          ],
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+function select(value = null) {}
+select(null);
+      `,
+      errors: [
+        {
+          column: 8,
+          endColumn: 12,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantArguments',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+function select(value = null) {}
+select();
+      `,
+            },
+          ],
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+function select(value = 0x10n) {}
+select(16n);
+      `,
+      errors: [
+        {
+          column: 8,
+          endColumn: 11,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantArguments',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+function select(value = 0x10n) {}
+select();
+      `,
+            },
+          ],
+        },
+      ],
+      languageOptions: {
+        parserOptions: {
+          project: './tsconfig.no-redundant-default-arguments.json',
+          projectService: false,
+        },
+      },
+      output: null,
+    },
+    {
+      code: `
+function select(value = -1n) {}
+select(-1n);
+      `,
+      errors: [
+        {
+          column: 8,
+          endColumn: 11,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantArguments',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+function select(value = -1n) {}
+select();
+      `,
+            },
+          ],
+        },
+      ],
+      languageOptions: {
+        parserOptions: {
+          project: './tsconfig.no-redundant-default-arguments.json',
+          projectService: false,
+        },
+      },
+      output: null,
+    },
+    {
+      code: `
+function select(value = -0) {}
+select(-0);
+      `,
+      errors: [
+        {
+          column: 8,
+          endColumn: 10,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantArguments',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+function select(value = -0) {}
+select();
+      `,
+            },
+          ],
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+function select(value = +1) {}
+select(1);
+      `,
+      errors: [
+        {
+          column: 8,
+          endColumn: 9,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantArguments',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+function select(value = +1) {}
+select();
+      `,
+            },
+          ],
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+function select({ value = 0, other = 1 }) {}
+select({ value: 2, other: 1 });
+      `,
+      errors: [
+        {
+          column: 20,
+          data: { name: 'other' },
+          endColumn: 28,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantProperty',
+          suggestions: [
+            {
+              data: { name: 'other' },
+              messageId: 'removeProperty',
+              output: `
+function select({ value = 0, other = 1 }) {}
+select({ value: 2 });
+      `,
+            },
+          ],
+        },
+      ],
+      output: null,
+    },
+    {
+      code: noFormat`
+function select(value = 0) {}
+select((/* keep */ 0));
+      `,
+      errors: [
+        {
+          column: 20,
+          endColumn: 21,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantArguments',
+          suggestions: [],
+        },
+      ],
+      output: null,
+    },
+    {
+      code: noFormat`
+function select(first = 0, second = 1) {}
+select(2, (1),);
+      `,
+      errors: [
+        {
+          column: 12,
+          endColumn: 13,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantArguments',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+function select(first = 0, second = 1) {}
+select(2);
+      `,
+            },
+          ],
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+function select({ value = 0 }) {}
+select({ value: 0 });
+      `,
+      errors: [
+        {
+          column: 10,
+          data: { name: 'value' },
+          endColumn: 18,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantProperty',
+          suggestions: [
+            {
+              data: { name: 'value' },
+              messageId: 'removeProperty',
+              output: `
+function select({ value = 0 }) {}
+select({  });
+      `,
+            },
+          ],
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+function select(value = 'ready') {}
+select(\`ready\`);
+      `,
+      errors: [
+        {
+          column: 8,
+          endColumn: 15,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantArguments',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+function select(value = 'ready') {}
+select();
+      `,
+            },
+          ],
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+function select(first = 0, second = 1) {}
+select(0, 1);
+      `,
+      errors: [
+        {
+          column: 8,
+          endColumn: 12,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantArguments',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+function select(first = 0, second = 1) {}
+select();
+      `,
+            },
+          ],
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+function select(value = 0) {}
+select(0);
+      `,
+      errors: [
+        {
+          column: 8,
+          endColumn: 9,
+          endLine: 3,
+          line: 3,
+          messageId: 'redundantArguments',
+          suggestions: [
+            {
+              messageId: 'removeArguments',
+              output: `
+function select(value = 0) {}
+select();
+      `,
+            },
+          ],
+        },
+      ],
+      output: null,
+    },
+  ],
+});

--- a/packages/eslint-plugin/tests/schema-snapshots/no-redundant-default-arguments.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-redundant-default-arguments.shot
@@ -1,0 +1,10 @@
+
+# SCHEMA:
+
+[]
+
+
+# TYPES:
+
+/** No options declared */
+type Options = [];


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #12782
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

This PR adds the type-aware `no-redundant-default-arguments` rule, which detects explicitly passed values that match their declared defaults.

The rule supports redundant trailing arguments, optional properties in destructured object parameters, and JSX props, including supported imported and cross-file cases.

It provides editor suggestions rather than automatic fixes. The implementation is intentionally conservative in cases where removing a value could change runtime behavior. Suggestions preserve comments and argument positions, retain required properties, and avoid ambiguous function origins and other unsafe cases.

This PR also includes the rule registration, configuration updates, documentation, test fixtures, and docs/schema snapshots.

Validation completed locally:

- 164 focused rule tests passed.
- Full unit and integration test suites passed.
- Build, ESLint, formatting, spelling, Markdown, Stylelint, Knip, typechecking, package typing, and dependency checks passed.
- Config and docs/schema regeneration produced no unexpected changes.
- Focused rule coverage reached 99.52% lines and 97.59% branches.

Areas where maintainer review would be particularly useful are function-origin resolution and the safety checks around argument, object-property, and JSX-prop omission.

Local validation was run on Windows with Node 24. The GitHub CI matrix remains to run.