### PR TITLE
docs: layer recommended flat config with type-aware rules

### DIFF
--- a/docs/getting-started/Typed_Linting.mdx
+++ b/docs/getting-started/Typed_Linting.mdx
@@ -143,6 +143,143 @@ module.exports = {
 
 You can read more about the rules provided by typescript-eslint in our [rules docs](/rules) and [shared configurations docs](../users/Shared_Configurations.mdx).
 
+## Customizing Rules on Top of Shared Configs
+
+ESLint applies later config objects on top of earlier ones.
+You can extend a shared config and then add config objects to enable additional type-aware rules or change rule severities and options.
+
+### Adding type-aware rules to `recommended`
+
+The [`recommended`](../users/Shared_Configurations.mdx#recommended) config does not enable type-aware rules.
+To add individual type-aware rules (such as [`no-floating-promises`](/rules/no-floating-promises)) on top of `recommended`, add a config object with `languageOptions.parserOptions.projectService` and the additional rules.
+Scope `files` to TypeScript file extensions so type-aware linting does not run on other file types such as JSON.
+
+<Tabs groupId="eslint-config">
+<TabItem value="Flat Config">
+
+```js title="eslint.config.mjs"
+import js from '@eslint/js';
+import { defineConfig } from 'eslint/config';
+import tseslint from 'typescript-eslint';
+
+export default defineConfig(
+  {
+    files: ['**/*.{js,ts}'],
+    extends: [js.configs.recommended, tseslint.configs.recommended],
+  },
+  {
+    files: [tseslint.globs.ts],
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-floating-promises': 'error',
+    },
+  },
+);
+```
+
+</TabItem>
+<TabItem value="Legacy Config">
+
+```js title=".eslintrc.cjs"
+/* eslint-env node */
+module.exports = {
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
+  plugins: ['@typescript-eslint'],
+  parser: '@typescript-eslint/parser',
+  overrides: [
+    {
+      files: ['**/*.ts', '**/*.tsx', '**/*.mts', '**/*.cts'],
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: __dirname,
+      },
+      rules: {
+        '@typescript-eslint/no-floating-promises': 'error',
+      },
+    },
+  ],
+  root: true,
+};
+```
+
+</TabItem>
+</Tabs>
+
+### Customizing rules in `recommendedTypeChecked`
+
+The [`recommendedTypeChecked`](../users/Shared_Configurations.mdx#recommended-type-checked) config enables all recommended type-aware rules and requires [`parserOptions.projectService`](../packages/Parser.mdx#projectservice).
+To change severity or options for individual type-aware rules, add a later config object with `rules` overrides.
+
+<Tabs groupId="eslint-config">
+<TabItem value="Flat Config">
+
+```js title="eslint.config.mjs"
+import js from '@eslint/js';
+import { defineConfig } from 'eslint/config';
+import tseslint from 'typescript-eslint';
+
+export default defineConfig(
+  {
+    files: ['**/*.{js,ts}'],
+    extends: [js.configs.recommended, tseslint.configs.recommendedTypeChecked],
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+  {
+    rules: {
+      '@typescript-eslint/no-floating-promises': 'error',
+    },
+  },
+  {
+    files: ['**/*.js'],
+    extends: [tseslint.configs.disableTypeChecked],
+  },
+);
+```
+
+</TabItem>
+<TabItem value="Legacy Config">
+
+```js title=".eslintrc.cjs"
+/* eslint-env node */
+module.exports = {
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended-type-checked',
+  ],
+  plugins: ['@typescript-eslint'],
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    projectService: true,
+    tsconfigRootDir: __dirname,
+  },
+  rules: {
+    '@typescript-eslint/no-floating-promises': 'error',
+  },
+  overrides: [
+    {
+      files: ['**/*.js'],
+      extends: ['plugin:@typescript-eslint/disable-type-checked'],
+    },
+  ],
+  root: true,
+};
+```
+
+</TabItem>
+</Tabs>
+
+See [How do I disable type-checked linting for a file?](../troubleshooting/typed-linting/index.mdx#how-do-i-disable-type-checked-linting-for-a-file) for more ways to disable type-aware linting on specific file patterns.
+
 ## Performance
 
 Typed rules come with a catch.

--- a/docs/packages/TypeScript_ESLint.mdx
+++ b/docs/packages/TypeScript_ESLint.mdx
@@ -51,6 +51,36 @@ export default defineConfig({
 
 This config file exports a flat config that enables both the [core ESLint recommended config](https://www.npmjs.com/package/@eslint/js) and [our recommended config](../users/Shared_Configurations.mdx#recommended).
 
+#### Customizing rules on top of shared configs
+
+To add type-aware rules or change rule settings on top of a shared config, add later config objects with `languageOptions.parserOptions` and `rules`.
+See [Customizing Rules on Top of Shared Configs](../getting-started/Typed_Linting.mdx#customizing-rules-on-top-of-shared-configs) for examples of layering `recommended` or `recommendedTypeChecked` with custom type-aware rules.
+
+```js title="eslint.config.mjs"
+import js from '@eslint/js';
+import { defineConfig } from 'eslint/config';
+import tseslint from 'typescript-eslint';
+
+export default defineConfig(
+  {
+    files: ['**/*.{js,ts}'],
+    extends: [js.configs.recommended, tseslint.configs.recommended],
+  },
+  {
+    files: [tseslint.globs.ts],
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-floating-promises': 'error',
+    },
+  },
+);
+```
+
 ### `extensions`
 
 The `extensions` export provides arrays of standard file extensions (without leading dots) for JavaScript and TypeScript files. These arrays are useful when you need to programmatically construct globs or perform file extension checks.


### PR DESCRIPTION
Fixes #9993

Documents how to extend shared flat configs with custom type-aware rules and `parserOptions.projectService`.

## Changes

- **`docs/getting-started/Typed_Linting.mdx`**: Added a "Customizing Rules on Top of Shared Configs" section with flat and legacy config examples for:
  - Adding individual type-aware rules on top of `recommended`
  - Customizing rules when using `recommendedTypeChecked`
- **`docs/packages/TypeScript_ESLint.mdx`**: Added a brief usage subsection linking to the typed linting guide with a flat config example.

## Example use case

Users who want `recommended` plus a single type-aware rule (such as `no-floating-promises`) can add a later config object scoped to TypeScript files with `projectService` enabled, without re-specifying `plugins` or `parser`.