### PR TITLE
fix(eslint-plugin): [no-unnecessary-type-assertion] false positive for empty object asserted to a type alias of Record

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -226,7 +226,7 @@ export default createRule<Options, MessageIds>({
       if (
         (isTypeFlagSet(uncast, ts.TypeFlags.NonPrimitive) &&
           !isTypeFlagSet(cast, ts.TypeFlags.NonPrimitive)) ||
-        (hasIndexSignature(uncast) && !hasIndexSignature(cast)) ||
+        hasIndexSignature(uncast) !== hasIndexSignature(cast) ||
         containsAny(uncast) ||
         containsAny(cast) ||
         (containsTypeVariable(cast) && !containsTypeVariable(uncast))

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -92,6 +92,14 @@ const foo = { hello: 'hello' } as PossibleTuple;
 type PossibleTuple = { 0: 'hello'; 5: 'hello' };
 const foo = { 0: 'hello', 5: 'hello' } as PossibleTuple;
     `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/12856
+    `
+const a = {};
+a as Record<string, string>;
+type Dict = Record<string, string>;
+a as Dict;
+a as { [key: string]: string };
+    `,
     `
 let bar: number | undefined = x;
 let foo: number = bar!;


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #12856
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

`hasIndexSignature(uncast) && !hasIndexSignature(cast)` only catches an index signature being *removed* by the assertion. It misses the opposite case: asserting a value with no index signature to a type that *adds* one through a non-generic alias, e.g. `type Dict = Record<string, string>; a as Dict`.

When going through such an alias, the resolved type doesn't carry `aliasTypeArguments` (since `Dict` itself takes no type parameters), so the existing type-argument-count check that happens to save the non-aliased case (`a as Record<string, string>`) never kicks in, and `{}`/`Record<string, string>` end up looking mutually assignable — hence the false positive.

Comparing `hasIndexSignature` in both directions (`!==`) catches this before the assignability check runs, regardless of aliasing.