### PR TITLE
fix(eslint-plugin): preserve assertions that add index signatures

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -226,7 +226,7 @@ export default createRule<Options, MessageIds>({
       if (
         (isTypeFlagSet(uncast, ts.TypeFlags.NonPrimitive) &&
           !isTypeFlagSet(cast, ts.TypeFlags.NonPrimitive)) ||
-        (hasIndexSignature(uncast) && !hasIndexSignature(cast)) ||
+        hasIndexSignature(uncast) !== hasIndexSignature(cast) ||
         containsAny(uncast) ||
         containsAny(cast) ||
         (containsTypeVariable(cast) && !containsTypeVariable(uncast))

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -84,6 +84,14 @@ const foo = [3, 'hi', 'bye'] as Tuple;
 type PossibleTuple = {};
 const foo = {} as PossibleTuple;
     `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/12856
+    `
+const a = {};
+a as Record<string, string>;
+type Dict = Record<string, string>;
+a as Dict;
+a as { [key: string]: string };
+    `,
     `
 type PossibleTuple = { hello: 'hello' };
 const foo = { hello: 'hello' } as PossibleTuple;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #12856
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

`no-unnecessary-type-assertion` only checked for index signatures in the uncast type. As a result, asserting `{}` to a `Record` type alias was reported as unnecessary even though removing the assertion loses the index signature.

This compares index-signature presence in both directions and adds regression coverage for direct, aliased, and explicit index-signature targets.

Validated with:

- focused rule test with coverage
- `eslint-plugin` test suite: 32,792 passed, 171 skipped
- `eslint-plugin` lint
- `eslint-plugin` typecheck
- `eslint-plugin` build
- Prettier check and `git diff --check`

💖
