### PR TITLE
fix(eslint-plugin): [no-unused-vars] track type and value exports separately

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unused-vars.ts
+++ b/packages/eslint-plugin/src/rules/no-unused-vars.ts
@@ -21,6 +21,7 @@ import {
   collectVariables,
   createRule,
   getNameLocationInGlobalDirectiveComment,
+  getUnusedDefinitionForPartiallyExportedVariable,
   isDefinitionFile,
   isFunction,
   nullThrows,
@@ -313,6 +314,7 @@ export default createRule<Options, MessageIds>({
         messageId: MessageIds;
         node?: TSESTree.Node;
       },
+      definition?: Definition,
     ) => {
       reportedUnusedVariables.add(unusedVar);
 
@@ -322,9 +324,12 @@ export default createRule<Options, MessageIds>({
           ref.from.variableScope === unusedVar.scope.variableScope,
       );
 
-      const id = writeReferences.length
-        ? writeReferences[writeReferences.length - 1].identifier
-        : unusedVar.identifiers[0];
+      const id =
+        definition?.name.type === AST_NODE_TYPES.Identifier
+          ? definition.name
+          : writeReferences.length
+            ? writeReferences[writeReferences.length - 1].identifier
+            : unusedVar.identifiers[0];
 
       const { start } = id.loc;
       const idLength = id.name.length;
@@ -842,8 +847,9 @@ export default createRule<Options, MessageIds>({
      */
     function getDefinedMessageData(
       unusedVar: ScopeVariable,
+      definition?: Definition,
     ): Record<string, unknown> {
-      const def = unusedVar.defs.at(0);
+      const def = definition ?? unusedVar.defs.at(0);
       let additionalMessageData = '';
 
       if (def) {
@@ -871,8 +877,9 @@ export default createRule<Options, MessageIds>({
      */
     function getAssignedMessageData(
       unusedVar: ScopeVariable,
+      definition?: Definition,
     ): Record<string, unknown> {
-      const def = unusedVar.defs.at(0);
+      const def = definition ?? unusedVar.defs.at(0);
       let additionalMessageData = '';
 
       if (def) {
@@ -918,7 +925,10 @@ export default createRule<Options, MessageIds>({
       };
     }
 
-    function collectUnusedVariables(): ScopeVariable[] {
+    function collectUnusedVariables(): {
+      definition?: Definition;
+      variable: ScopeVariable;
+    }[] {
       /**
        * Checks whether a node is a sibling of the rest property or not.
        * @param node a node to check
@@ -980,12 +990,15 @@ export default createRule<Options, MessageIds>({
           variable,
         })),
       ];
-      const unusedVariablesReturn: ScopeVariable[] = [];
+      const unusedVariablesReturn: {
+        definition?: Definition;
+        variable: ScopeVariable;
+      }[] = [];
       for (const { used, variable } of variables) {
         // explicit global variables don't have definitions.
         if (variable.defs.length === 0) {
           if (!used) {
-            unusedVariablesReturn.push(variable);
+            unusedVariablesReturn.push({ variable });
           }
 
           continue;
@@ -1119,8 +1132,16 @@ export default createRule<Options, MessageIds>({
           continue;
         }
 
-        if (!used) {
-          unusedVariablesReturn.push(variable);
+        const partiallyUnusedDefinition = used
+          ? getUnusedDefinitionForPartiallyExportedVariable(variable)
+          : null;
+        if (partiallyUnusedDefinition) {
+          unusedVariablesReturn.push({
+            definition: partiallyUnusedDefinition,
+            variable,
+          });
+        } else if (!used) {
+          unusedVariablesReturn.push({ variable });
         }
       }
 
@@ -1203,14 +1224,15 @@ export default createRule<Options, MessageIds>({
       'Program:exit'(programNode): void {
         const unusedVars = collectUnusedVariables();
 
-        for (const unusedVar of unusedVars) {
-          // Report the first declaration.
+        for (const { definition, variable: unusedVar } of unusedVars) {
           if (unusedVar.defs.length > 0) {
-            const usedOnlyAsType = unusedVar.references.some(
-              ref =>
-                referenceContainsTypeQuery(ref.identifier) ||
-                referenceContainsTypePredicate(ref.identifier),
-            );
+            const usedOnlyAsType =
+              (definition == null || definition.isVariableDefinition) &&
+              unusedVar.references.some(
+                ref =>
+                  referenceContainsTypeQuery(ref.identifier) ||
+                  referenceContainsTypePredicate(ref.identifier),
+              );
             const messageId = usedOnlyAsType ? 'usedOnlyAsType' : 'unusedVar';
 
             const isImportUsedOnlyAsType =
@@ -1222,12 +1244,19 @@ export default createRule<Options, MessageIds>({
               continue;
             }
 
-            report(unusedVar, {
-              messageId,
-              data: unusedVar.references.some(ref => ref.isWrite())
-                ? getAssignedMessageData(unusedVar)
-                : getDefinedMessageData(unusedVar),
-            });
+            const isAssigned =
+              (definition == null || definition.isVariableDefinition) &&
+              unusedVar.references.some(ref => ref.isWrite());
+            report(
+              unusedVar,
+              {
+                messageId,
+                data: isAssigned
+                  ? getAssignedMessageData(unusedVar, definition)
+                  : getDefinedMessageData(unusedVar, definition),
+              },
+              definition,
+            );
 
             // If there are no regular declaration, report the first `/*globals*/` comment directive.
           } else if (

--- a/packages/eslint-plugin/src/util/collectUnusedVariables.ts
+++ b/packages/eslint-plugin/src/util/collectUnusedVariables.ts
@@ -1,4 +1,5 @@
 import type {
+  Definition,
   ScopeManager,
   ScopeVariable,
 } from '@typescript-eslint/scope-manager';
@@ -425,24 +426,27 @@ const MERGEABLE_TYPES = new Set([
  */
 function isMergeableExported(variable: ScopeVariable): boolean {
   // If all of the merged things are of the same type, TS will error if not all of them are exported - so we only need to find one
-  for (const def of variable.defs) {
-    // parameters can never be exported.
-    // their `node` prop points to the function decl, which can be exported
-    // so we need to special case them
-    if (def.type === TSESLint.Scope.DefinitionType.Parameter) {
-      continue;
-    }
+  return variable.defs.some(
+    definition =>
+      isDefinitionDirectlyExported(definition) &&
+      (MERGEABLE_TYPES.has(definition.node.type) ||
+        definition.node.parent.type ===
+          AST_NODE_TYPES.ExportDefaultDeclaration),
+  );
+}
 
-    if (
-      (MERGEABLE_TYPES.has(def.node.type) &&
-        def.node.parent.type === AST_NODE_TYPES.ExportNamedDeclaration) ||
-      def.node.parent.type === AST_NODE_TYPES.ExportDefaultDeclaration
-    ) {
-      return true;
-    }
+function isDefinitionDirectlyExported(definition: Definition): boolean {
+  // Parameters can never be exported, but their node points to the containing
+  // function declaration, which can be exported.
+  if (definition.type === TSESLint.Scope.DefinitionType.Parameter) {
+    return false;
   }
 
-  return false;
+  const node =
+    definition.node.type === AST_NODE_TYPES.VariableDeclarator
+      ? definition.node.parent
+      : definition.node;
+  return node.parent.type.startsWith('Export');
 }
 
 /**
@@ -451,17 +455,7 @@ function isMergeableExported(variable: ScopeVariable): boolean {
  * @returns True if the variable is exported, false if not.
  */
 function isExported(variable: ScopeVariable): boolean {
-  return variable.defs.some(definition => {
-    let node = definition.node;
-
-    if (node.type === AST_NODE_TYPES.VariableDeclarator) {
-      node = node.parent;
-    } else if (definition.type === TSESLint.Scope.DefinitionType.Parameter) {
-      return false;
-    }
-
-    return node.parent.type.startsWith('Export');
-  });
+  return variable.defs.some(isDefinitionDirectlyExported);
 }
 
 const LOGICAL_ASSIGNMENT_OPERATORS = new Set(['??=', '&&=', '||=']);
@@ -471,7 +465,10 @@ const LOGICAL_ASSIGNMENT_OPERATORS = new Set(['??=', '&&=', '||=']);
  * @param variable The variable to check.
  * @returns True if the variable is used
  */
-function isUsedVariable(variable: ScopeVariable): boolean {
+function isUsedVariable(
+  variable: ScopeVariable,
+  namespace?: 'type' | 'value',
+): boolean {
   /**
    * Gets a list of function definitions for a specified variable.
    * @param variable eslint-scope variable object.
@@ -801,12 +798,78 @@ function isUsedVariable(variable: ScopeVariable): boolean {
       !(isFunctionDefinition && isSelfReference(ref, functionNodes)) &&
       !(isTypeDecl && isInsideOneOf(ref, typeDeclNodes)) &&
       !(isModuleDecl && isSelfReference(ref, moduleDeclNodes)) &&
-      !(isEnumDecl && isSelfReference(ref, enumDeclNodes))
+      !(isEnumDecl && isSelfReference(ref, enumDeclNodes)) &&
+      (namespace == null ||
+        (namespace === 'type' ? ref.isTypeReference : ref.isValueReference))
     );
   });
 }
 
 //#endregion private helpers
+
+/**
+ * Finds the unused type or value declaration when same-named declarations use
+ * separate TypeScript namespaces and an export exposes only one namespace.
+ *
+ * Declarations such as classes that occupy both namespaces are treated as one
+ * definition and are excluded from this check.
+ */
+export function getUnusedDefinitionForPartiallyExportedVariable(
+  variable: ScopeVariable,
+): Definition | null {
+  if (variable.defs.length < 2) {
+    return null;
+  }
+
+  const typeOnlyDefinition = variable.defs.find(
+    def => def.isTypeDefinition && !def.isVariableDefinition,
+  );
+  const valueOnlyDefinition = variable.defs.find(
+    def => !def.isTypeDefinition && def.isVariableDefinition,
+  );
+
+  if (!typeOnlyDefinition || !valueOnlyDefinition) {
+    return null;
+  }
+
+  let hasExport = false;
+  let typeDefinitionsExported = false;
+  let valueDefinitionsExported = false;
+  for (const definition of variable.defs) {
+    if (isDefinitionDirectlyExported(definition)) {
+      hasExport = true;
+      typeDefinitionsExported ||= definition.isTypeDefinition;
+      valueDefinitionsExported ||= definition.isVariableDefinition;
+    }
+  }
+  for (const reference of variable.references) {
+    if (
+      reference.identifier.parent.type === AST_NODE_TYPES.ExportSpecifier ||
+      reference.identifier.parent.type ===
+        AST_NODE_TYPES.ExportDefaultDeclaration ||
+      reference.identifier.parent.type === AST_NODE_TYPES.TSExportAssignment
+    ) {
+      hasExport = true;
+      typeDefinitionsExported ||= reference.isTypeReference;
+      valueDefinitionsExported ||= reference.isValueReference;
+    }
+  }
+
+  if (!hasExport || (typeDefinitionsExported && valueDefinitionsExported)) {
+    return null;
+  }
+
+  const typeDefinitionsUsed =
+    typeDefinitionsExported || isUsedVariable(variable, 'type');
+  const valueDefinitionsUsed =
+    valueDefinitionsExported || isUsedVariable(variable, 'value');
+
+  if (typeDefinitionsUsed === valueDefinitionsUsed) {
+    return null;
+  }
+
+  return typeDefinitionsUsed ? valueOnlyDefinition : typeOnlyDefinition;
+}
 
 /**
  * Collects the set of unused variables for a given context.

--- a/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars.test.ts
@@ -2243,6 +2243,210 @@ export const myTypeGuard = (data: unknown): data is string => {
         },
       ],
     },
+    // https://github.com/typescript-eslint/typescript-eslint/issues/10658
+    {
+      code: `
+const A = 0;
+export type A = typeof A;
+      `,
+      errors: [
+        {
+          column: 7,
+          data: {
+            action: 'assigned a value',
+            additional: '',
+            varName: 'A',
+          },
+          endColumn: 8,
+          endLine: 2,
+          line: 2,
+          messageId: 'usedOnlyAsType',
+        },
+      ],
+    },
+    {
+      code: `
+interface TypeFirst {
+  next?: TypeFirst;
+}
+export const TypeFirst = 0;
+      `,
+      errors: [
+        {
+          column: 11,
+          data: {
+            action: 'defined',
+            additional: '',
+            varName: 'TypeFirst',
+          },
+          endColumn: 20,
+          endLine: 2,
+          line: 2,
+          messageId: 'unusedVar',
+        },
+      ],
+    },
+    {
+      code: `
+type AliasFirst = 0;
+export const AliasFirst = 0;
+      `,
+      errors: [
+        {
+          column: 6,
+          data: {
+            action: 'defined',
+            additional: '',
+            varName: 'AliasFirst',
+          },
+          endColumn: 16,
+          endLine: 2,
+          line: 2,
+          messageId: 'unusedVar',
+        },
+      ],
+    },
+    {
+      code: `
+export const ValueFirstType = 0;
+interface ValueFirstType {}
+      `,
+      errors: [
+        {
+          column: 11,
+          data: {
+            action: 'defined',
+            additional: '',
+            varName: 'ValueFirstType',
+          },
+          endColumn: 25,
+          endLine: 3,
+          line: 3,
+          messageId: 'unusedVar',
+        },
+      ],
+    },
+    {
+      code: `
+export const ValueFirstAlias = 0;
+type ValueFirstAlias = 0;
+      `,
+      errors: [
+        {
+          column: 6,
+          data: {
+            action: 'defined',
+            additional: '',
+            varName: 'ValueFirstAlias',
+          },
+          endColumn: 21,
+          endLine: 3,
+          line: 3,
+          messageId: 'unusedVar',
+        },
+      ],
+    },
+    {
+      code: `
+export interface TypeExported {}
+const TypeExported = 0;
+      `,
+      errors: [
+        {
+          column: 7,
+          data: {
+            action: 'assigned a value',
+            additional: '',
+            varName: 'TypeExported',
+          },
+          endColumn: 19,
+          endLine: 3,
+          line: 3,
+          messageId: 'unusedVar',
+        },
+      ],
+    },
+    {
+      code: `
+export type AliasExported = 0;
+const AliasExported = 0;
+      `,
+      errors: [
+        {
+          column: 7,
+          data: {
+            action: 'assigned a value',
+            additional: '',
+            varName: 'AliasExported',
+          },
+          endColumn: 20,
+          endLine: 3,
+          line: 3,
+          messageId: 'unusedVar',
+        },
+      ],
+    },
+    {
+      code: `
+const ValueBeforeType = 0;
+export interface ValueBeforeType {}
+      `,
+      errors: [
+        {
+          column: 7,
+          data: {
+            action: 'assigned a value',
+            additional: '',
+            varName: 'ValueBeforeType',
+          },
+          endColumn: 22,
+          endLine: 2,
+          line: 2,
+          messageId: 'unusedVar',
+        },
+      ],
+    },
+    {
+      code: `
+const ValueBeforeAlias = 0;
+export type ValueBeforeAlias = 0;
+      `,
+      errors: [
+        {
+          column: 7,
+          data: {
+            action: 'assigned a value',
+            additional: '',
+            varName: 'ValueBeforeAlias',
+          },
+          endColumn: 23,
+          endLine: 2,
+          line: 2,
+          messageId: 'unusedVar',
+        },
+      ],
+    },
+    {
+      code: `
+interface NamedType {}
+const NamedType = 0;
+export type { NamedType };
+      `,
+      errors: [
+        {
+          column: 7,
+          data: {
+            action: 'assigned a value',
+            additional: '',
+            varName: 'NamedType',
+          },
+          endColumn: 16,
+          endLine: 3,
+          line: 3,
+          messageId: 'unusedVar',
+        },
+      ],
+    },
   ],
 
   valid: [
@@ -3302,16 +3506,49 @@ export class Foo {
       `,
     },
     `
-interface Foo {
-  bar: string;
-}
-export const Foo = 'bar';
+export interface DirectInterfaceFirst {}
+export const DirectInterfaceFirst = 0;
+
+export type DirectAliasFirst = 0;
+export const DirectAliasFirst = 0;
+
+export const DirectValueFirstInterface = 0;
+export interface DirectValueFirstInterface {}
+
+export const DirectValueFirstAlias = 0;
+export type DirectValueFirstAlias = 0;
     `,
     `
-export const Foo = 'bar';
-interface Foo {
-  bar: string;
-}
+interface NamedInterfaceFirst {}
+const NamedInterfaceFirst = 0;
+export { NamedInterfaceFirst };
+
+type NamedAliasFirst = 0;
+const NamedAliasFirst = 0;
+export { NamedAliasFirst };
+
+const NamedValueFirstInterface = 0;
+interface NamedValueFirstInterface {}
+export { NamedValueFirstInterface };
+
+const NamedValueFirstAlias = 0;
+type NamedValueFirstAlias = 0;
+export { NamedValueFirstAlias };
+    `,
+    `
+interface SharedName {}
+export const SharedName = 0;
+export type UsesSharedName = SharedName;
+    `,
+    `
+export interface SharedName {}
+const SharedName = 0;
+console.log(SharedName);
+    `,
+    `
+interface LocalName {}
+const LocalName = 0;
+export type UsesLocalName = LocalName;
     `,
     `
 let foo = 1;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #10658
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

`no-unused-vars` currently treats same-named type and value declarations as fully used when an export exposes only one TypeScript namespace. This can hide the declaration that remains local and unused, as in #10658.

This change tracks type and value exports separately and reports the unused definition at its own source location. Regression tests cover the four export combinations discussed in #11322, both declaration orders, interfaces and type aliases, named type exports, local use of the unexported namespace, and unchanged local-only behavior.

This implementation was written independently and does not reuse code from #11322.

Tests:

- `pnpm exec vitest run --config=vitest.config.mts packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars.test.ts --pool=forks --maxWorkers=1`
- `pnpm exec nx run eslint-plugin:test --coverage=false --run`
- `pnpm exec nx run eslint-plugin:lint`
- `pnpm exec nx run eslint-plugin:typecheck`
